### PR TITLE
Review 2/4: the Smithay compositor (wm-wayland)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,38 @@ jobs:
 
           echo "smoke test passed: WM handshake present, client managed"
           kill "$XTERM_PID" "$WM_PID" "$XVFB_PID" || true
+
+  # The Wayland half of the dual architecture. There is no Xvfb
+  # equivalent to smoke-test a compositor on a headless runner (the
+  # nested backend needs a host display), so this job's gate is the
+  # strictest thing CI can still do: build the compositor backend and
+  # its binary against the real system libraries, then run the
+  # backend's unit tests. The build step is the load-bearing one — the
+  # -sys crates under Smithay's winit/GLES path (libxkbcommon for the
+  # keymap machinery, EGL/GLES for the renderer, the Wayland client
+  # libraries winit itself links) resolve and link at build time, so a
+  # plain `cargo build` on Linux already proves what the macOS dev
+  # host, where this crate is cfg-empty, structurally cannot. Only the
+  # nested-session dependencies are installed: the `session` feature
+  # (DRM/KMS, libinput, libseat) is off by default and stays off here,
+  # which keeps this job light and honest about what it exercises.
+  wayland:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install Wayland build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-dev libegl-dev libgles-dev libwayland-dev
+
+      # --locked: the compositor pins Smithay 0.7.0, and a silent
+      # re-resolution here would test a different dependency tree than
+      # the one the repository actually ships.
+      - name: Build the Wayland compositor and binary
+        run: cargo build -p wm-wayland -p chonkstep-wayland --locked
+
+      - name: Run the wm-wayland test suite
+        run: cargo test -p wm-wayland

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,12 +9,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.1",
+ "cc",
+ "jni",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "appendlist"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e149dc73cd30538307e7ffa2acd3d2221148eaeed4871f246657b1c3eaa1cbd2"
+
+[[package]]
+name = "approx"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2a05fd1bd10b2527e20a2cd32d8873d115b8b39fe219ee25f42a8aca6ba278"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -30,6 +83,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atomic_float"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628d228f918ac3b82fe590352cc719d30664a0c13ca3a60266fe02c7132d480a"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,6 +117,30 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -62,10 +163,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.13.1",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.1",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "cc"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "cgmath"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a98d30140e3296250832bbaaff83b27dcd6fa3cc70fb6f1f3e5c9c0023b5317"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "chonk-about"
@@ -118,13 +292,69 @@ dependencies = [
 name = "chonkstep-wayland"
 version = "0.1.0"
 dependencies = [
- "chonk-shell",
  "tracing",
  "tracing-subscriber",
  "wm-config",
- "wm-core",
- "wm-theme",
  "wm-wayland",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
 ]
 
 [[package]]
@@ -148,6 +378,15 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -185,10 +424,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dpi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "drm-fourcc"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
 name = "either"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -203,8 +510,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdeflate"
@@ -214,6 +527,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -258,13 +577,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "gethostname"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -272,6 +686,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "indexmap"
@@ -282,6 +702,91 @@ dependencies = [
  "equivalent",
  "hashbrown",
 ]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "lazy_static"
@@ -296,10 +801,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.9.3",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -348,12 +881,276 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-contacts",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -363,10 +1160,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -382,12 +1227,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -400,10 +1305,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
@@ -436,6 +1388,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +1435,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +1465,15 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustybuzz"
@@ -495,10 +1493,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "self_cell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -540,6 +1565,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,10 +1585,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "skrifa"
@@ -563,6 +1621,12 @@ dependencies = [
  "bytemuck",
  "read-fonts",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slotmap"
@@ -578,6 +1642,81 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smithay"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740cea6927892bc182d5bf70c8f79806c8bc9f68f2fb96e55a30be171b63af98"
+dependencies = [
+ "appendlist",
+ "atomic_float",
+ "bitflags 2.13.1",
+ "calloop 0.14.4",
+ "cgmath",
+ "cursor-icon",
+ "downcast-rs",
+ "drm-fourcc",
+ "encoding_rs",
+ "errno",
+ "gl_generator",
+ "indexmap",
+ "libc",
+ "libloading",
+ "profiling",
+ "rand",
+ "rustix 1.1.4",
+ "scopeguard",
+ "sha2",
+ "smallvec",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tracing",
+ "wayland-client",
+ "wayland-cursor",
+ "wayland-egl",
+ "wayland-protocols",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-server",
+ "winit",
+ "x11rb",
+ "xkbcommon",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.13.1",
+ "calloop 0.13.0",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "strict-num"
@@ -628,12 +1767,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.20",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -706,7 +1878,7 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
@@ -719,6 +1891,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -742,6 +1935,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -810,6 +2004,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,10 +2070,278 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.127"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-egl"
+version = "0.32.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b97bdb7c49e5bd9b7562f38ff84f0dad47079fdc9e926f691a787f6dbc05451"
+dependencies = [
+ "wayland-backend",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-protocols",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+ "wayland-server",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-server"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde9c29be0f723a573977de51ee455bf3dfa03652730a74f9dd3b337e374d75"
+dependencies = [
+ "bitflags 2.13.1",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -882,6 +2350,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.13.1",
+ "block2",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation",
+ "core-graphics",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
 ]
 
 [[package]]
@@ -895,6 +2478,15 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wm-config"
@@ -938,8 +2530,12 @@ dependencies = [
 name = "wm-wayland"
 version = "0.1.0"
 dependencies = [
+ "chonk-shell",
+ "smithay",
  "tracing",
+ "wm-config",
  "wm-core",
+ "wm-theme",
  "wm-theme-api",
 ]
 
@@ -947,11 +2543,22 @@ dependencies = [
 name = "wm-x11"
 version = "0.1.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
  "wm-core",
  "wm-theme-api",
  "x11rb",
+]
+
+[[package]]
+name = "x11-dl"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38735924fedd5314a6e548792904ed8c6de6636285cb9fec04d5b1db85c1516f"
+dependencies = [
+ "libc",
+ "once_cell",
+ "pkg-config",
 ]
 
 [[package]]
@@ -960,8 +2567,12 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
- "rustix",
+ "libc",
+ "libloading",
+ "once_cell",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
@@ -970,6 +2581,48 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "163b33ed8786455e2fa5d72f554057ce3f3182425434f756cd39c99839d88e23"
+
+[[package]]
+name = "xkbcommon"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d66ca9352cbd4eecbbc40871d8a11b4ac8107cfc528a6e14d7c19c69d0e1ac9"
+dependencies = [
+ "libc",
+ "memmap2",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.1",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "yazi"
@@ -982,3 +2635,23 @@ name = "zeno"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,56 @@ scripts/update.sh
 
 which pulls, rebuilds, and hot-restarts the running session in place.
 
+## Wayland
+
+chonkstep is one desktop with two faces. Everything the desktop *is*
+lives in backend-generic crates - `wm-core` decides (placement, focus,
+stacking, workspaces, the modal Alt-Tab machinery), `wm-theme` renders
+the decorations, and `chonk-shell` is the whole desktop above them:
+dock, instruments, Clip, launcher strip, menus, wallpaper, themes. Two
+backends implement the one backend contract those crates are written
+against - `wm-x11`, and `wm-wayland`, a compositor built on
+[Smithay](https://github.com/Smithay/smithay) - and two thin binaries,
+`chonkstep` and `chonkstep-wayland`, wire the same shell to each. That
+is what keeps the two sessions identical: a feature or a fix lands
+once, in the shared crates, and both stacks get it by construction
+rather than by porting discipline.
+
+The Wayland side is the younger half, and its current shape is stated
+honestly: it runs today as a *nested* session for development. The
+compositor opens a regular window on your existing desktop (Wayland or
+X11, via Smithay's winit backend), and that window is its screen -
+chrome, dock, root menu, themes, and all. A true DRM/KMS session that
+owns the hardware from a TTY, the way Xorg does for the X11 side, is
+planned behind the crate's `session` feature but is not built yet.
+
+To run it nested, from a terminal on any desktop:
+
+```sh
+cargo build --release -p chonkstep-wayland
+./target/release/chonkstep-wayland
+```
+
+The compositor allocates its own Wayland socket and sets
+`WAYLAND_DISPLAY` (and `DISPLAY`, through XWayland) for everything it
+spawns, so applications launched from the root menu or the themed
+terminal land inside the nested session automatically. To aim a client
+at it from an outside terminal instead, point these variables at the
+socket names from the startup log - the Wayland socket is typically
+the first free slot (`wayland-1` when your host desktop holds
+`wayland-0`), and XWayland's display number is printed alongside it:
+
+```sh
+WAYLAND_DISPLAY=wayland-1 some-wayland-app
+DISPLAY=:1 urxvt
+```
+
+X11 applications are first-class citizens, not a compatibility
+afterthought: the compositor starts XWayland at boot and manages its
+windows through exactly the same decoration and policy machinery as
+native Wayland clients, so urxvt - and everything else that predates
+Wayland - runs unchanged.
+
 ## Configuration
 
 chonkstep reads `~/.config/chonkstep/config.toml` (or
@@ -182,11 +232,14 @@ always available; it is not rebindable from the config file.
   regression tests for the WindowMaker relief recipes.
 
 The workspace splits along seams that keep the core testable: `wm-core`
-(window management logic, no X11), `wm-x11` (the backend), `wm-theme`
-(decoration rendering), `wm-theme-api` (the boundary between them),
-`chonkstep` (the binary and desktop shell), and `chonk-ui`/`chonk-about`
-(a small SDK surface proving third-party apps can draw with the same
-visual language). Within `wm-theme`, the `tile` module is the common UI
+(window management logic, no display server), `wm-theme` (decoration
+rendering), `wm-theme-api` (the boundary between them), `chonk-shell`
+(the entire desktop - dock, instruments, Clip, launcher, menus,
+wallpaper - generic over the backend), `wm-x11` and `wm-wayland` (the
+two backends implementing that contract), `chonkstep` and
+`chonkstep-wayland` (the thin binaries wiring the shell to each), and
+`chonk-ui`/`chonk-about` (a small SDK surface proving third-party apps
+can draw with the same visual language). Within `wm-theme`, the `tile` module is the common UI
 platform for everything square: the workspace Clip's look formalized - a
 diagonal WindowMaker `IconBack`-gradient face under the stock RAISED2
 relief, luminance-picked ink, and sunken instrument-panel wells. Dock

--- a/crates/chonkstep-wayland/Cargo.toml
+++ b/crates/chonkstep-wayland/Cargo.toml
@@ -5,13 +5,15 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[dependencies]
+# Everything here is Linux-only: on any other host the binary compiles
+# to its stub arm (see main.rs) with no dependencies at all, so the
+# workspace builds and tests on a macOS dev machine. The list is short
+# on purpose — `wm_wayland::run` owns the compositor, the shell, and
+# the event loop, so this binary reaches `chonk-shell`/`wm-core`
+# through `wm-wayland` rather than naming them itself; only the config
+# loader and the compositor crate appear here.
+[target.'cfg(target_os = "linux")'.dependencies]
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-chonk-shell = { path = "../chonk-shell" }
-wm-core = { path = "../wm-core" }
 wm-config = { path = "../wm-config" }
-wm-theme = { path = "../wm-theme" }
 wm-wayland = { path = "../wm-wayland" }

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -1,18 +1,52 @@
-//! chonkstep as a native Wayland compositor - the same desktop as the
-//! X11 binary, driven through `wm-wayland`'s Smithay backend.
+//! The Wayland chonkstep binary: process bootstrap for the compositor
+//! in `wm-wayland`, and deliberately nothing more. The X11 binary owns
+//! a real event loop because an X client can poll a socket it does not
+//! own — but a Wayland compositor *is* the display server, its loop
+//! belongs to calloop and Smithay, and it cannot be driven from out
+//! here. So everything `chonkstep`'s `main.rs` does inline — keymap
+//! interception, motion coalescing, the shell click/resize drains,
+//! `Shell::tick` — lives inside `wm_wayland::run`'s dispatch loop
+//! instead, mirrored step for step from that file, and this binary is
+//! left with exactly the irreducibly process-side jobs: logging setup,
+//! configuration loading, and the exit code.
 
 #[cfg(target_os = "linux")]
 fn main() {
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
-    // Replaced by the Wayland event loop as wm-wayland lands - the
-    // stub keeps the dual-binary structure buildable everywhere while
-    // the compositor grows behind it.
-    tracing::error!("the wm-wayland backend is still under construction; use the chonkstep (X11) binary");
-    std::process::exit(1);
+    tracing::info!(
+        version = env!("CARGO_PKG_VERSION"),
+        "chonkstep-wayland starting \u{2014} the chonkstep desktop as a native Wayland compositor"
+    );
+
+    // Same contract as the X11 binary: `wm_config::load()` never fails.
+    // No file yields the defaults, and a broken file logs what is wrong
+    // and yields the defaults too — a typo in the config must never
+    // cost the user their session, because with the compositor refusing
+    // to start there is no terminal to fix the typo from.
+    let config = wm_config::load();
+
+    // `run` owns the entire session — backend and renderer init, the
+    // Wayland globals, XWayland, the `WindowManager` + `Shell` wiring,
+    // and the dispatch loop — and returns only when the session is
+    // over: `Ok` for a deliberate exit (the root menu's Exit), `Err`
+    // for anything that prevented the session from starting or ended
+    // it abnormally. The error is logged rather than propagated as a
+    // panic/`Result` from `main` so it lands in the same tracing
+    // stream a session launcher captures, not on a raw stderr line
+    // formatted differently from every other message.
+    if let Err(error) = wm_wayland::run(config) {
+        tracing::error!(%error, "compositor exited with an error");
+        std::process::exit(1);
+    }
 }
 
 #[cfg(not(target_os = "linux"))]
 fn main() {
+    // The crate still *builds* everywhere — `wm-wayland` is cfg-empty
+    // off Linux and this crate's dependencies are target-gated — so
+    // `cargo test --workspace` on a macOS dev host keeps gating the
+    // whole tree. Running, though, is Linux-only by nature, and saying
+    // so beats a linker error.
     eprintln!("chonkstep-wayland only runs on Linux");
     std::process::exit(1);
 }

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -10,15 +10,56 @@ license.workspace = true
 # and tests on a macOS dev machine.
 [target.'cfg(target_os = "linux")'.dependencies]
 wm-core = { path = "../wm-core" }
+wm-theme = { path = "../wm-theme" }
 wm-theme-api = { path = "../wm-theme-api" }
+wm-config = { path = "../wm-config" }
+chonk-shell = { path = "../chonk-shell" }
 tracing = "0.1"
+
+# Smithay 0.7 is the pinned compositor framework. Features are opted
+# into explicitly (default-features = false) so the DRM/KMS, libinput,
+# udev, and Vulkan stacks — all of which want system libraries at build
+# time — stay out of the graph until the `session` feature grows real:
+#
+# - backend_winit: the nested development backend (the compositor runs
+#   inside a window on an existing desktop), which also pulls in
+#   backend_egl and the winit/wayland-client plumbing it needs.
+# - renderer_gl: the GLES2 renderer every render element in
+#   `renderer.rs` is typed against.
+# - desktop: `PopupManager` and the surface-tree helpers
+#   (`send_frames_surface_tree`) — we deliberately do NOT use its
+#   `Space`, since `wm-core` owns geometry and stacking, but the
+#   utilities are shared.
+# - wayland_frontend: the wayland-server protocol machinery (pure-Rust
+#   wayland-backend; `use_system_lib` stays OFF on purpose so no
+#   system libwayland is required to build).
+# - xwayland: XWayland process management plus the X11 window-manager
+#   connection (X11Wm/XwmHandler), so X11 apps run under the
+#   compositor unchanged.
+#
+# Keysyms and modifier state come through Smithay's own xkbcommon
+# re-exports (`smithay::input::keyboard::{Keysym, ModifiersState}`), so
+# no direct xkbcommon dependency is needed.
+smithay = { version = "0.7.0", default-features = false, features = [
+    "backend_winit",
+    "renderer_gl",
+    "desktop",
+    "wayland_frontend",
+    "xwayland",
+] }
 
 [features]
 default = ["winit"]
 # The nested development backend: the compositor runs inside a window
-# on an existing X11/Wayland desktop.
+# on an existing X11/Wayland desktop. Currently a marker — the winit
+# stack is unconditionally compiled in via the smithay features above —
+# kept so the eventual `--no-default-features --features session` build
+# has a name to exclude.
 winit = []
-# The real-hardware session: DRM/KMS + libinput + libseat. Needs the
-# corresponding system libraries at build time; off by default so CI
-# and the nested dev loop stay light.
+# The real-hardware session: DRM/KMS + libinput + libseat. A documented
+# placeholder for now — enabling it does nothing yet. When it grows
+# real it will turn on smithay's backend_drm/backend_libinput/
+# backend_session_libseat features, which need the corresponding system
+# libraries at build time; off by default so CI and the nested dev loop
+# stay light.
 session = []

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -1,0 +1,890 @@
+//! `wm_core::Backend` (and `wm_theme_api::PopupHost`) for the Smithay
+//! compositor — the half of the Wayland port that makes the X11-era
+//! policy brain drive a scene the compositor itself owns.
+//!
+//! Where `wm-x11` translates every verb into protocol requests against
+//! a server it doesn't control, this backend IS the server: every verb
+//! just mutates the records in [`WaylandBackend`] (`windows`, `frames`,
+//! `shells`, `stacking`) and sets the `damage` flag; the renderer walks
+//! those records on the next redraw. The only calls that leave the
+//! process are the ones a client must hear about — xdg configures,
+//! close requests, and their XWayland equivalents.
+//!
+//! Coordinate convention (shared with the renderer and input modules):
+//! `FrameRecord::geometry`, `ShellRecord::geometry`, and
+//! `WindowRecord::content` are all GLOBAL (output-space) rectangles.
+//! `wm-core` thinks of the client as sitting at a frame-local offset
+//! inside its frame (that's what reparenting means on X11), so the
+//! verbs that speak frame-local coordinates (`create_decoration`'s
+//! `client_offset`, `position_client`) are translated to global here,
+//! and `set_frame_geometry` carries the content rect along with the
+//! frame by the same delta. Keeping every stored rect in one space is
+//! what lets the renderer and the pointer hit-test compare frame,
+//! content, and shell rects directly.
+//!
+//! Stacking: `stacking` holds frames and shell surfaces bottom-to-top,
+//! but the effective z-order is partitioned — `above: false` shells
+//! (desktop furniture) render below every frame, `above: true` shells
+//! (dock, menus) above them — with `stacking`'s relative order applying
+//! within each band. The reordering verbs here (`raise`, `restack`,
+//! `raise_shell_surface`) therefore only need to get the relative order
+//! within a band right; hit-testing must walk the same three bands
+//! top-down to agree with what the renderer paints.
+
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
+use smithay::reexports::wayland_server::backend::protocol::ProtocolError;
+use smithay::reexports::wayland_server::Resource;
+use smithay::utils::{Logical, Rectangle as SmithayRect, Transform};
+use smithay::wayland::compositor::with_states;
+use smithay::wayland::shell::xdg::{SurfaceCachedState, ToplevelSurface, XdgToplevelSurfaceData};
+use smithay::xwayland::xwm::WmWindowType;
+
+use wm_core::{
+    Backend, BackendEvent, DragHandle, KeyCombo, MonitorInfo, MouseButton, SizeHints, WindowType,
+    WmClass, WmProtocol,
+};
+use wm_theme_api::{DecorationBuffer, DecorationLayout, Point, Rect, ResizeEdge, Size};
+
+use crate::state::{
+    FrameRecord, ManagedSurface, RootBackground, ShellRecord, StackEntry, WaylandBackend,
+    WlFrameId, WlShellId, WlWindowId,
+};
+
+/// `wm-theme` rect -> smithay logical rect. The theme side is
+/// `i32`/`u32`, smithay is `i32`/`i32`; sizes are window-sized, nowhere
+/// near the cast boundary.
+fn smithay_rect(rect: Rect) -> SmithayRect<i32, Logical> {
+    SmithayRect::new(
+        (rect.pos.x, rect.pos.y).into(),
+        (rect.size.w as i32, rect.size.h as i32).into(),
+    )
+}
+
+/// Imports theme-rendered pixels into a renderer-side buffer. The
+/// `DecorationBuffer` contract is premultiplied RGBA8 straight from
+/// tiny-skia's `data()`, which is exactly what smithay's renderers
+/// assume for shm-style formats — so this is a plain copy, no channel
+/// swizzling or (un)premultiplying. `Abgr8888` because DRM fourcc names
+/// describe the packed little-endian word: bytes R,G,B,A in memory read
+/// back as the 32-bit value 0xAABBGGRR, i.e. ABGR. Scale is 1 — the
+/// theme already rasterizes at `CHONKSTEP_SCALE`, so its buffers are
+/// physical pixels, not logical ones needing another scale factor.
+/// `None` for an empty buffer (nothing to show; callers keep whatever
+/// they had), mirroring `wm-x11`'s blit ignoring empty buffers.
+fn import_buffer(buffer: &DecorationBuffer) -> Option<MemoryRenderBuffer> {
+    if buffer.width == 0 || buffer.height == 0 {
+        return None;
+    }
+    Some(MemoryRenderBuffer::from_slice(
+        &buffer.pixels,
+        Fourcc::Abgr8888,
+        (buffer.width as i32, buffer.height as i32),
+        1,
+        Transform::Normal,
+        None,
+    ))
+}
+
+/// Reads one field of the xdg toplevel's role attributes (title,
+/// app_id) — smithay parks them on the surface's user-data map as
+/// `XdgToplevelSurfaceData`. `None` if the toplevel is gone, the data
+/// was never attached, or the field itself was never set.
+fn xdg_attribute<T>(
+    toplevel: &ToplevelSurface,
+    read: impl FnOnce(&smithay::wayland::shell::xdg::XdgToplevelSurfaceRoleAttributes) -> Option<T>,
+) -> Option<T> {
+    if !toplevel.alive() {
+        return None;
+    }
+    with_states(toplevel.wl_surface(), |states| {
+        let data = states.data_map.get::<XdgToplevelSurfaceData>()?;
+        let attributes = data.lock().ok()?;
+        read(&attributes)
+    })
+}
+
+impl Backend for WaylandBackend {
+    type WindowId = WlWindowId;
+    type FrameId = WlFrameId;
+    type ShellId = WlShellId;
+
+    // -- lifecycle --------------------------------------------------------
+
+    fn scan_existing_windows(&mut self) -> Vec<Self::WindowId> {
+        // A compositor owns its display from the first instant — no
+        // client can have connected before `run()` created the socket,
+        // so unlike an X11 WM adopting a running session, there is
+        // never anything pre-existing to adopt.
+        Vec::new()
+    }
+
+    fn monitors(&self) -> Vec<MonitorInfo> {
+        // One output for now (the winit window in the nested dev loop):
+        // same single-monitor shape `wm-x11` reports before RandR.
+        vec![MonitorInfo {
+            geometry: Rect { pos: Point::new(0, 0), size: self.output_size },
+            name: "wayland-0".to_string(),
+        }]
+    }
+
+    // -- shell surfaces ---------------------------------------------------
+    // On X11 these were override-redirect windows; here they are pure
+    // scene records the renderer draws directly — creation cannot fail,
+    // and none of these verbs involve a client at all.
+
+    fn create_shell_surface(
+        &mut self,
+        geometry: Rect,
+        background: (u8, u8, u8),
+        above: bool,
+    ) -> Option<Self::ShellId> {
+        let id = WlShellId(self.alloc_id());
+        self.shells.insert(
+            id,
+            ShellRecord { geometry, buffer: None, background, above, mapped: false },
+        );
+        self.stacking.push(StackEntry::Shell(id));
+        // Not visible until mapped — no damage yet.
+        Some(id)
+    }
+
+    fn map_shell_surface(&mut self, id: Self::ShellId) {
+        if let Some(shell) = self.shells.get_mut(&id) {
+            shell.mapped = true;
+            self.damage = true;
+        }
+    }
+
+    fn unmap_shell_surface(&mut self, id: Self::ShellId) {
+        if let Some(shell) = self.shells.get_mut(&id) {
+            shell.mapped = false;
+            self.damage = true;
+        }
+    }
+
+    fn destroy_shell_surface(&mut self, id: Self::ShellId) {
+        if self.shells.remove(&id).is_some() {
+            self.stacking
+                .retain(|entry| !matches!(entry, StackEntry::Shell(s) if *s == id));
+            self.damage = true;
+        }
+    }
+
+    fn raise_shell_surface(&mut self, id: Self::ShellId) {
+        // To the top of `stacking`; whether that puts it over managed
+        // frames is decided by its `above` flag (see the module doc's
+        // stacking bands), exactly like an override-redirect window's
+        // stacking versus reparented frames on X11.
+        if let Some(index) = self
+            .stacking
+            .iter()
+            .position(|entry| matches!(entry, StackEntry::Shell(s) if *s == id))
+        {
+            let entry = self.stacking.remove(index);
+            self.stacking.push(entry);
+            self.damage = true;
+        }
+    }
+
+    fn configure_shell_surface(&mut self, id: Self::ShellId, geometry: Rect) {
+        if let Some(shell) = self.shells.get_mut(&id) {
+            shell.geometry = geometry;
+            self.damage = true;
+        }
+    }
+
+    fn paint_shell_surface(&mut self, id: Self::ShellId, buffer: &DecorationBuffer) {
+        if let Some(shell) = self.shells.get_mut(&id) {
+            if let Some(imported) = import_buffer(buffer) {
+                shell.buffer = Some(imported);
+                self.damage = true;
+            }
+        }
+    }
+
+    fn paint_root_color(&mut self, rgb: (u8, u8, u8)) {
+        self.root_background = RootBackground::Color(rgb);
+        self.damage = true;
+    }
+
+    fn paint_root_image(&mut self, buffer: &DecorationBuffer) {
+        // An empty buffer keeps the previous background rather than
+        // installing a zero-sized image nothing can render.
+        if let Some(imported) = import_buffer(buffer) {
+            self.root_background = RootBackground::Image(imported);
+            self.damage = true;
+        }
+    }
+
+    // -- input/event queues -----------------------------------------------
+    // The input module translates raw seat events into these queues (it
+    // has the hit-testing context); the binary loop drains them here,
+    // through the same trait methods it uses on X11.
+
+    fn take_shell_click(&mut self) -> Option<(Self::ShellId, Point, MouseButton, bool)> {
+        self.shell_clicks.pop_front()
+    }
+
+    fn take_shell_motion(&mut self) -> Option<(Self::ShellId, Point)> {
+        self.shell_motions.pop_front()
+    }
+
+    fn take_screen_resize(&mut self) -> Option<Size> {
+        self.pending_resize.take()
+    }
+
+    fn screen_size(&self) -> Size {
+        self.output_size
+    }
+
+    fn poll_event(&mut self) -> Option<BackendEvent<Self::WindowId, Self::FrameId>> {
+        // Protocol handlers already translated everything into
+        // `pending` during dispatch — polling is a plain drain, with no
+        // connection to go dead underneath us (`ShutdownRequested` is
+        // queued by whoever tears the session down, not synthesized
+        // here).
+        self.pending.pop_front()
+    }
+
+    // -- properties -------------------------------------------------------
+
+    fn window_title(&self, window: Self::WindowId) -> Option<String> {
+        let record = self.windows.get(&window)?;
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                xdg_attribute(toplevel, |attributes| attributes.title.clone())
+            }
+            ManagedSurface::X11(surface) => {
+                // Smithay tracks `_NET_WM_NAME`/`WM_NAME` itself and
+                // hands back one string; empty means "never set", which
+                // callers expect as `None`, not "" (see `wm-x11`'s
+                // `get_text_property`).
+                let title = surface.title();
+                if title.is_empty() {
+                    None
+                } else {
+                    Some(title)
+                }
+            }
+        }
+    }
+
+    fn window_class(&self, window: Self::WindowId) -> Option<WmClass> {
+        let record = self.windows.get(&window)?;
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                // Wayland has one identity string (the xdg app_id, by
+                // convention the desktop-file id) where ICCCM has an
+                // instance/class pair; reporting it as both halves lets
+                // every `WM_CLASS`-keyed policy in the shell (launch
+                // matching, opacity rules) keep working unchanged.
+                let app_id = xdg_attribute(toplevel, |attributes| attributes.app_id.clone())?;
+                Some(WmClass { instance: app_id.clone(), class: app_id })
+            }
+            ManagedSurface::X11(surface) => {
+                let class = surface.class();
+                let instance = surface.instance();
+                if class.is_empty() && instance.is_empty() {
+                    None
+                } else {
+                    Some(WmClass { instance, class })
+                }
+            }
+        }
+    }
+
+    fn window_pid(&self, window: Self::WindowId) -> Option<u32> {
+        let record = self.windows.get(&window)?;
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                // No property to trust here — the kernel tells us who
+                // is on the other end of the socket (SO_PEERCRED),
+                // which is strictly more reliable than X11's
+                // client-asserted `_NET_WM_PID`.
+                if !toplevel.alive() {
+                    return None;
+                }
+                let client = toplevel.wl_surface().client()?;
+                let credentials = client.get_credentials(&self.display_handle).ok()?;
+                u32::try_from(credentials.pid).ok()
+            }
+            ManagedSurface::X11(surface) => surface.pid(),
+        }
+    }
+
+    fn size_hints(&self, window: Self::WindowId) -> SizeHints {
+        let Some(record) = self.windows.get(&window) else {
+            return SizeHints::default();
+        };
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                if !toplevel.alive() {
+                    return SizeHints::default();
+                }
+                // xdg_toplevel's set_min_size/set_max_size land in the
+                // surface's committed cached state; (0, 0) is the
+                // protocol's "no limit", which is exactly `None` here.
+                // Wayland has no resize-increment concept at all —
+                // terminals snap themselves — so that stays `None`
+                // rather than being faked.
+                let (min, max) = with_states(toplevel.wl_surface(), |states| {
+                    let mut guard = states.cached_state.get::<SurfaceCachedState>();
+                    let cached = guard.current();
+                    (cached.min_size, cached.max_size)
+                });
+                let to_size = |size: smithay::utils::Size<i32, Logical>| {
+                    if size.w > 0 && size.h > 0 {
+                        Some(Size::new(size.w as u32, size.h as u32))
+                    } else {
+                        None
+                    }
+                };
+                SizeHints { min_size: to_size(min), max_size: to_size(max), resize_increment: None }
+            }
+            ManagedSurface::X11(surface) => {
+                let to_size = |size: smithay::utils::Size<i32, Logical>| {
+                    if size.w > 0 && size.h > 0 {
+                        Some(Size::new(size.w as u32, size.h as u32))
+                    } else {
+                        None
+                    }
+                };
+                SizeHints {
+                    min_size: surface.min_size().and_then(to_size),
+                    max_size: surface.max_size().and_then(to_size),
+                    // `WM_NORMAL_HINTS` does carry increments and
+                    // smithay parses them — pass them through so an
+                    // xterm under XWayland resizes in cell steps.
+                    resize_increment: surface.size_hints().and_then(|hints| {
+                        let (w, h) = hints.size_increment?;
+                        if w > 0 && h > 0 {
+                            Some(Size::new(w as u32, h as u32))
+                        } else {
+                            None
+                        }
+                    }),
+                }
+            }
+        }
+    }
+
+    fn supports_protocol(&self, window: Self::WindowId, protocol: WmProtocol) -> bool {
+        let _ = window;
+        match protocol {
+            // Every xdg toplevel understands xdg_toplevel.close, and
+            // smithay's `X11Surface::close` handles the WM_DELETE-vs-
+            // destroy decision internally — so from `wm-core`'s
+            // perspective a polite close is always available.
+            WmProtocol::DeleteWindow => true,
+            // No Wayland analog of `WM_TAKE_FOCUS` exists (focus is
+            // compositor-assigned, never client-negotiated), so no
+            // client "supports" it — `wm-core` then just focuses
+            // directly, which is the right thing here.
+            WmProtocol::TakeFocus => false,
+        }
+    }
+
+    fn window_geometry(&self, window: Self::WindowId) -> Rect {
+        // Queried at map time for the fresh client's desired size (see
+        // the trait doc). (0, 0) as the position is `wm-core`'s own
+        // "don't care, WM decides" convention — which is what a Wayland
+        // client, having no say over its position at all, always means.
+        let fallback = Rect { pos: Point::new(0, 0), size: Size::new(200, 150) };
+        let Some(record) = self.windows.get(&window) else {
+            return fallback;
+        };
+        match &record.surface {
+            // The XWM tracks X11 geometry live (clients configure
+            // themselves pre-map), so ask it rather than our record.
+            ManagedSurface::X11(surface) => {
+                let geometry = surface.geometry();
+                Rect {
+                    pos: Point::new(geometry.loc.x, geometry.loc.y),
+                    size: Size::new(geometry.size.w.max(1) as u32, geometry.size.h.max(1) as u32),
+                }
+            }
+            ManagedSurface::Xdg(_) => {
+                if record.content.size.w == 0 || record.content.size.h == 0 {
+                    fallback
+                } else {
+                    record.content
+                }
+            }
+        }
+    }
+
+    /// Best-effort `None` for now: the miniaturize preview needs the
+    /// window's rendered pixels, which on this backend means rendering
+    /// the surface tree into an offscreen GLES target and reading it
+    /// back — a self-contained follow-up (the renderer module owns the
+    /// GLES context this needs). The icon/switcher SDK already designs
+    /// for missing previews, so the cost of shipping without it is a
+    /// generic tile instead of a live thumbnail, not a broken feature.
+    fn capture_window_image(&self, _window: Self::WindowId, _size: Size) -> Option<DecorationBuffer> {
+        None
+    }
+
+    // -- decoration realization -------------------------------------------
+
+    fn create_decoration(&mut self, window: Self::WindowId, layout: &DecorationLayout) -> Self::FrameId {
+        let frame = WlFrameId(self.alloc_id());
+        // Born at the origin; `wm-core` always follows up with
+        // `set_frame_geometry` to place it (see `manage_window`), and
+        // that call carries the content rect along.
+        let geometry = Rect { pos: Point::new(0, 0), size: layout.frame_size };
+        if let Some(record) = self.windows.get_mut(&window) {
+            // The X11 backend reparents the client to `client_offset`
+            // inside the frame and maps it here; our equivalent is
+            // pinning the content rect to that offset (frame currently
+            // at the origin, so global == frame-local) and marking the
+            // content drawable.
+            record.content.pos = Point::new(layout.client_offset.x, layout.client_offset.y);
+            record.mapped = true;
+        }
+        self.frames.insert(
+            frame,
+            FrameRecord { window, geometry, buffer: None, mapped: false },
+        );
+        self.stacking.push(StackEntry::Frame(frame));
+        frame
+    }
+
+    fn destroy_decoration(&mut self, frame: Self::FrameId) {
+        if self.frames.remove(&frame).is_some() {
+            self.stacking
+                .retain(|entry| !matches!(entry, StackEntry::Frame(f) if *f == frame));
+            self.damage = true;
+        }
+    }
+
+    fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
+        if let Some(record) = self.frames.get_mut(&frame) {
+            if let Some(imported) = import_buffer(buffer) {
+                record.buffer = Some(imported);
+                self.damage = true;
+            }
+        }
+    }
+
+    /// No-op for now: the pointer image is composited by the renderer
+    /// from the input module's pointer state, so indicating a resize
+    /// edge means swapping that cursor image, not flagging a window —
+    /// a follow-up in the input/renderer pair once a second cursor
+    /// image exists to swap to. Harmless meanwhile: resize itself works,
+    /// only the hover affordance is missing.
+    fn set_frame_cursor(&mut self, _frame: Self::FrameId, _edge: Option<ResizeEdge>) {}
+
+    // -- geometry / visibility --------------------------------------------
+
+    fn set_frame_geometry(&mut self, frame: Self::FrameId, geometry: Rect) {
+        let Some(record) = self.frames.get_mut(&frame) else {
+            return;
+        };
+        // The client rides inside the frame (on X11 the server moves it
+        // for free, being a child window) — translate the content rect
+        // by the same delta so both stay in global coordinates. Pure
+        // moves are exactly this; resizes leave the content alone until
+        // the separate `resize_client` call that always accompanies
+        // them.
+        let delta = Point::new(
+            geometry.pos.x - record.geometry.pos.x,
+            geometry.pos.y - record.geometry.pos.y,
+        );
+        record.geometry = geometry;
+        let window = record.window;
+        if let Some(window_record) = self.windows.get_mut(&window) {
+            window_record.content.pos.x += delta.x;
+            window_record.content.pos.y += delta.y;
+            // An X11 client must be told where it now sits — apps
+            // position popups relative to their own believed root
+            // coordinates, and a stale idea of those puts menus in the
+            // wrong place (the classic reparenting-WM bug).
+            if let ManagedSurface::X11(surface) = &window_record.surface {
+                if surface.alive() {
+                    if let Err(error) = surface.configure(smithay_rect(window_record.content)) {
+                        tracing::warn!(?error, ?window, "X11 configure after frame move failed");
+                    }
+                }
+            }
+        }
+        self.damage = true;
+    }
+
+    fn resize_client(&mut self, window: Self::WindowId, size: Size) {
+        let Some(record) = self.windows.get_mut(&window) else {
+            return;
+        };
+        record.content.size = size;
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                if toplevel.alive() {
+                    // The configure/ack/commit dance is how a Wayland
+                    // client learns its size — there is no server-side
+                    // resize to perform. `send_pending_configure`
+                    // dedups: a size the client already has produces no
+                    // event, which matters during interactive resize
+                    // where this is called per motion event.
+                    toplevel.with_pending_state(|state| {
+                        state.size = Some((size.w as i32, size.h as i32).into());
+                    });
+                    let _ = toplevel.send_pending_configure();
+                }
+            }
+            ManagedSurface::X11(surface) => {
+                if surface.alive() {
+                    if let Err(error) = surface.configure(smithay_rect(record.content)) {
+                        tracing::warn!(?error, ?window, "X11 resize configure failed");
+                    }
+                }
+            }
+        }
+        self.damage = true;
+    }
+
+    fn configure_unmanaged(&mut self, window: Self::WindowId, geometry: Rect) {
+        let Some(record) = self.windows.get_mut(&window) else {
+            return;
+        };
+        record.content = geometry;
+        match &record.surface {
+            ManagedSurface::X11(surface) => {
+                // The ICCCM case this verb exists for: an X11 client
+                // configuring itself before its first map must be
+                // acknowledged or it deadlocks waiting.
+                if surface.alive() {
+                    if let Err(error) = surface.configure(smithay_rect(geometry)) {
+                        tracing::warn!(?error, ?window, "X11 unmanaged configure failed");
+                    }
+                }
+            }
+            ManagedSurface::Xdg(toplevel) => {
+                // xdg clients never configure themselves, so `wm-core`
+                // only reaches here via a translated size request —
+                // answer with a configure for the size half; position
+                // isn't a concept the protocol lets us grant.
+                if toplevel.alive() {
+                    toplevel.with_pending_state(|state| {
+                        state.size = Some((geometry.size.w as i32, geometry.size.h as i32).into());
+                    });
+                    let _ = toplevel.send_pending_configure();
+                }
+            }
+        }
+        if record.mapped {
+            self.damage = true;
+        }
+    }
+
+    fn map_frame(&mut self, frame: Self::FrameId) {
+        if let Some(record) = self.frames.get_mut(&frame) {
+            record.mapped = true;
+            self.damage = true;
+        }
+    }
+
+    fn unmap_frame(&mut self, frame: Self::FrameId) {
+        if let Some(record) = self.frames.get_mut(&frame) {
+            record.mapped = false;
+            self.damage = true;
+        }
+    }
+
+    fn set_client_mapped(&mut self, window: Self::WindowId, mapped: bool) {
+        // Shading, purely compositor-side: the renderer stops drawing
+        // the content while the frame stays. The client never learns —
+        // no unmap event exists to suppress (unlike `wm-x11`, which has
+        // to swallow the UnmapNotify its own request generates), and
+        // Wayland clients keep their buffers, so the unshade path needs
+        // no repaint coaxing either.
+        if let Some(record) = self.windows.get_mut(&window) {
+            record.mapped = mapped;
+            self.damage = true;
+        }
+    }
+
+    // -- stacking ---------------------------------------------------------
+
+    fn raise(&mut self, frame: Self::FrameId) {
+        if let Some(index) = self
+            .stacking
+            .iter()
+            .position(|entry| matches!(entry, StackEntry::Frame(f) if *f == frame))
+        {
+            let entry = self.stacking.remove(index);
+            self.stacking.push(entry);
+            self.damage = true;
+        }
+    }
+
+    fn restack(&mut self, order_back_to_front: &[Self::FrameId]) {
+        // Pull the listed frames out and re-append them in the given
+        // order. Their position relative to shell entries in the Vec is
+        // irrelevant — the renderer's banding (module doc) decides
+        // frame-vs-shell layering — so only the relative order among
+        // frames needs to be exact. Frames the caller didn't list
+        // (other workspaces, miniaturized) keep their slots below the
+        // relisted ones, which matches X11's restack pushing the listed
+        // stack to the bottom-to-front order as a block.
+        let listed: Vec<StackEntry> = order_back_to_front
+            .iter()
+            .filter(|frame| self.frames.contains_key(frame))
+            .map(|&frame| StackEntry::Frame(frame))
+            .collect();
+        self.stacking
+            .retain(|entry| !matches!(entry, StackEntry::Frame(f) if order_back_to_front.contains(f)));
+        self.stacking.extend(listed);
+        self.damage = true;
+    }
+
+    // -- focus / close ----------------------------------------------------
+
+    fn set_input_focus(&mut self, window: Self::WindowId) {
+        // Deferred, not applied: `KeyboardHandle::set_focus` needs
+        // `&mut Compositor` (it dispatches enter/leave through the
+        // handler traits), and this backend lives INSIDE the
+        // `Compositor` (via `WindowManager`) — so the seat call from
+        // here would be a self-reborrow. The main loop drains this
+        // after every dispatch/notification pass and performs the seat
+        // focus (plus `X11Surface::set_activated` for XWayland
+        // windows) with the whole `Compositor` in hand.
+        self.pending_focus = Some(window);
+    }
+
+    fn send_close(&mut self, window: Self::WindowId) {
+        let Some(record) = self.windows.get(&window) else {
+            return;
+        };
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                if toplevel.alive() {
+                    toplevel.send_close();
+                }
+            }
+            ManagedSurface::X11(surface) => {
+                // Smithay's close() already implements this trait
+                // method's exact contract: WM_DELETE_WINDOW when the
+                // client supports it, outright destruction otherwise.
+                if surface.alive() {
+                    if let Err(error) = surface.close() {
+                        tracing::warn!(?error, ?window, "X11 close request failed");
+                    }
+                }
+            }
+        }
+    }
+
+    fn kill_client(&mut self, window: Self::WindowId) {
+        let Some(record) = self.windows.get(&window) else {
+            return;
+        };
+        match &record.surface {
+            ManagedSurface::Xdg(toplevel) => {
+                // The Wayland equivalent of XKillClient: sever the
+                // client's connection. Posting a protocol error is the
+                // mechanism wayland-server offers for a server-initiated
+                // disconnect; the object fields are zero because no
+                // object misbehaved — the user did the killing.
+                if let Some(client) = toplevel.wl_surface().client() {
+                    client.kill(
+                        &self.display_handle,
+                        ProtocolError {
+                            code: 0,
+                            object_id: 0,
+                            object_interface: String::new(),
+                            message: "killed by the window manager (close request unanswered)"
+                                .to_string(),
+                        },
+                    );
+                }
+            }
+            ManagedSurface::X11(surface) => {
+                // Smithay exposes no XKillClient; close() at least
+                // destroys the window outright for clients without
+                // WM_DELETE_WINDOW. A true connection kill for a hung
+                // XWayland client is a follow-up (needs the XWM's own
+                // connection, which the xwayland module owns).
+                if surface.alive() {
+                    if let Err(error) = surface.close() {
+                        tracing::warn!(?error, ?window, "X11 kill (close) failed");
+                    }
+                }
+            }
+        }
+    }
+
+    // -- input grabs ------------------------------------------------------
+
+    /// A compositor owns the pointer unconditionally — every motion and
+    /// button event already flows through this process before any
+    /// client sees it, which is the entire condition an X11 pointer
+    /// grab exists to create. During a drag the input module simply
+    /// keeps routing events to the WM instead of the surface under the
+    /// pointer, so a no-op handle is the CORRECT implementation, not a
+    /// stub.
+    fn grab_pointer_for_drag(&mut self) -> DragHandle {
+        DragHandle(0)
+    }
+
+    fn ungrab_pointer(&mut self, _handle: DragHandle) {}
+
+    fn grab_key(&mut self, combo: KeyCombo) {
+        // No server to register grabs with — the keyboard handler
+        // checks every press against this list before deciding whether
+        // the client gets the key (see the input module). Idempotent so
+        // a rebind pass can't inflate the list.
+        if !self.grabbed_combos.contains(&combo) {
+            self.grabbed_combos.push(combo);
+        }
+    }
+
+    fn ungrab_key(&mut self, combo: KeyCombo) {
+        self.grabbed_combos.retain(|existing| *existing != combo);
+    }
+
+    fn grab_keyboard(&mut self) {
+        // The modal Alt-Tab grab: while set, the input module routes
+        // every press AND release to `wm-core` (as KeyPress/KeyRelease)
+        // and none to clients — same effect as the X11 active grab,
+        // with no server round-trip to fail.
+        self.keyboard_grabbed = true;
+    }
+
+    fn ungrab_keyboard(&mut self) {
+        self.keyboard_grabbed = false;
+    }
+
+    fn refresh_client(&mut self, _window: Self::WindowId, _size: Size) {
+        // Wayland clients own their buffers — the compositor never
+        // discards content the way an unmapped X11 window loses its
+        // pixels, so there is nothing to ask the client to repaint;
+        // redrawing our own scene from the retained buffers suffices.
+        self.damage = true;
+    }
+
+    // -- EWMH-shaped policy reads/acts ------------------------------------
+    // The publish_* family stays at the trait's no-op defaults: a
+    // Wayland session has no EWMH root properties to publish. A later
+    // foreign-toplevel-management pass can override them to feed
+    // Wayland-native taskbars the same information.
+
+    fn window_type(&self, window: Self::WindowId) -> WindowType {
+        let Some(record) = self.windows.get(&window) else {
+            return WindowType::Normal;
+        };
+        match &record.surface {
+            // xdg toplevels are, by protocol construction, exactly the
+            // decorate-and-manage kind — menus/tooltips arrive as
+            // xdg_popups, which never reach `wm-core` as MapRequests at
+            // all (the xdg module positions and renders them directly).
+            ManagedSurface::Xdg(_) => WindowType::Normal,
+            ManagedSurface::X11(surface) => {
+                // Override-redirect means "stay out of my way" by
+                // definition, before any type property is consulted.
+                if surface.is_override_redirect() {
+                    return WindowType::Unmanaged;
+                }
+                match surface.window_type() {
+                    Some(WmWindowType::Dialog) => WindowType::Dialog,
+                    Some(WmWindowType::Normal) | Some(WmWindowType::Utility) | None => {
+                        WindowType::Normal
+                    }
+                    // Menus, docks, tooltips, splashes, notifications:
+                    // draw their own chrome, place themselves — same
+                    // bucket `wm-x11` sorts these atoms into.
+                    Some(_) => WindowType::Unmanaged,
+                }
+            }
+        }
+    }
+
+    fn map_unmanaged(&mut self, window: Self::WindowId) {
+        if let Some(record) = self.windows.get_mut(&window) {
+            record.mapped = true;
+            if let ManagedSurface::X11(surface) = &record.surface {
+                // A non-OR X11 window that asked to map still needs its
+                // MapRequest honored by the (X11) WM even when we
+                // decline to decorate it; OR windows mapped themselves
+                // already and set_mapped would rightly refuse them.
+                if surface.alive() && !surface.is_override_redirect() {
+                    if let Err(error) = surface.set_mapped(true) {
+                        tracing::warn!(?error, ?window, "X11 unmanaged map failed");
+                    }
+                }
+            }
+            self.damage = true;
+        }
+    }
+
+    fn position_client(&mut self, window: Self::WindowId, pos: Point) {
+        // `pos` is frame-local (the chrome offset — see the trait doc:
+        // this only fires when that offset changes, fullscreen in/out).
+        // Translate to global against the owning frame.
+        let Some(frame_pos) = self
+            .frames
+            .values()
+            .find(|record| record.window == window)
+            .map(|record| record.geometry.pos)
+        else {
+            return;
+        };
+        let Some(record) = self.windows.get_mut(&window) else {
+            return;
+        };
+        record.content.pos = Point::new(frame_pos.x + pos.x, frame_pos.y + pos.y);
+        if let ManagedSurface::X11(surface) = &record.surface {
+            if surface.alive() {
+                if let Err(error) = surface.configure(smithay_rect(record.content)) {
+                    tracing::warn!(?error, ?window, "X11 position configure failed");
+                }
+            }
+        }
+        self.damage = true;
+    }
+
+    // A compositor sees every click before any client does, so there is
+    // no first-click race for click-to-focus and nothing to passively
+    // grab or replay — the trait's own doc calls these out as no-ops on
+    // exactly this kind of backend.
+    fn grab_button_passive(&mut self, _window: Self::WindowId, _button: MouseButton) {}
+
+    fn ungrab_button_passive(&mut self, _window: Self::WindowId, _button: MouseButton) {}
+
+    fn replay_pointer(&mut self) {}
+}
+
+/// The desktop shell's popup family (cascade menus, tooltips), on the
+/// same id space as the shell surfaces so `chonk-shell`'s
+/// `Shell<B: Backend + PopupHost<PopupId = B::ShellId>>` bound holds —
+/// popups are simply above-band shell surfaces created pre-mapped and
+/// pre-raised.
+impl wm_theme_api::PopupHost for WaylandBackend {
+    type PopupId = WlShellId;
+
+    fn create_popup(&mut self, geometry: Rect, background: (u8, u8, u8)) -> Option<Self::PopupId> {
+        let popup = <Self as Backend>::create_shell_surface(self, geometry, background, true)?;
+        <Self as Backend>::map_shell_surface(self, popup);
+        <Self as Backend>::raise_shell_surface(self, popup);
+        Some(popup)
+    }
+
+    fn destroy_popup(&mut self, popup: Self::PopupId) {
+        <Self as Backend>::destroy_shell_surface(self, popup);
+    }
+
+    fn paint_popup(&mut self, popup: Self::PopupId, buffer: &DecorationBuffer) {
+        <Self as Backend>::paint_shell_surface(self, popup, buffer);
+    }
+
+    /// Trivial token: on X11 this is a real server-side pointer grab so
+    /// a press-drag-release over a menu doesn't get swallowed by the
+    /// implicit grab of wherever the press started — but this
+    /// compositor already receives every pointer event and does its own
+    /// top-down hit-test per event, so the "grab" the cascade
+    /// controller wants is simply how input routing always works here.
+    fn grab_pointer(&mut self) -> wm_theme_api::PopupGrab {
+        wm_theme_api::PopupGrab(0)
+    }
+
+    fn ungrab_pointer(&mut self, _grab: wm_theme_api::PopupGrab) {}
+}

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -1,0 +1,762 @@
+//! Seat input translation: raw backend events (winit today, libinput
+//! under the `session` feature later) into exactly the `BackendEvent`
+//! stream `wm-x11` produces, plus direct wl_seat delivery for the input
+//! that belongs to clients rather than the window manager.
+//!
+//! The routing authority here is the same top-down hit-test the
+//! renderer paints by: unmanaged override-redirect X11 windows, `above`
+//! shell surfaces, frames (each with its client's xdg popups floating
+//! over it), `below` shell surfaces (see `backend_impl.rs`'s module doc
+//! on stacking bands). On X11 this routing was the server's job —
+//! event windows, passive grabs, replay — and `wm-x11` merely
+//! translated what the server had already decided. A compositor IS the
+//! server, so the decisions live here, and the grab verbs on the
+//! backend (`grab_pointer_for_drag`, `grab_keyboard`) reduce to flags
+//! this module consults instead of round-trips that can fail.
+//!
+//! X11's implicit grab — after a button press, every pointer event
+//! until the last release reports against the window the press landed
+//! on — is reproduced literally (`ImplicitGrab` below), because two
+//! shell behaviors depend on it: a titlebar drag's release must reach
+//! the frame even when the pointer has outrun it mid-drag, and a
+//! launcher-strip/menu drag's release must reach the shell surface the
+//! press armed, wherever the pointer is by then. For clicks that land
+//! on client content, smithay's seat runs its own click grab with the
+//! same semantics, so this module only pins the *routing* decision and
+//! lets the seat pin the client-side focus.
+//!
+//! Presses that hit nothing at all queue under [`ROOT_SHELL`] — the
+//! sentinel `Compositor::dispatch_pending` splits off into
+//! `Shell::on_root_press`, standing in for the root-window id the X11
+//! loop compares against.
+//!
+//! The cross-event routing state ([`InputState`]) lives in the seat's
+//! user-data map rather than as a `Compositor` field: the seat is the
+//! thing whose events the state describes, the map ties the lifetime to
+//! it for free, and the handlers here stay the only code that can see
+//! it.
+
+use std::cell::RefCell;
+
+use smithay::backend::input::{
+    AbsolutePositionEvent, Axis, AxisSource, ButtonState, Event, InputBackend, InputEvent,
+    KeyState, KeyboardKeyEvent, MouseButton as InputMouseButton, PointerAxisEvent,
+    PointerButtonEvent, PointerMotionEvent,
+};
+use smithay::desktop::utils::under_from_surface_tree;
+use smithay::desktop::{PopupManager, WindowSurfaceType};
+use smithay::input::keyboard::{FilterResult, Keycode, ModifiersState};
+use smithay::input::pointer::{AxisFrame, ButtonEvent, MotionEvent};
+use smithay::input::Seat;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::utils::{Logical, Point as LogicalPoint, SERIAL_COUNTER};
+
+use wm_core::{BackendEvent, KeyCombo, Modifiers, MouseButton, SurfaceRef};
+use wm_theme_api::Point;
+
+use crate::state::{
+    Compositor, ManagedSurface, StackEntry, WaylandBackend, WlFrameId, WlShellId, WlWindowId,
+    ROOT_SHELL,
+};
+
+/// The event shorthand every queue in this module speaks.
+type WmEvent = BackendEvent<WlWindowId, WlFrameId>;
+
+/// Input-routing state the event handlers carry between events. All of
+/// it is *cross-event* memory — what the last event decided constrains
+/// where the next one is allowed to go — parked on the seat's user-data
+/// map (see the module doc for why there and not on `Compositor`).
+#[derive(Default)]
+struct InputState {
+    /// The frame the pointer was inside (chrome or content) at the last
+    /// motion — crossing INTO a frame emits `BackendEvent::PointerEnter`
+    /// exactly once, which is what focus-follows-mouse keys off. X11
+    /// gave us EnterNotify for free; here the crossing is detected by
+    /// comparing consecutive hit-tests.
+    hovered_frame: Option<WlFrameId>,
+    /// X11-style implicit pointer grab: set on the first button press,
+    /// held until the last button release, and every pointer event in
+    /// between routes to the press's target rather than whatever is
+    /// under the pointer now.
+    implicit_grab: Option<ImplicitGrab>,
+    /// Keycodes whose press was intercepted (a grabbed combo, or any
+    /// press during the modal keyboard grab) — their releases are
+    /// swallowed too, so a client never sees a release for a press it
+    /// never got. This is what an X11 passive grab did server-side; a
+    /// stray release confuses stateful clients (games, VMs) even though
+    /// most toolkits shrug it off.
+    suppressed_keys: Vec<Keycode>,
+}
+
+struct ImplicitGrab {
+    target: PressTarget,
+    /// Number of buttons currently held. X11 keeps the original grab
+    /// window when further buttons press mid-grab, and releases only
+    /// end the grab when the last button lifts — mirrored exactly.
+    buttons: u32,
+}
+
+/// Where a button press landed — the routing target its whole implicit
+/// grab inherits.
+#[derive(Clone, Copy)]
+enum PressTarget {
+    Shell(WlShellId),
+    Frame(WlFrameId),
+    Content(WlWindowId),
+    Root,
+}
+
+/// Runs `f` against the seat's [`InputState`], creating it on first
+/// use. Callers keep each access short — never across a seat call that
+/// re-enters the `Compositor` handlers — which the closure shape makes
+/// structural rather than a discipline.
+fn with_input<T>(seat: &Seat<Compositor>, f: impl FnOnce(&mut InputState) -> T) -> T {
+    let user_data = seat.user_data();
+    user_data.insert_if_missing(|| RefCell::new(InputState::default()));
+    let cell = user_data.get::<RefCell<InputState>>().unwrap();
+    f(&mut cell.borrow_mut())
+}
+
+/// One entry point for `run()`'s event loop: translate and route a
+/// single input event. Generic over the smithay input backend so the
+/// winit dev loop and a future libinput session share every line of
+/// routing policy — only the raw event types differ.
+pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event: InputEvent<I>) {
+    match event {
+        InputEvent::Keyboard { event } => on_keyboard_key::<I>(state, event),
+        InputEvent::PointerMotionAbsolute { event } => on_pointer_move_absolute::<I>(state, event),
+        InputEvent::PointerMotion { event } => on_pointer_move_relative::<I>(state, event),
+        InputEvent::PointerButton { event } => on_pointer_button::<I>(state, event),
+        InputEvent::PointerAxis { event } => on_pointer_axis::<I>(state, event),
+        // Touch, gestures, device hotplug: nothing chonkstep models yet.
+        _ => {}
+    }
+}
+
+// -- keyboard ------------------------------------------------------------
+
+/// Runs every key through the seat keyboard's xkb state (which owns the
+/// keymap, modifier tracking, and client delivery) with a filter that
+/// implements the WM's grab contract:
+///
+/// - a pressed combo matching `grabbed_combos` — or ANY press while the
+///   modal `keyboard_grabbed` flag is set (Alt-Tab) — becomes
+///   `BackendEvent::KeyPress` and never reaches a client;
+/// - releases are forwarded to clients normally, except releases of
+///   keys whose press was intercepted (see `suppressed_keys`); while
+///   `keyboard_grabbed`, every release ADDITIONALLY queues
+///   `BackendEvent::KeyRelease` — the Alt release is what commits an
+///   Alt-Tab cycle (see `wm-x11`'s KeyRelease comment; same contract).
+fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKeyEvent) {
+    let keycode = event.key_code();
+    let key_state = event.state();
+    let serial = SERIAL_COUNTER.next_serial();
+    let time = event.time_msec();
+    let Some(keyboard) = state.seat.get_keyboard() else {
+        return;
+    };
+    let seat = state.seat.clone();
+    keyboard.input::<(), _>(state, keycode, key_state, serial, time, |data, mods, handle| {
+        // Level-0 (unshifted) keysym, exactly like `wm-x11`'s
+        // `keysym_for_keycode` taking the keycode's first sym: a combo
+        // bound as Alt+Shift+T must match the T key with SHIFT in the
+        // modifier mask, not the keysym 'T' that shift-modified lookup
+        // would produce (and Shift+Tab must stay XK_Tab, not
+        // ISO_Left_Tab — `wm-core`'s cycle-backwards match depends on
+        // it). The latin fallback keeps bindings working on non-latin
+        // layouts.
+        let keysym = handle
+            .raw_latin_sym_or_raw_current_sym()
+            .unwrap_or_else(|| handle.modified_sym());
+        let combo = KeyCombo { keysym: keysym.raw(), modifiers: combo_modifiers(mods) };
+        match key_state {
+            KeyState::Pressed => {
+                let backend = data.wm.backend_mut();
+                if backend.keyboard_grabbed || backend.grabbed_combos.contains(&combo) {
+                    backend.queue(WmEvent::KeyPress(combo));
+                    with_input(&seat, |input| input.suppressed_keys.push(keycode));
+                    FilterResult::Intercept(())
+                } else {
+                    FilterResult::Forward
+                }
+            }
+            KeyState::Released => {
+                let backend = data.wm.backend_mut();
+                if backend.keyboard_grabbed {
+                    backend.queue(WmEvent::KeyRelease(combo));
+                }
+                let suppressed = with_input(&seat, |input| {
+                    match input.suppressed_keys.iter().position(|k| *k == keycode) {
+                        Some(index) => {
+                            input.suppressed_keys.swap_remove(index);
+                            true
+                        }
+                        None => false,
+                    }
+                });
+                if suppressed {
+                    FilterResult::Intercept(())
+                } else {
+                    FilterResult::Forward
+                }
+            }
+        }
+    });
+}
+
+/// xkb modifier state -> the backend-agnostic `Modifiers` `wm-core`
+/// reasons about — the exact counterpart of `wm-x11`'s
+/// `modifiers_from_state` (whose Mod1=Alt / Mod4=Super conventions xkb
+/// simply names directly).
+fn combo_modifiers(mods: &ModifiersState) -> Modifiers {
+    let mut result = Modifiers::empty();
+    if mods.shift {
+        result |= Modifiers::SHIFT;
+    }
+    if mods.ctrl {
+        result |= Modifiers::CONTROL;
+    }
+    if mods.alt {
+        result |= Modifiers::ALT;
+    }
+    if mods.logo {
+        result |= Modifiers::SUPER;
+    }
+    result
+}
+
+// -- pointer motion ------------------------------------------------------
+
+/// Winit reports the pointer absolutely against the host window;
+/// transform to output space and route.
+fn on_pointer_move_absolute<I: InputBackend>(
+    state: &mut Compositor,
+    event: I::PointerMotionAbsoluteEvent,
+) {
+    let size = state.wm.backend().output_size;
+    let position = event.position_transformed((size.w as i32, size.h as i32).into());
+    pointer_moved(state, position, event.time_msec());
+}
+
+/// Relative motion (the libinput/session path): accumulate onto the
+/// current location and clamp to the output — the compositor equivalent
+/// of the X server confining the pointer to the screen.
+fn on_pointer_move_relative<I: InputBackend>(
+    state: &mut Compositor,
+    event: I::PointerMotionEvent,
+) {
+    let size = state.wm.backend().output_size;
+    let mut position = state.pointer_location + event.delta();
+    position.x = position.x.clamp(0.0, (size.w.max(1) - 1) as f64);
+    position.y = position.y.clamp(0.0, (size.h.max(1) - 1) as f64);
+    pointer_moved(state, position, event.time_msec());
+}
+
+/// The shared motion path: hover/crossing bookkeeping, WM/shell queue
+/// routing (honoring an implicit grab), then one seat `motion` +
+/// `frame` so smithay's location tracking and client enter/leave stay
+/// correct no matter where the event was routed.
+fn pointer_moved(state: &mut Compositor, position: LogicalPoint<f64, Logical>, time: u32) {
+    let serial = SERIAL_COUNTER.next_serial();
+    // Floor, not round: a pointer at x=10.7 is over pixel 10, and
+    // rounding at the output's far edge would name a pixel outside
+    // every rect (`Rect::contains` is half-open).
+    let at = Point::new(position.x.floor() as i32, position.y.floor() as i32);
+    let Some(pointer) = state.seat.get_pointer() else {
+        return;
+    };
+    let seat = state.seat.clone();
+    // The renderer composites the cursor at this location itself (no
+    // hardware cursor plane on the nested backend), so pointer motion
+    // is scene damage by definition — without this the arrow freezes
+    // between window updates.
+    state.pointer_location = position;
+    let hit = hit_at(state.wm.backend(), at, position);
+
+    // Enter/crossing detection, only while no implicit grab holds —
+    // X11 suppressed crossing events for the duration of a grab too
+    // (the drag's grab mask never selected them), and focus-follows-
+    // mouse mid-drag would focus every window a fast drag brushes.
+    let now_hovered = match &hit {
+        Hit::FrameChrome { frame, .. } => Some(*frame),
+        Hit::Content { frame, .. } => *frame,
+        _ => None,
+    };
+    let entered = with_input(&seat, |input| {
+        if input.implicit_grab.is_some() || now_hovered == input.hovered_frame {
+            None
+        } else {
+            input.hovered_frame = now_hovered;
+            now_hovered
+        }
+    });
+    let grab_target = with_input(&seat, |input| input.implicit_grab.as_ref().map(|g| g.target));
+
+    let backend = state.wm.backend_mut();
+    backend.mark_damaged();
+    if let Some(frame) = entered {
+        backend.queue(WmEvent::PointerEnter { surface: SurfaceRef::Frame(frame) });
+    }
+    // The client focus this motion carries into the seat. Only content
+    // routes focus a client; every other route clears it (generating
+    // the wl_pointer.leave a client under the pointer's previous
+    // position expects). During a non-content implicit grab the focus
+    // is pinned to None so a WM drag never leaks motion into whatever
+    // client windows it crosses — the X11 grab hid those too.
+    let mut focus: Option<(WlSurface, LogicalPoint<f64, Logical>)> = None;
+    match grab_target {
+        Some(PressTarget::Shell(shell)) => {
+            if let Some(record) = backend.shells.get(&shell) {
+                backend
+                    .shell_motions
+                    .push_back((shell, local_to(at, record.geometry.pos)));
+            }
+            backend.queue(WmEvent::PointerMotion { root: at, surface_local: None });
+        }
+        Some(PressTarget::Frame(frame)) => {
+            let surface_local = backend
+                .frames
+                .get(&frame)
+                .map(|record| (SurfaceRef::Frame(frame), local_to(at, record.geometry.pos)));
+            backend.queue(WmEvent::PointerMotion { root: at, surface_local });
+        }
+        Some(PressTarget::Content(_)) => {
+            // The seat's own click grab pins the client-side focus; the
+            // hit-test result is passed through untouched (smithay
+            // ignores it while the grab holds, and needs it the instant
+            // the grab ends).
+            if let Hit::Content { surface: Some(surface), origin, .. } = &hit {
+                focus = Some((surface.clone(), *origin));
+            }
+        }
+        Some(PressTarget::Root) => {
+            backend.queue(WmEvent::PointerMotion { root: at, surface_local: None });
+        }
+        None => match &hit {
+            Hit::Shell { shell, local } => {
+                // Both queues, from the one event, exactly like
+                // `wm-x11`: the shell drains its surface-local motion
+                // inside `on_motion`, which the loop only calls when a
+                // root-coordinate `PointerMotion` arrives.
+                backend.shell_motions.push_back((*shell, *local));
+                backend.queue(WmEvent::PointerMotion { root: at, surface_local: None });
+            }
+            Hit::FrameChrome { frame, local } => {
+                backend.queue(WmEvent::PointerMotion {
+                    root: at,
+                    surface_local: Some((SurfaceRef::Frame(*frame), *local)),
+                });
+            }
+            Hit::Content { surface, origin, .. } => {
+                // Client territory: the WM does not see idle motion
+                // over client content on X11 (no motion mask there) and
+                // it doesn't here either.
+                if let Some(surface) = surface {
+                    focus = Some((surface.clone(), *origin));
+                }
+            }
+            Hit::Root => {
+                backend.queue(WmEvent::PointerMotion { root: at, surface_local: None });
+            }
+        },
+    }
+
+    pointer.motion(state, focus, &MotionEvent { location: position, serial, time });
+    pointer.frame(state);
+}
+
+// -- pointer buttons -----------------------------------------------------
+
+/// Button routing: the press's hit-test establishes (or joins) the
+/// implicit grab, and both press and release are dispatched against the
+/// grab's target — shell queue, WM event, client seat delivery, or a
+/// [`ROOT_SHELL`] click the loop feeds to `shell.on_root_press`.
+fn on_pointer_button<I: InputBackend>(state: &mut Compositor, event: I::PointerButtonEvent) {
+    let serial = SERIAL_COUNTER.next_serial();
+    let time = event.time_msec();
+    let pressed = event.state() == ButtonState::Pressed;
+    // L/M/R map onto the WM's vocabulary; anything else (side buttons,
+    // wheel tilt) is client-only — `wm-x11` swallowed those outright,
+    // here they at least still reach a client under the pointer.
+    let button = event.button().and_then(wm_button);
+    let Some(pointer) = state.seat.get_pointer() else {
+        return;
+    };
+    let seat = state.seat.clone();
+    let position = state.pointer_location;
+    let at = Point::new(position.x.floor() as i32, position.y.floor() as i32);
+    let mods = state
+        .seat
+        .get_keyboard()
+        .map(|keyboard| combo_modifiers(&keyboard.modifier_state()))
+        .unwrap_or_else(Modifiers::empty);
+
+    let hit = hit_at(state.wm.backend(), at, position);
+    let target = with_input(&seat, |input| {
+        if pressed {
+            match input.implicit_grab.as_mut() {
+                // A second button mid-grab joins the grab; the original
+                // target keeps every event (X11 semantics).
+                Some(grab) => {
+                    grab.buttons += 1;
+                    grab.target
+                }
+                None => {
+                    let target = press_target(&hit);
+                    input.implicit_grab = Some(ImplicitGrab { target, buttons: 1 });
+                    target
+                }
+            }
+        } else {
+            match input.implicit_grab.as_mut() {
+                Some(grab) => {
+                    let target = grab.target;
+                    grab.buttons = grab.buttons.saturating_sub(1);
+                    if grab.buttons == 0 {
+                        input.implicit_grab = None;
+                    }
+                    target
+                }
+                // A release with no tracked press (button already down
+                // when the compositor started): best-effort location
+                // routing.
+                None => press_target(&hit),
+            }
+        }
+    });
+
+    let backend = state.wm.backend_mut();
+    let mut deliver_to_client = false;
+    match target {
+        PressTarget::Shell(shell) => {
+            if let (Some(button), Some(record)) = (button, backend.shells.get(&shell)) {
+                backend.shell_clicks.push_back((
+                    shell,
+                    local_to(at, record.geometry.pos),
+                    button,
+                    pressed,
+                ));
+            }
+        }
+        PressTarget::Frame(frame) => {
+            if let (Some(button), Some(record)) = (button, backend.frames.get(&frame)) {
+                backend.queue(WmEvent::PointerButton {
+                    surface: SurfaceRef::Frame(frame),
+                    local: local_to(at, record.geometry.pos),
+                    button,
+                    pressed,
+                    time_ms: time,
+                    mods,
+                });
+            }
+        }
+        PressTarget::Content(window) => {
+            // The WM hears about content clicks too — that's the whole
+            // click-to-focus path (`wm-core`'s `handle_client_button`
+            // focuses and calls `replay_pointer`, a no-op here because
+            // the very next lines deliver the click to the client
+            // themselves; no passive-grab race exists to replay
+            // around).
+            if let Some(button) = button {
+                let local = backend
+                    .windows
+                    .get(&window)
+                    .map(|record| local_to(at, record.content.pos))
+                    .unwrap_or(at);
+                backend.queue(WmEvent::PointerButton {
+                    surface: SurfaceRef::Client(window),
+                    local,
+                    button,
+                    pressed,
+                    time_ms: time,
+                    mods,
+                });
+            }
+            deliver_to_client = true;
+        }
+        PressTarget::Root => {
+            // Background clicks travel the shell-click queue under the
+            // sentinel id; `dispatch_pending` splits presses off to
+            // `on_root_press` and lets releases flow through
+            // `on_shell_click`, mirroring the X11 loop's routing
+            // asymmetry. Root-local coordinates ARE global ones.
+            if let Some(button) = button {
+                backend.shell_clicks.push_back((ROOT_SHELL, at, button, pressed));
+            }
+        }
+    }
+
+    if deliver_to_client {
+        pointer.button(
+            state,
+            &ButtonEvent { serial, time, button: event.button_code(), state: event.state() },
+        );
+        pointer.frame(state);
+    }
+}
+
+fn wm_button(button: InputMouseButton) -> Option<MouseButton> {
+    match button {
+        InputMouseButton::Left => Some(MouseButton::Left),
+        InputMouseButton::Middle => Some(MouseButton::Middle),
+        InputMouseButton::Right => Some(MouseButton::Right),
+        _ => None,
+    }
+}
+
+fn press_target(hit: &Hit) -> PressTarget {
+    match hit {
+        Hit::Shell { shell, .. } => PressTarget::Shell(*shell),
+        Hit::FrameChrome { frame, .. } => PressTarget::Frame(*frame),
+        Hit::Content { window, .. } => PressTarget::Content(*window),
+        Hit::Root => PressTarget::Root,
+    }
+}
+
+// -- pointer axis --------------------------------------------------------
+
+/// Scroll goes to clients only (the WM has no scroll gestures — same as
+/// X11, where wheel events were buttons 4/5 and `wm-x11` dropped them).
+/// The seat delivers to the current pointer focus, which the motion
+/// routing above only ever points at client content — so a scroll over
+/// chrome or a shell surface lands nowhere, exactly as intended.
+fn on_pointer_axis<I: InputBackend>(state: &mut Compositor, event: I::PointerAxisEvent) {
+    let horizontal = event
+        .amount(Axis::Horizontal)
+        .unwrap_or_else(|| event.amount_v120(Axis::Horizontal).unwrap_or(0.0) * 15.0 / 120.0);
+    let vertical = event
+        .amount(Axis::Vertical)
+        .unwrap_or_else(|| event.amount_v120(Axis::Vertical).unwrap_or(0.0) * 15.0 / 120.0);
+
+    let mut frame = AxisFrame::new(event.time_msec()).source(event.source());
+    if horizontal != 0.0 {
+        frame = frame
+            .relative_direction(Axis::Horizontal, event.relative_direction(Axis::Horizontal));
+        frame = frame.value(Axis::Horizontal, horizontal);
+        if let Some(discrete) = event.amount_v120(Axis::Horizontal) {
+            frame = frame.v120(Axis::Horizontal, discrete as i32);
+        }
+    }
+    if vertical != 0.0 {
+        frame = frame.relative_direction(Axis::Vertical, event.relative_direction(Axis::Vertical));
+        frame = frame.value(Axis::Vertical, vertical);
+        if let Some(discrete) = event.amount_v120(Axis::Vertical) {
+            frame = frame.v120(Axis::Vertical, discrete as i32);
+        }
+    }
+    // A finger lifting off a touchpad ends kinetic scroll with an
+    // explicit stop event per axis — clients (GTK especially) use it to
+    // start their fling animation.
+    if event.source() == AxisSource::Finger {
+        if event.amount(Axis::Horizontal) == Some(0.0) {
+            frame = frame.stop(Axis::Horizontal);
+        }
+        if event.amount(Axis::Vertical) == Some(0.0) {
+            frame = frame.stop(Axis::Vertical);
+        }
+    }
+    let Some(pointer) = state.seat.get_pointer() else {
+        return;
+    };
+    pointer.axis(state, frame);
+    pointer.frame(state);
+}
+
+// -- hit-testing ---------------------------------------------------------
+
+/// The scene's input authority: what sits under a point, walking the
+/// SAME z-order the renderer paints — unmanaged override-redirect X11
+/// windows (menus, tooltips) on top, then `above` shells, frames (with
+/// each frame's xdg popups floating over its chrome), and `below`
+/// shells; the desktop background catches the rest. Any disagreement
+/// between this walk and the renderer's makes clicks land on things the
+/// user cannot see, so both sides cite `backend_impl.rs`'s
+/// stacking-band contract.
+fn hit_at(backend: &WaylandBackend, at: Point, position: LogicalPoint<f64, Logical>) -> Hit {
+    // Unmanaged override-redirect X11 windows first: they self-position
+    // over everything (an open menu overlapping the dock must win the
+    // click), and being frameless they live outside `stacking`.
+    for (&window, record) in backend.windows.iter() {
+        if !record.mapped || !record.content.contains(at) {
+            continue;
+        }
+        let has_frame = backend.frames.values().any(|frame| frame.window == window);
+        if has_frame {
+            continue;
+        }
+        if let Some(hit) = content_hit(backend, None, window, position) {
+            return hit;
+        }
+    }
+
+    // `above` shell band (dock, shell menus), topmost stacking entry
+    // first.
+    for entry in backend.stacking.iter().rev() {
+        let StackEntry::Shell(shell) = entry else {
+            continue;
+        };
+        if let Some(record) = backend.shells.get(shell) {
+            if record.above && record.mapped && record.geometry.contains(at) {
+                return Hit::Shell { shell: *shell, local: local_to(at, record.geometry.pos) };
+            }
+        }
+    }
+
+    // Frame band.
+    for entry in backend.stacking.iter().rev() {
+        let StackEntry::Frame(frame) = entry else {
+            continue;
+        };
+        let Some(record) = backend.frames.get(frame) else {
+            continue;
+        };
+        if !record.mapped {
+            continue;
+        }
+        // The frame's client's xdg popups float above its chrome and
+        // may extend beyond the frame rect entirely (a context menu
+        // opened near an edge), so they are tested before — and
+        // independent of — the frame's own geometry.
+        if let Some(hit) = popup_hit(backend, *frame, record.window, position) {
+            return hit;
+        }
+        if !record.geometry.contains(at) {
+            continue;
+        }
+        let over_content = backend
+            .windows
+            .get(&record.window)
+            .is_some_and(|window| window.mapped && window.content.contains(at));
+        if over_content {
+            if let Some(hit) = content_hit(backend, Some(*frame), record.window, position) {
+                return hit;
+            }
+        }
+        return Hit::FrameChrome { frame: *frame, local: local_to(at, record.geometry.pos) };
+    }
+
+    // `below` shell band (desktop-level furniture).
+    for entry in backend.stacking.iter().rev() {
+        let StackEntry::Shell(shell) = entry else {
+            continue;
+        };
+        if let Some(record) = backend.shells.get(shell) {
+            if !record.above && record.mapped && record.geometry.contains(at) {
+                return Hit::Shell { shell: *shell, local: local_to(at, record.geometry.pos) };
+            }
+        }
+    }
+
+    Hit::Root
+}
+
+/// What the top-down hit-test found under a point.
+enum Hit {
+    /// A mapped shell surface (dock, menu, icon tile), with the
+    /// surface-local position the shell's click/motion routing expects.
+    Shell { shell: WlShellId, local: Point },
+    /// Frame chrome: inside a frame's geometry but outside its client's
+    /// content rect (titlebar, borders, resize edges) — `wm-core`'s
+    /// territory, reported frame-local like X11 frame events.
+    FrameChrome { frame: WlFrameId, local: Point },
+    /// Client content (or one of its xdg popups): input goes to the
+    /// client through the seat. `frame` is the owning frame when one
+    /// exists (`None` for unmanaged override-redirect X11 windows);
+    /// `surface`/`origin` name the exact wl_surface to focus and its
+    /// global position (`None` surface for an X11 window whose
+    /// wl_surface has not been associated yet — nothing to deliver to,
+    /// but the WM still learns about the click). No local coordinate:
+    /// `wm-core` ignores it for `SurfaceRef::Client` events, and the
+    /// button handler recomputes a content-local point from the record
+    /// for the event shape.
+    Content {
+        frame: Option<WlFrameId>,
+        window: WlWindowId,
+        surface: Option<WlSurface>,
+        origin: LogicalPoint<f64, Logical>,
+    },
+    /// The desktop background.
+    Root,
+}
+
+/// Content hit for a window whose content rect contains the point:
+/// resolves the exact wl_surface (subsurfaces included) to hand the
+/// seat. Falls back to the root surface when the tree walk declines the
+/// point (a client buffer briefly smaller than its configured rect
+/// mid-resize) — coordinates a little outside the buffer are what X11
+/// delivered in that gap too, and clients cope.
+fn content_hit(
+    backend: &WaylandBackend,
+    frame: Option<WlFrameId>,
+    window: WlWindowId,
+    position: LogicalPoint<f64, Logical>,
+) -> Option<Hit> {
+    let record = backend.windows.get(&window)?;
+    let root_surface = record.surface.wl_surface();
+    let content_origin = record.content.pos;
+    let (surface, origin) = match &root_surface {
+        Some(root) => under_from_surface_tree(
+            root,
+            position,
+            (content_origin.x, content_origin.y),
+            WindowSurfaceType::ALL,
+        )
+        .map(|(surface, origin)| (Some(surface), origin.to_f64()))
+        .unwrap_or_else(|| {
+            (root_surface.clone(), (content_origin.x as f64, content_origin.y as f64).into())
+        }),
+        // An X11 window whose wl_surface has not been associated yet:
+        // nothing to deliver to, but the click still counts for
+        // click-to-focus.
+        None => (None, (content_origin.x as f64, content_origin.y as f64).into()),
+    };
+    Some(Hit::Content { frame, window, surface, origin })
+}
+
+/// Tests a window's xdg popup tree (context menus, dropdowns of native
+/// Wayland clients). Popup offsets from
+/// `PopupManager::popups_for_surface` are parent-surface-relative; the
+/// renderer resolves them against the content rect (`content.pos +
+/// offset` — see `renderer.rs`'s `push_window_content`) and this walk
+/// must resolve them identically or popup clicks land beside the menu
+/// the user sees.
+fn popup_hit(
+    backend: &WaylandBackend,
+    frame: WlFrameId,
+    window: WlWindowId,
+    position: LogicalPoint<f64, Logical>,
+) -> Option<Hit> {
+    let record = backend.windows.get(&window)?;
+    if !record.mapped {
+        return None;
+    }
+    let ManagedSurface::Xdg(toplevel) = &record.surface else {
+        // X11 menus arrive as override-redirect windows, handled at the
+        // top of `hit_at` — no xdg popups to test here.
+        return None;
+    };
+    let content_origin = record.content.pos;
+    for (popup, offset) in PopupManager::popups_for_surface(toplevel.wl_surface()) {
+        let popup_origin: LogicalPoint<i32, Logical> =
+            (content_origin.x + offset.x, content_origin.y + offset.y).into();
+        if let Some((surface, origin)) = under_from_surface_tree(
+            popup.wl_surface(),
+            position,
+            popup_origin,
+            WindowSurfaceType::ALL,
+        ) {
+            return Some(Hit::Content {
+                frame: Some(frame),
+                window,
+                surface: Some(surface),
+                origin: origin.to_f64(),
+            });
+        }
+    }
+    None
+}
+
+/// Root-space point -> a rect's local coordinates.
+fn local_to(at: Point, origin: Point) -> Point {
+    Point::new(at.x - origin.x, at.y - origin.y)
+}

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -4,6 +4,30 @@
 //! policy brain and the same `chonk-shell` desktop drive a native
 //! Wayland session exactly as they drive X11.
 //!
+//! The crate owns the *whole* compositor application, not just a
+//! backend: on X11 the display server is someone else's process and
+//! the WM is one client among many, but a Wayland compositor *is* the
+//! display server, so everything — protocol globals, the GLES
+//! renderer, input, XWayland, and the `WindowManager`/`Shell` pair —
+//! has to live in one process behind one event loop. The binary
+//! (`chonkstep-wayland`) therefore only calls [`run`].
+//!
+//! Everything hangs off one type, [`Compositor`], because Smithay's
+//! delegate macros demand it: each Wayland protocol is wired up with a
+//! `delegate_*!(Compositor)` invocation that implements the dispatch
+//! traits *for that concrete type*, so the calloop data type, every
+//! protocol handler, and the render loop must all agree on a single
+//! struct. See `state.rs` for the full shape and the module split.
+//!
 //! Linux-only by nature; on any other host this crate is deliberately
 //! empty so the workspace builds everywhere.
 #![cfg(target_os = "linux")]
+
+mod backend_impl;
+mod input;
+mod renderer;
+mod state;
+mod xdg;
+mod xwayland;
+
+pub use state::{run, Compositor, WaylandBackend, WlFrameId, WlShellId, WlWindowId};

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -1,0 +1,383 @@
+//! Scene composition: turns the [`WaylandBackend`] ledger into GLES
+//! render elements and puts a frame on screen.
+//!
+//! The composition order is fixed, bottom to top: the root background
+//! (solid color or wallpaper image), then the ledger's `stacking`
+//! sequence partitioned so `above: false` shell surfaces come before
+//! all frames and `above: true` shells after them, each frame drawing
+//! its decoration buffer at its geometry with its client's surface
+//! tree (and that client's xdg popups) on top at the window's content
+//! rect, then XWayland override-redirect windows, then the pointer
+//! cursor. That is exactly the stacking the X11 session produces with
+//! real windows, reproduced here as a plain ordered walk.
+//!
+//! Every redraw damages the full frame (`age = 0` to the damage
+//! tracker, full-output submit) rather than tracking per-element
+//! damage — correctness first: the X11 side made the same call by
+//! running picom with `--no-use-damage`, trading a little GPU fill for
+//! never chasing partial-damage artifacts. Revisit only with evidence.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
+use smithay::backend::renderer::element::solid::SolidColorRenderElement;
+use smithay::backend::renderer::element::surface::{
+    render_elements_from_surface_tree, WaylandSurfaceRenderElement,
+};
+use smithay::backend::renderer::element::{Id, Kind};
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::utils::CommitCounter;
+use smithay::backend::renderer::{Color32F, ImportAll, ImportMem};
+use smithay::desktop::utils::send_frames_surface_tree;
+use smithay::desktop::PopupManager;
+use smithay::input::pointer::{CursorImageAttributes, CursorImageStatus};
+use smithay::render_elements;
+use smithay::utils::{IsAlive, Physical, Point as SPoint, Rectangle as SRect};
+use smithay::wayland::compositor::with_states;
+
+use wm_theme_api::Rect;
+
+use crate::state::{Compositor, RootBackground, StackEntry, WaylandBackend};
+
+render_elements! {
+    /// Everything one frame is composed of. The macro generates the
+    /// `Element`/`RenderElement` plumbing for the enum so a single
+    /// `Vec` can carry client surfaces, decoration/wallpaper/cursor
+    /// buffers, and solid fills through one `render_output` call.
+    pub SceneElement<R> where R: ImportAll + ImportMem;
+    Surface = WaylandSurfaceRenderElement<R>,
+    Memory = MemoryRenderBufferRenderElement<R>,
+    Solid = SolidColorRenderElement,
+}
+
+/// Renders one full frame from the current ledger, submits it, sends
+/// frame callbacks so clients keep animating, and clears the damage
+/// flag. Failures log and leave the damage flag set — the next wakeup
+/// simply tries again, which is the only sane recovery for a transient
+/// GL hiccup.
+pub(crate) fn render_frame(comp: &mut Compositor) {
+    // Disjoint field borrows: the winit backend (renderer +
+    // framebuffer) mutates while the ledger is read — both live on
+    // `Compositor`, so destructure instead of going through `&mut
+    // self` methods.
+    let Compositor {
+        wm,
+        winit_backend,
+        damage_tracker,
+        output,
+        pointer_location,
+        cursor_status,
+        default_cursor,
+        start_time,
+        ..
+    } = comp;
+
+    {
+        let (renderer, mut framebuffer) = match winit_backend.bind() {
+            Ok(bound) => bound,
+            Err(error) => {
+                tracing::warn!(?error, "could not bind the winit framebuffer; skipping frame");
+                return;
+            }
+        };
+
+        let backend = wm.backend();
+
+        // Elements are assembled FRONT to BACK — the damage tracker's
+        // convention (first element occludes later ones) — so this
+        // walk is the module-doc composition order reversed: cursor,
+        // above-shells, override-redirect windows, frames, below-
+        // shells, wallpaper.
+        let mut elements: Vec<SceneElement<GlesRenderer>> = Vec::new();
+
+        push_cursor_elements(
+            &mut elements,
+            renderer,
+            *pointer_location,
+            cursor_status,
+            default_cursor,
+        );
+
+        for entry in backend.stacking.iter().rev() {
+            if let StackEntry::Shell(id) = entry {
+                let Some(record) = backend.shells.get(id) else { continue };
+                if record.above && record.mapped {
+                    push_shell_elements(&mut elements, renderer, record);
+                }
+            }
+        }
+
+        // XWayland override-redirect windows (menus, tooltips —
+        // `WindowType::Unmanaged`, so they own no frame and no
+        // stacking entry) draw above every managed frame, which is
+        // where the X server would put a just-mapped override-redirect
+        // window in practice.
+        for record in backend.windows.values() {
+            if record.window_type == wm_core::WindowType::Unmanaged && record.mapped {
+                push_window_content(&mut elements, renderer, record.content, record);
+            }
+        }
+
+        for entry in backend.stacking.iter().rev() {
+            if let StackEntry::Frame(id) = entry {
+                let Some(frame) = backend.frames.get(id) else { continue };
+                if !frame.mapped {
+                    continue;
+                }
+                let window = backend.windows.get(&frame.window);
+                // Content above chrome: the client's tree first
+                // (front-to-back), then the decoration buffer. A
+                // shaded window keeps its frame mapped with the
+                // content unmapped (`set_client_mapped(false)`), which
+                // falls out naturally here.
+                if let Some(record) = window {
+                    if record.mapped {
+                        push_window_content(&mut elements, renderer, record.content, record);
+                    }
+                }
+                if let Some(buffer) = &frame.buffer {
+                    let location = SPoint::<f64, Physical>::from((
+                        frame.geometry.pos.x as f64,
+                        frame.geometry.pos.y as f64,
+                    ));
+                    match MemoryRenderBufferRenderElement::from_buffer(
+                        renderer,
+                        location,
+                        buffer,
+                        None,
+                        None,
+                        None,
+                        Kind::Unspecified,
+                    ) {
+                        Ok(element) => elements.push(element.into()),
+                        Err(error) => tracing::warn!(?error, "failed to import a decoration buffer"),
+                    }
+                }
+            }
+        }
+
+        for entry in backend.stacking.iter().rev() {
+            if let StackEntry::Shell(id) = entry {
+                let Some(record) = backend.shells.get(id) else { continue };
+                if !record.above && record.mapped {
+                    push_shell_elements(&mut elements, renderer, record);
+                }
+            }
+        }
+
+        // Root background. A solid color is simply the clear color —
+        // with full-frame damage every pixel gets cleared, so no
+        // element is needed; a wallpaper image is the bottom-most
+        // element over a black clear.
+        let clear_color = match &backend.root_background {
+            RootBackground::Color((r, g, b)) => {
+                Color32F::new(*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0, 1.0)
+            }
+            RootBackground::Image(buffer) => {
+                match MemoryRenderBufferRenderElement::from_buffer(
+                    renderer,
+                    SPoint::<f64, Physical>::from((0.0, 0.0)),
+                    buffer,
+                    None,
+                    None,
+                    None,
+                    Kind::Unspecified,
+                ) {
+                    Ok(element) => elements.push(element.into()),
+                    Err(error) => tracing::warn!(?error, "failed to import the wallpaper buffer"),
+                }
+                Color32F::new(0.0, 0.0, 0.0, 1.0)
+            }
+        };
+
+        // Age 0 = "assume every pixel stale": the deliberate
+        // full-frame redraw described in the module docs.
+        if let Err(error) =
+            damage_tracker.render_output(renderer, &mut framebuffer, 0, &elements, clear_color)
+        {
+            tracing::warn!(?error, "render failed; keeping damage for a retry");
+            return;
+        }
+    }
+
+    let size = winit_backend.window_size();
+    if let Err(error) = winit_backend.submit(Some(&[SRect::from_size(size)])) {
+        tracing::warn!(?error, "swap failed; keeping damage for a retry");
+        return;
+    }
+
+    // Frame callbacks: clients gate their next commit on these, so
+    // every mapped window (and its popups, and a client-provided
+    // cursor surface) hears about the frame it just appeared in. The
+    // throttle mirrors smithay's reference compositors.
+    let elapsed = start_time.elapsed();
+    let backend: &WaylandBackend = wm.backend();
+    for record in backend.windows.values() {
+        if !record.mapped || !record.surface.alive() {
+            continue;
+        }
+        if let Some(surface) = record.surface.wl_surface() {
+            send_frames_surface_tree(&surface, output, elapsed, Some(Duration::ZERO), |_, _| {
+                Some(output.clone())
+            });
+            for (popup, _) in PopupManager::popups_for_surface(&surface) {
+                send_frames_surface_tree(
+                    popup.wl_surface(),
+                    output,
+                    elapsed,
+                    Some(Duration::ZERO),
+                    |_, _| Some(output.clone()),
+                );
+            }
+        }
+    }
+    if let CursorImageStatus::Surface(surface) = cursor_status {
+        send_frames_surface_tree(surface, output, elapsed, Some(Duration::ZERO), |_, _| {
+            Some(output.clone())
+        });
+    }
+
+    wm.backend_mut().damage = false;
+}
+
+/// Pushes one shell surface's elements (front to back): its painted
+/// buffer, or a solid fill of its background color when it has never
+/// been painted — the same visual the X11 backend gets from a fresh
+/// window's background pixel before the first blit.
+fn push_shell_elements(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    record: &crate::state::ShellRecord,
+) {
+    match &record.buffer {
+        Some(buffer) => {
+            let location = SPoint::<f64, Physical>::from((
+                record.geometry.pos.x as f64,
+                record.geometry.pos.y as f64,
+            ));
+            match MemoryRenderBufferRenderElement::from_buffer(
+                renderer,
+                location,
+                buffer,
+                None,
+                None,
+                None,
+                Kind::Unspecified,
+            ) {
+                Ok(element) => elements.push(element.into()),
+                Err(error) => tracing::warn!(?error, "failed to import a shell surface buffer"),
+            }
+        }
+        None => {
+            let (r, g, b) = record.background;
+            let geometry = SRect::<i32, Physical>::new(
+                (record.geometry.pos.x, record.geometry.pos.y).into(),
+                (record.geometry.size.w as i32, record.geometry.size.h as i32).into(),
+            );
+            // A fresh Id each frame would normally defeat damage
+            // tracking, but full-frame redraws (age 0) never consult
+            // element history — see the module docs.
+            elements.push(
+                SolidColorRenderElement::new(
+                    Id::new(),
+                    geometry,
+                    CommitCounter::default(),
+                    Color32F::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0),
+                    Kind::Unspecified,
+                )
+                .into(),
+            );
+        }
+    }
+}
+
+/// Pushes one managed window's client content (front to back): its
+/// xdg popups above, then the surface tree itself at the content rect.
+/// The tree is drawn at the content origin directly — with server-side
+/// decorations enforced via xdg-decoration, clients do not wrap their
+/// buffers in shadow margins, so the surface origin and the xdg window
+/// geometry origin coincide.
+fn push_window_content(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    content: Rect,
+    record: &crate::state::WindowRecord,
+) {
+    if !record.surface.alive() {
+        return;
+    }
+    let Some(surface) = record.surface.wl_surface() else {
+        return;
+    };
+    let origin = SPoint::<i32, Physical>::from((content.pos.x, content.pos.y));
+    for (popup, offset) in PopupManager::popups_for_surface(&surface) {
+        let location = origin + SPoint::<i32, Physical>::from((offset.x, offset.y));
+        elements.extend(render_elements_from_surface_tree(
+            renderer,
+            popup.wl_surface(),
+            location,
+            1.0,
+            1.0,
+            Kind::Unspecified,
+        ));
+    }
+    elements.extend(render_elements_from_surface_tree(
+        renderer,
+        &surface,
+        origin,
+        1.0,
+        1.0,
+        Kind::Unspecified,
+    ));
+}
+
+/// Pushes the pointer's elements: the client-set cursor surface when
+/// one is active (offset by its hotspot, which smithay stashes in the
+/// surface's data map), the built-in arrow otherwise. `Named` cursor
+/// shapes also fall back to the arrow — shipping an Xcursor theme
+/// loader is not worth it for a nested dev backend, and clients that
+/// care set surface cursors.
+fn push_cursor_elements(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    location: SPoint<f64, smithay::utils::Logical>,
+    status: &CursorImageStatus,
+    default_cursor: &smithay::backend::renderer::element::memory::MemoryRenderBuffer,
+) {
+    match status {
+        CursorImageStatus::Hidden => {}
+        CursorImageStatus::Surface(surface) if surface.alive() => {
+            let hotspot = with_states(surface, |states| {
+                states
+                    .data_map
+                    .get::<Mutex<CursorImageAttributes>>()
+                    .map(|attrs| attrs.lock().unwrap().hotspot)
+                    .unwrap_or_default()
+            });
+            let position = (location - hotspot.to_f64()).to_physical(1.0).to_i32_round();
+            elements.extend(render_elements_from_surface_tree(
+                renderer,
+                surface,
+                position,
+                1.0,
+                1.0,
+                Kind::Cursor,
+            ));
+        }
+        _ => {
+            match MemoryRenderBufferRenderElement::from_buffer(
+                renderer,
+                location.to_physical(1.0),
+                default_cursor,
+                None,
+                None,
+                None,
+                Kind::Cursor,
+            ) {
+                Ok(element) => elements.push(element.into()),
+                Err(error) => tracing::warn!(?error, "failed to import the default cursor"),
+            }
+        }
+    }
+}

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -1,0 +1,1002 @@
+//! The compositor application's central state and entry point.
+//!
+//! Two types carry everything, and the split between them is the whole
+//! architecture:
+//!
+//! - [`WaylandBackend`] is what `wm_core::WindowManager<B>` owns as its
+//!   `B`. It is a *ledger*, not a connection: plain records of every
+//!   window, decoration frame, and shell surface, a bottom-to-top
+//!   stacking order, and queues of pending events. The `Backend` trait
+//!   verbs (in `backend_impl.rs`) mutate these records and set
+//!   [`WaylandBackend::damage`]; nothing here talks to a display
+//!   server, because in this process *we are* the display server.
+//!
+//! - [`Compositor`] is the one calloop data type. Smithay's delegate
+//!   macros (`delegate_compositor!`, `delegate_xdg_shell!`, ...)
+//!   implement each protocol's dispatch traits for a single concrete
+//!   type, so every per-protocol state object, the seat, the output,
+//!   the winit backend with its GLES renderer, and the
+//!   `WindowManager`/`Shell` pair all hang off this struct — there is
+//!   no way to split them into separately-owned pieces without
+//!   fighting the macros. Protocol handlers (in `xdg.rs`,
+//!   `xwayland.rs`, `input.rs`) reach the ledger via
+//!   `self.wm.backend_mut()` and queue `BackendEvent`s / records;
+//!   [`Compositor::dispatch_pending`] then drains those queues in
+//!   exactly the order the X11 binary's event loop drains its backend
+//!   (read `crates/chonkstep/src/main.rs` — it is the reference), so
+//!   the same `wm-core` brain and the same `chonk-shell` desktop see
+//!   the same event discipline on both stacks.
+//!
+//! [`run`] wires it all together: winit + GLES, the Wayland globals,
+//! XWayland, `WindowManager` + `Shell` construction with the same
+//! theme/scale precedence as the X11 binary, and the dispatch loop.
+
+use std::collections::{HashMap, VecDeque};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::damage::OutputDamageTracker;
+use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::winit::{self, WinitEvent, WinitGraphicsBackend};
+use smithay::desktop::PopupManager;
+use smithay::input::keyboard::XkbConfig;
+use smithay::input::pointer::CursorImageStatus;
+use smithay::input::{Seat, SeatState};
+use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
+use smithay::reexports::calloop::generic::Generic;
+use smithay::reexports::calloop::{EventLoop, Interest, LoopHandle, Mode as TriggerMode, PostAction};
+use smithay::reexports::wayland_server::backend::{ClientData, ClientId, DisconnectReason};
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::{Display, DisplayHandle};
+use smithay::utils::{Logical, Physical, Transform, SERIAL_COUNTER};
+use smithay::utils::{Point as SPoint, Size as SSize};
+use smithay::wayland::compositor::{CompositorClientState, CompositorState};
+use smithay::wayland::output::OutputManagerState;
+use smithay::wayland::selection::data_device::DataDeviceState;
+use smithay::wayland::shell::xdg::decoration::XdgDecorationState;
+use smithay::wayland::shell::xdg::{ToplevelSurface, XdgShellState};
+use smithay::wayland::shm::ShmState;
+use smithay::wayland::socket::ListeningSocketSource;
+use smithay::wayland::xwayland_shell::XWaylandShellState;
+use smithay::xwayland::{X11Surface, X11Wm, XWayland, XWaylandEvent};
+
+use wm_core::{
+    Backend, BackendEvent, FocusPolicy, KeyCombo, MouseButton, WindowManager, WindowType,
+};
+use wm_theme::{RasterThemeEngine, Theme};
+use wm_theme_api::{Point, Rect, Size};
+
+use chonk_shell::shell::{Shell, ShellOutcome};
+use chonk_shell::theme_select;
+
+/// A managed client window (an xdg toplevel or an XWayland surface) in
+/// the id space `wm-core` reasons about. Plain integers rather than
+/// protocol handles so the ids stay `Copy + Eq + Hash` and the ledger
+/// records own the actual handles exactly once.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct WlWindowId(pub u64);
+
+/// A decoration frame. On X11 this is a real second window the client
+/// gets reparented into; here it is purely a ledger entry — a geometry
+/// plus a rendered decoration buffer the renderer composes behind the
+/// client's content. Distinct from [`WlWindowId`] for the same reason
+/// the X11 backend keeps `XWindow`/`XFrame` distinct: the type system
+/// rules out handing the wrong handle to the wrong `Backend` verb.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct WlFrameId(pub u64);
+
+/// A shell-owned surface (dock, Clip, launcher strip, icon tiles, menu
+/// popups) — the id space `chonk-shell` draws the whole desktop
+/// through. On X11 these are override-redirect windows; here they are
+/// internal scene elements the renderer composes directly, which is
+/// exactly the substitution `wm_core::Backend`'s docs promise the
+/// shell cannot observe.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct WlShellId(pub u64);
+
+/// The stand-in for "the root window" in shell-click routing. The X11
+/// binary tells root presses apart from shell-surface clicks by
+/// comparing against the real root window's XID; a Wayland session has
+/// no root window, so the input code queues background presses (a
+/// press that hit no shell surface, no frame, and no client) under
+/// this sentinel id instead. Id 0 is never allocated —
+/// [`WaylandBackend`]'s id counter starts at 1 — so the comparison in
+/// [`Compositor::dispatch_pending`] can never collide with a real
+/// surface.
+pub(crate) const ROOT_SHELL: WlShellId = WlShellId(0);
+
+/// One entry in the bottom-to-top stacking order. Frames and shell
+/// surfaces interleave in a single sequence because that is what the
+/// X11 server maintains for the X11 backend implicitly: the WM raises
+/// and restacks frames *among* the shell's override-redirect windows.
+/// The renderer partitions the walk (`above: false` shells, then
+/// frames, then `above: true` shells) so docks and menus stay over
+/// managed clients exactly as their X11 counterparts do.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum StackEntry {
+    Frame(WlFrameId),
+    Shell(WlShellId),
+}
+
+/// The protocol handle behind a managed window. Both kinds flow
+/// through the same [`WlWindowId`] space and the same `BackendEvent`
+/// translations, which is what lets urxvt (X11, via XWayland) and a
+/// native Wayland terminal receive identical management.
+pub(crate) enum ManagedSurface {
+    Xdg(ToplevelSurface),
+    X11(X11Surface),
+}
+
+impl ManagedSurface {
+    /// The `wl_surface` carrying this window's pixels — what the
+    /// renderer draws and the seat focuses. `None` for an XWayland
+    /// window whose surface association hasn't arrived yet (X11
+    /// windows exist before XWayland binds a `wl_surface` to them; the
+    /// renderer and focus plumbing simply skip them until it lands).
+    pub(crate) fn wl_surface(&self) -> Option<WlSurface> {
+        match self {
+            ManagedSurface::Xdg(toplevel) => Some(toplevel.wl_surface().clone()),
+            ManagedSurface::X11(surface) => surface.wl_surface(),
+        }
+    }
+
+    /// Whether the client end of this handle still exists. Dead
+    /// handles are skipped rather than drawn — a client can vanish
+    /// between a protocol callback and the next render.
+    pub(crate) fn alive(&self) -> bool {
+        match self {
+            ManagedSurface::Xdg(toplevel) => toplevel.alive(),
+            ManagedSurface::X11(surface) => surface.alive(),
+        }
+    }
+}
+
+/// Ledger entry for one managed client window. The protocol handlers
+/// (`xdg.rs`, `xwayland.rs`) create and update these; `backend_impl.rs`
+/// reads them to answer the `Backend` property queries the X11 backend
+/// answers with ICCCM round-trips — on Wayland the data is pushed to
+/// us (xdg toplevel state, XWayland property events), so the record
+/// caches it and the queries become lookups.
+pub(crate) struct WindowRecord {
+    pub surface: ManagedSurface,
+    /// The client content's root-relative rectangle — the analogue of
+    /// the client window's geometry inside its X11 frame. Written by
+    /// `Backend::configure_client`/`position_client`; read by the
+    /// renderer (where to draw the surface tree) and the input code
+    /// (chrome vs. content hit-testing).
+    pub content: Rect,
+    pub mapped: bool,
+    /// Cached title (xdg `set_title` / XWayland property events keep
+    /// it current and queue `BackendEvent::TitleChanged`).
+    pub title: Option<String>,
+    /// xdg `app_id` / X11 `WM_CLASS` — what `Backend::window_class`
+    /// reports so per-app shell behavior (dock matching, opacity
+    /// rules) works identically on both stacks.
+    pub app_id: Option<String>,
+    /// Decoration policy class, decided at map time exactly as the X11
+    /// backend decides it from `_NET_WM_WINDOW_TYPE`: override-redirect
+    /// XWayland windows (menus, tooltips) come through as `Unmanaged`
+    /// and are rendered as-is with no frame.
+    pub window_type: WindowType,
+}
+
+impl WindowRecord {
+    /// A fresh record for a surface that just appeared: unmapped, no
+    /// cached properties yet — the handlers fill fields in as the
+    /// client provides them.
+    pub(crate) fn new(surface: ManagedSurface, content: Rect) -> Self {
+        Self {
+            surface,
+            content,
+            mapped: false,
+            title: None,
+            app_id: None,
+            window_type: WindowType::Normal,
+        }
+    }
+}
+
+/// Ledger entry for one decoration frame. `buffer` holds the imported
+/// decoration pixels (`None` until the first `paint_decoration`).
+/// No layout is cached here: chrome hit-testing happens in `wm-core`
+/// against the client's own theme-authoritative layout, so the
+/// backend only needs where the frame is, never what is drawn on it.
+pub(crate) struct FrameRecord {
+    pub window: WlWindowId,
+    pub geometry: Rect,
+    pub buffer: Option<MemoryRenderBuffer>,
+    pub mapped: bool,
+}
+
+/// Ledger entry for one shell surface. `buffer: None` means "never
+/// painted yet" — the renderer fills the geometry with `background`
+/// then, mirroring the X11 backend's window-background-color behavior
+/// between creation and first blit.
+pub(crate) struct ShellRecord {
+    pub geometry: Rect,
+    pub buffer: Option<MemoryRenderBuffer>,
+    pub background: (u8, u8, u8),
+    pub above: bool,
+    pub mapped: bool,
+}
+
+/// The desktop background, as last painted by the shell through
+/// `Backend::paint_root_color`/`paint_root_image`. On X11 this becomes
+/// a root-window pixmap; here the renderer simply draws it as the
+/// scene's bottom layer — same trait verbs, no pixmap machinery.
+pub(crate) enum RootBackground {
+    Color((u8, u8, u8)),
+    Image(MemoryRenderBuffer),
+}
+
+/// The `Backend` the `WindowManager` owns: pure bookkeeping the
+/// protocol handlers write into and the renderer reads out of. See the
+/// module docs for why no display connection lives here.
+pub struct WaylandBackend {
+    /// Shared allocator for all three id spaces — window, frame, and
+    /// shell ids never collide, which makes stray-id bugs loud in logs
+    /// instead of silently aliasing. Starts at 1 so [`ROOT_SHELL`]
+    /// (id 0) stays forever unallocated.
+    next_id: u64,
+    pub(crate) windows: HashMap<WlWindowId, WindowRecord>,
+    pub(crate) frames: HashMap<WlFrameId, FrameRecord>,
+    pub(crate) shells: HashMap<WlShellId, ShellRecord>,
+    /// Bottom-to-top: frames and shell surfaces interleaved — see
+    /// [`StackEntry`].
+    pub(crate) stacking: Vec<StackEntry>,
+    /// Events queued by protocol handlers and backend verbs, drained
+    /// by `Backend::poll_event` exactly as the X11 backend's socket is.
+    pub(crate) pending: VecDeque<BackendEvent<WlWindowId, WlFrameId>>,
+    /// Clicks on shell surfaces (surface, surface-local position,
+    /// button, pressed) — plus background presses under [`ROOT_SHELL`].
+    /// Drained by `Backend::take_shell_click` for the loop's shell
+    /// routing.
+    pub(crate) shell_clicks: VecDeque<(WlShellId, Point, MouseButton, bool)>,
+    /// Pointer motion over shell surfaces, drained by
+    /// `Backend::take_shell_motion` (the shell itself drains this
+    /// inside `Shell::on_motion`, same as on X11).
+    pub(crate) shell_motions: VecDeque<(WlShellId, Point)>,
+    /// Output size change waiting for the loop's
+    /// `take_screen_resize` drain (the winit window was resized).
+    pub(crate) pending_resize: Option<Size>,
+    /// Key combos the WM asked to intercept (`Backend::grab_key`).
+    /// There is no server to register grabs with — the compositor sees
+    /// every key anyway — so "grabbing" is just this filter list the
+    /// input code consults before deciding whether a press becomes a
+    /// `BackendEvent::KeyPress` or is forwarded to the focused client.
+    pub(crate) grabbed_combos: Vec<KeyCombo>,
+    /// The modal exclusive grab (`Backend::grab_keyboard`, the Alt-Tab
+    /// switcher): while set, *every* press becomes a `KeyPress` and
+    /// releases additionally queue `KeyRelease` — see wm-x11's
+    /// KeyRelease commentary, mirrored by `input.rs`.
+    pub(crate) keyboard_grabbed: bool,
+    pub(crate) root_background: RootBackground,
+    pub(crate) output_size: Size,
+    /// Set by every mutating verb (paint, map, move, restack, ...);
+    /// the renderer clears it after drawing. This is the whole
+    /// redraw-scheduling protocol: no damage, no render.
+    pub(crate) damage: bool,
+    /// Handle to the wayland display, for verbs that must touch
+    /// protocol state directly (client credentials for `window_pid`,
+    /// disconnecting a client for `kill_client`).
+    pub(crate) display_handle: DisplayHandle,
+    /// Focus intent recorded by `Backend::set_input_focus`. The
+    /// keyboard lives on the seat, the seat lives on [`Compositor`],
+    /// and applying focus needs `&mut Compositor` — which a backend
+    /// verb, running inside the `WindowManager`'s `&mut self`, can
+    /// never have. So the verb records the intent here and
+    /// [`Compositor::dispatch_pending`] applies it after the drain,
+    /// the same each-loop cadence X11 focus changes effectively land
+    /// on.
+    pub(crate) pending_focus: Option<WlWindowId>,
+}
+
+impl WaylandBackend {
+    pub(crate) fn new(display_handle: DisplayHandle, output_size: Size) -> Self {
+        Self {
+            next_id: 1,
+            windows: HashMap::new(),
+            frames: HashMap::new(),
+            shells: HashMap::new(),
+            stacking: Vec::new(),
+            pending: VecDeque::new(),
+            shell_clicks: VecDeque::new(),
+            shell_motions: VecDeque::new(),
+            pending_resize: None,
+            grabbed_combos: Vec::new(),
+            keyboard_grabbed: false,
+            root_background: RootBackground::Color((0, 0, 0)),
+            output_size,
+            damage: true,
+            display_handle,
+            pending_focus: None,
+        }
+    }
+
+    /// Allocates the next id in the shared counter — used by the
+    /// protocol handlers for window ids and by `backend_impl` for
+    /// frame/shell ids.
+    pub(crate) fn alloc_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Queues an event for the next `poll_event` drain.
+    pub(crate) fn queue(&mut self, event: BackendEvent<WlWindowId, WlFrameId>) {
+        self.pending.push_back(event);
+    }
+
+    /// Marks the scene dirty. Every mutating verb and every handler
+    /// that changes anything visible must call this (or set the field)
+    /// or its change waits for the next unrelated damage to appear.
+    pub(crate) fn mark_damaged(&mut self) {
+        self.damage = true;
+    }
+
+    /// Resolves a `wl_surface` back to the managed window it belongs
+    /// to, comparing against each record's root surface. Linear over
+    /// the window count — fine at WM scale, and it avoids a second
+    /// index that could drift from the authoritative `windows` map.
+    pub(crate) fn window_for_surface(&self, surface: &WlSurface) -> Option<WlWindowId> {
+        self.windows
+            .iter()
+            .find(|(_, record)| record.surface.wl_surface().as_ref() == Some(surface))
+            .map(|(id, _)| *id)
+    }
+}
+
+/// Per-client data attached when a wayland client connects. Smithay's
+/// compositor protocol machinery requires each client to carry its
+/// `CompositorClientState`; nothing else is needed per-client yet.
+#[derive(Default)]
+pub struct ClientState {
+    pub compositor_state: CompositorClientState,
+}
+
+impl ClientData for ClientState {
+    fn initialized(&self, _client_id: ClientId) {}
+    fn disconnected(&self, _client_id: ClientId, _reason: DisconnectReason) {}
+}
+
+/// How often the dispatch loop wakes with zero protocol activity, to
+/// run `Shell::tick` and the restart-marker check — same value and
+/// same rationale as the X11 binary's `HOUSEKEEPING_INTERVAL`: ~60Hz
+/// is far more than the clock or menu timers need, but cheap, and
+/// real events (client commits, input) wake calloop immediately
+/// regardless of this bound.
+const HOUSEKEEPING_INTERVAL: Duration = Duration::from_millis(16);
+
+/// The one calloop data type — see the module docs for why everything
+/// must live on a single struct. Fields are `pub` (not `pub(crate)`)
+/// only where the re-exported API surface needs them; the protocol
+/// handler modules are in-crate and reach everything either way.
+pub struct Compositor {
+    /// The policy brain, owning the [`WaylandBackend`] ledger. Protocol
+    /// handlers reach the ledger through `self.wm.backend_mut()`.
+    pub wm: WindowManager<WaylandBackend>,
+    /// The whole desktop — dock, Clip, menus, launcher, wallpaper —
+    /// identical by construction to the X11 session's.
+    pub shell: Shell<WaylandBackend>,
+
+    pub display_handle: DisplayHandle,
+    pub loop_handle: LoopHandle<'static, Compositor>,
+
+    // Per-protocol smithay state. Constructed once in `run`; the
+    // handler impls in `xdg.rs`/`input.rs`/`xwayland.rs` return these
+    // from their `*_state()` accessors.
+    pub compositor_state: CompositorState,
+    pub xdg_shell_state: XdgShellState,
+    pub xdg_decoration_state: XdgDecorationState,
+    pub shm_state: ShmState,
+    pub seat_state: SeatState<Compositor>,
+    pub output_manager_state: OutputManagerState,
+    pub data_device_state: DataDeviceState,
+    pub xwayland_shell_state: XWaylandShellState,
+    /// Tracks xdg popups (client menus, tooltips) so the renderer can
+    /// draw them above their parent window — `wm-core` never learns
+    /// about them, exactly as it never learns about X11
+    /// override-redirect windows.
+    pub popups: PopupManager,
+
+    pub seat: Seat<Compositor>,
+    /// The single output. Multi-monitor waits for the `session`
+    /// backend; `Backend::monitors` reports this one spanning
+    /// everything, same as wm-x11 before RandR.
+    pub output: Output,
+
+    /// The X11 window-manager connection into XWayland, once
+    /// `XWaylandEvent::Ready` has arrived (`None` before that, or if
+    /// XWayland failed to start — native Wayland clients work either
+    /// way).
+    pub xwm: Option<X11Wm>,
+    /// XWayland's display number, mirrored into `DISPLAY` so children
+    /// the shell spawns find it.
+    pub xdisplay: Option<u32>,
+
+    /// The nested development backend: the host window this session
+    /// renders into, with its EGL context and GLES renderer.
+    pub winit_backend: WinitGraphicsBackend<GlesRenderer>,
+    pub damage_tracker: OutputDamageTracker,
+
+    /// Latest pointer position in compositor space, maintained by
+    /// `input.rs` — the renderer draws the cursor here, and hit-tests
+    /// run against it.
+    pub pointer_location: SPoint<f64, Logical>,
+    /// What the cursor should look like, per the focused client's
+    /// `wl_pointer.set_cursor` (maintained by `input.rs`'s
+    /// `SeatHandler::cursor_image`). The renderer falls back to
+    /// [`Compositor::default_cursor`] for `Named` shapes.
+    pub cursor_status: CursorImageStatus,
+    /// Built-in arrow drawn whenever no client cursor surface applies
+    /// — a compositor draws its own cursor, there is no server to
+    /// inherit one from.
+    pub(crate) default_cursor: MemoryRenderBuffer,
+
+    /// The active theme — kept for the pieces the loop owner still
+    /// needs after `Shell::new` (mirrors the X11 binary keeping its
+    /// copy for engine construction and per-app rules).
+    pub theme: Theme,
+    /// Monotonic session clock for frame-callback timestamps.
+    pub start_time: Instant,
+    /// Cleared to exit the dispatch loop (root-menu Exit, host window
+    /// closed, display teardown).
+    pub running: bool,
+    /// Set (with `running` cleared) to re-exec the on-disk binary
+    /// after teardown — the theme-menu / `scripts/restart.sh` hot
+    /// restart. Unlike X11 there is no SaveSet: Wayland clients die
+    /// with the compositor's socket, so a restart costs the session's
+    /// clients. That matches what a compositor *can* do today; a
+    /// future session handoff could improve it.
+    pub restart: bool,
+}
+
+impl Compositor {
+    /// Drains everything the protocol handlers queued since the last
+    /// pass, in exactly the X11 binary loop's order — keymap
+    /// interception before dispatch, motion coalescing, notification
+    /// and resize drains, shell-click routing, `Shell::tick` — then
+    /// applies deferred focus and renders if anything was damaged.
+    /// Called once per calloop wakeup from [`run`]'s loop; keeping the
+    /// order identical to `crates/chonkstep/src/main.rs` is what makes
+    /// "the desktop behaves identically" a structural property rather
+    /// than a porting promise, so change that file first if this order
+    /// ever needs to move.
+    pub(crate) fn dispatch_pending(&mut self) {
+        // Consecutive `PointerMotion` events coalesce to the most
+        // recent one — same rationale as the X11 loop: during a fast
+        // drag every intermediate position is stale by the time it
+        // would draw, and the held-back motion still commits before
+        // any later non-motion event in the same burst.
+        let mut pending_motion = None;
+        while let Some(event) = self.wm.backend_mut().poll_event() {
+            if matches!(event, BackendEvent::ShutdownRequested) {
+                // The display is going away for good; nothing below
+                // can succeed.
+                self.running = false;
+                return;
+            }
+            if matches!(event, BackendEvent::PointerMotion { .. }) {
+                pending_motion = Some(event);
+                continue;
+            }
+            // Configured keybindings resolve BEFORE `wm.dispatch`, and
+            // misses MUST keep flowing through unchanged — during a
+            // modal Alt+Tab session every key arrives here as a
+            // `KeyPress`, and swallowing unbound ones would wedge the
+            // switcher open (see the X11 loop's longer commentary;
+            // `KeyRelease` is never intercepted at all).
+            if let BackendEvent::KeyPress(combo) = &event {
+                if let Some(action) = self.shell.keymap_action(combo) {
+                    if let Some(motion) = pending_motion.take() {
+                        self.dispatch_motion(motion);
+                    }
+                    let outcome = self.shell.run_action(&mut self.wm, &action);
+                    self.note_outcome(outcome);
+                    continue;
+                }
+            }
+            if let Some(motion) = pending_motion.take() {
+                self.dispatch_motion(motion);
+            }
+            self.wm.dispatch(event);
+        }
+        if let Some(motion) = pending_motion.take() {
+            self.dispatch_motion(motion);
+        }
+
+        while let Some(notification) = self.wm.take_notification() {
+            self.shell.on_notification(&mut self.wm, notification);
+        }
+
+        if let Some(new_size) = self.wm.backend_mut().take_screen_resize() {
+            tracing::info!(width = new_size.w, height = new_size.h, "output resized");
+            self.shell.on_screen_resize(&mut self.wm, new_size);
+            self.wm.set_workarea(self.shell.workarea(new_size));
+        }
+
+        // Shell-surface clicks drain to the shell, with background
+        // presses split off to `on_root_press` under the [`ROOT_SHELL`]
+        // sentinel — the same press/release routing asymmetry as the
+        // X11 loop (root reacts on press; releases still flow through
+        // `on_shell_click` so an in-progress launcher-strip drag sees
+        // them).
+        while let Some((surface, local, button, pressed)) = self.wm.backend_mut().take_shell_click() {
+            let outcome = if surface == ROOT_SHELL && pressed {
+                self.shell.on_root_press(&mut self.wm, local, button)
+            } else {
+                self.shell.on_shell_click(&mut self.wm, surface, local, button, pressed)
+            };
+            self.note_outcome(outcome);
+        }
+        if !self.running {
+            // Exit/restart was requested somewhere above — mirror the
+            // X11 loop's break-before-tick.
+            return;
+        }
+
+        // No separate shell-motion drain, same as X11: the shell
+        // drains `take_shell_motion` itself inside `on_motion`, which
+        // every coalesced `PointerMotion` above passes through.
+
+        self.shell.tick(&mut self.wm);
+
+        // Wayland-side housekeeping with no X11 counterpart: dead xdg
+        // popups age out, and the focus intent a backend verb recorded
+        // lands on the seat (see `WaylandBackend::pending_focus` for
+        // why it cannot land inline).
+        self.popups.cleanup();
+        self.apply_pending_focus();
+
+        if self.wm.backend().damage {
+            crate::renderer::render_frame(self);
+        }
+
+        // Protocol replies queued by everything above (configures,
+        // frame callbacks, focus enter/leave) only reach clients on a
+        // flush.
+        let _ = self.display_handle.flush_clients();
+    }
+
+    /// Feeds one already-coalesced `PointerMotion` to the shell's drag
+    /// trackers and then to `wm-core` — identical to the X11 binary's
+    /// `dispatch_motion`, and split out for the same two call sites
+    /// (mid-burst before a non-motion event, and once after the burst).
+    fn dispatch_motion(&mut self, event: BackendEvent<WlWindowId, WlFrameId>) {
+        if let BackendEvent::PointerMotion { root, .. } = &event {
+            self.shell.on_motion(&mut self.wm, *root);
+        }
+        self.wm.dispatch(event);
+    }
+
+    /// Applies a [`ShellOutcome`] to the session. `Exit` and `Restart`
+    /// both end the dispatch loop; `Restart` additionally asks [`run`]
+    /// to re-exec the on-disk binary after teardown, which is the
+    /// config/theme hot-reload gesture on both stacks.
+    fn note_outcome(&mut self, outcome: ShellOutcome) {
+        match outcome {
+            ShellOutcome::Continue => {}
+            ShellOutcome::Exit => self.running = false,
+            ShellOutcome::Restart => {
+                self.restart = true;
+                self.running = false;
+            }
+        }
+    }
+
+    /// The host winit window changed size: retune the wayland output's
+    /// mode and queue the resize for the loop's `take_screen_resize`
+    /// drain, which is exactly where an X11 RandR change lands.
+    pub(crate) fn on_output_resized(&mut self, size: SSize<i32, Physical>) {
+        let mode = Mode { size, refresh: 60_000 };
+        self.output.change_current_state(Some(mode), None, None, None);
+        self.output.set_preferred(mode);
+        let logical = Size::new(size.w.max(0) as u32, size.h.max(0) as u32);
+        let backend = self.wm.backend_mut();
+        backend.output_size = logical;
+        backend.pending_resize = Some(logical);
+        backend.damage = true;
+    }
+
+    /// Lands a deferred `set_input_focus` on the seat's keyboard. A
+    /// window with no `wl_surface` yet (an XWayland window before its
+    /// association) or one that died in the meantime clears focus
+    /// rather than leaving it on the previous window — matching what
+    /// the X11 server does when a focused window disappears.
+    fn apply_pending_focus(&mut self) {
+        let Some(id) = self.wm.backend_mut().pending_focus.take() else {
+            return;
+        };
+        // XWayland windows additionally track an "activated" flag their
+        // clients read for focus styling; keep it in lockstep with the
+        // seat focus for every X11 window, not just the new one, so a
+        // window losing focus repaints inactive.
+        for (window_id, record) in self.wm.backend().windows.iter() {
+            if let ManagedSurface::X11(surface) = &record.surface {
+                if surface.alive() {
+                    let _ = surface.set_activated(*window_id == id);
+                }
+            }
+        }
+        let surface = self
+            .wm
+            .backend()
+            .windows
+            .get(&id)
+            .filter(|record| record.surface.alive())
+            .and_then(|record| record.surface.wl_surface());
+        if let Some(keyboard) = self.seat.get_keyboard() {
+            keyboard.set_focus(self, surface, SERIAL_COUNTER.next_serial());
+        }
+    }
+}
+
+/// Builds and runs the entire compositor session; returns when the
+/// session ends (root-menu Exit, host window closed) or re-execs in
+/// place on a requested restart. The Wayland analogue of everything
+/// `crates/chonkstep/src/main.rs` does after config load — read that
+/// file for the loop-order rationale this mirrors.
+pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> {
+    let mut event_loop: EventLoop<Compositor> = EventLoop::try_new()?;
+    let loop_handle = event_loop.handle();
+
+    let display: Display<Compositor> = Display::new()?;
+    let display_handle = display.handle();
+
+    // The nested development backend: a host window with an EGL
+    // context and GLES renderer. Real-hardware DRM/KMS waits on the
+    // `session` feature.
+    let (winit_backend, winit_source) =
+        winit::init::<GlesRenderer>().map_err(|error| format!("winit backend init failed: {error}"))?;
+    let window_size = winit_backend.window_size();
+    let output_size = Size::new(window_size.w.max(0) as u32, window_size.h.max(0) as u32);
+
+    // Wayland globals. Each `new::<Compositor>` registers the global
+    // against the delegate impls in `xdg.rs`/`input.rs`/`xwayland.rs`.
+    let compositor_state = CompositorState::new::<Compositor>(&display_handle);
+    let xdg_shell_state = XdgShellState::new::<Compositor>(&display_handle);
+    // xdg-decoration is what lets us tell clients "the server draws
+    // your chrome" — without it every GTK/Qt app draws its own
+    // titlebar and the WindowMaker frames would double up.
+    let xdg_decoration_state = XdgDecorationState::new::<Compositor>(&display_handle);
+    let shm_state = ShmState::new::<Compositor>(&display_handle, vec![]);
+    let output_manager_state = OutputManagerState::new_with_xdg_output::<Compositor>(&display_handle);
+    let data_device_state = DataDeviceState::new::<Compositor>(&display_handle);
+    let xwayland_shell_state = XWaylandShellState::new::<Compositor>(&display_handle);
+
+    let mut seat_state: SeatState<Compositor> = SeatState::new();
+    let mut seat: Seat<Compositor> = seat_state.new_wl_seat(&display_handle, "chonkstep");
+    // Keyboard and pointer are assumed present — this is a desktop
+    // compositor; hot-plug tracking can come with the session backend.
+    seat.add_keyboard(XkbConfig::default(), 200, 25)
+        .map_err(|error| format!("failed to initialize the seat keyboard: {error}"))?;
+    seat.add_pointer();
+
+    // The single output, mirroring the winit window. Flipped180 is
+    // deliberately copied from Smithay's own winit references (anvil,
+    // smallvil): the winit EGL surface's coordinate origin differs
+    // from the output's, and this transform is how upstream squares
+    // the two.
+    let mode = Mode { size: window_size, refresh: 60_000 };
+    let output = Output::new(
+        "chonkstep".to_string(),
+        PhysicalProperties {
+            size: (0, 0).into(),
+            subpixel: Subpixel::Unknown,
+            make: "chonkstep".into(),
+            model: "winit".into(),
+        },
+    );
+    let _global = output.create_global::<Compositor>(&display_handle);
+    output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
+    output.set_preferred(mode);
+    let damage_tracker = OutputDamageTracker::from_output(&output);
+
+    // The listening socket clients connect to, plus the display's own
+    // fd so wayland-server processes client requests — both plain
+    // calloop sources.
+    let listening_socket = ListeningSocketSource::new_auto()?;
+    let socket_name = listening_socket.socket_name().to_os_string();
+    loop_handle
+        .insert_source(listening_socket, |client_stream, _, comp| {
+            if let Err(error) = comp
+                .display_handle
+                .insert_client(client_stream, Arc::new(ClientState::default()))
+            {
+                tracing::warn!(?error, "failed to admit a wayland client");
+            }
+        })
+        .map_err(|error| format!("failed to register the wayland socket source: {error}"))?;
+    loop_handle
+        .insert_source(
+            Generic::new(display, Interest::READ, TriggerMode::Level),
+            |_, display, comp| {
+                // SAFETY: the display is owned by this source and never
+                // moved out of it; `get_mut` is the documented access
+                // pattern for dispatching from inside calloop.
+                if let Err(error) = unsafe { display.get_mut().dispatch_clients(comp) } {
+                    tracing::error!(?error, "wayland display dispatch failed, shutting down");
+                    comp.running = false;
+                }
+                Ok(PostAction::Continue)
+            },
+        )
+        .map_err(|error| format!("failed to register the wayland display source: {error}"))?;
+
+    // Children the shell spawns find the session through the
+    // environment, so it must be set before `Shell::new` (which may
+    // autostart things) and before XWayland comes up. `DISPLAY`
+    // follows once XWayland reports ready.
+    std::env::set_var("WAYLAND_DISPLAY", &socket_name);
+    tracing::info!(socket = ?socket_name, "wayland socket listening");
+
+    // Scale and theme. Scale comes from the config alone (the
+    // CHONKSTEP_SCALE env override is an X11-session concern — its
+    // consumers are the nested-Xephyr dev scripts); theme precedence
+    // is identical to the X11 binary: persisted theme-menu choice,
+    // else the config's theme, else the flagship.
+    let scale = config.scale.filter(|s| s.is_finite() && *s > 0.0).unwrap_or(1.0);
+    tracing::info!(scale, "UI scale (config `scale`)");
+    let theme = resolve_theme(config.theme.as_deref()).scaled(scale);
+    tracing::info!(theme = %theme.id, "theme loaded");
+    let engine = RasterThemeEngine::new(theme.clone());
+
+    // The desktop shell is built against the mutable backend before
+    // `WindowManager::new` takes ownership — the exact construction
+    // order the X11 binary uses, for the exact same borrow reason.
+    let mut backend = WaylandBackend::new(display_handle.clone(), output_size);
+    let shell = Shell::new(&mut backend, &config, theme.clone(), scale);
+    // No `scan_existing_windows` here: a compositor's clients cannot
+    // predate the compositor. (Hot-restart adoption is impossible for
+    // the same reason — see `Compositor::restart`.)
+    let mut wm = WindowManager::new(backend, Box::new(engine));
+    wm.set_workarea(shell.workarea(output_size));
+    wm.bind_default_keys();
+    // Same contract as X11: every configured combo is registered on
+    // top of the defaults. Here a "grab" is only a filter entry (the
+    // compositor sees all keys regardless), but registering through
+    // the same `grab_key` path keeps `wm-core`'s bookkeeping — and any
+    // future per-combo policy — identical on both stacks.
+    for (combo, _) in &config.keybindings {
+        wm.grab_key(*combo);
+    }
+    if config.focus_follows_mouse {
+        tracing::info!("focus-follows-mouse enabled (config `focus_follows_mouse`)");
+        wm.set_focus_policy(FocusPolicy::FocusFollowsMouse);
+    }
+    wm.set_placement_policy(config.placement);
+    wm.set_snap_threshold(config.edge_resistance);
+
+    // Host-window events: input feeds the translation layer in
+    // `input.rs` (the seam where raw winit input becomes seat events
+    // plus `BackendEvent`s per the wm-x11 contract); everything else
+    // is resize/redraw/close plumbing handled right here.
+    loop_handle
+        .insert_source(winit_source, |event, _, comp| match event {
+            WinitEvent::Resized { size, .. } => comp.on_output_resized(size),
+            WinitEvent::Input(event) => crate::input::process_input_event(comp, event),
+            // The host asked us to repaint (the window was exposed or
+            // resized): full-frame damage, same as any scene change.
+            WinitEvent::Redraw => comp.wm.backend_mut().mark_damaged(),
+            WinitEvent::CloseRequested => comp.running = false,
+            WinitEvent::Focus(_) => {}
+        })
+        .map_err(|error| format!("failed to register the winit event source: {error}"))?;
+
+    // XWayland: spawned here, attached (X11Wm::start_wm) when it
+    // reports ready. Failure to start is a degraded session — X11
+    // apps unavailable — not a dead one, so it logs instead of
+    // erroring out.
+    match XWayland::spawn(
+        &display_handle,
+        None,
+        std::iter::empty::<(String, String)>(),
+        true,
+        Stdio::null(),
+        Stdio::null(),
+        |_| (),
+    ) {
+        Ok((xwayland, xwayland_client)) => {
+            loop_handle
+                .insert_source(xwayland, move |event, _, comp| match event {
+                    XWaylandEvent::Ready { x11_socket, display_number } => {
+                        match X11Wm::start_wm(comp.loop_handle.clone(), x11_socket, xwayland_client.clone()) {
+                            Ok(xwm) => {
+                                comp.xwm = Some(xwm);
+                                comp.xdisplay = Some(display_number);
+                                // Children the shell spawns (terminals,
+                                // X11 apps) inherit this, same as the
+                                // X11 session's DISPLAY inheritance.
+                                std::env::set_var("DISPLAY", format!(":{display_number}"));
+                                tracing::info!(display = display_number, "XWayland ready");
+                            }
+                            Err(error) => {
+                                tracing::error!(?error, "failed to attach the X11 window manager to XWayland");
+                            }
+                        }
+                    }
+                    XWaylandEvent::Error => {
+                        tracing::warn!("XWayland exited or failed to start; X11 apps unavailable");
+                    }
+                })
+                .map_err(|error| format!("failed to register the XWayland event source: {error}"))?;
+        }
+        Err(error) => {
+            tracing::warn!(?error, "could not spawn XWayland; X11 apps unavailable");
+        }
+    }
+
+    let mut comp = Compositor {
+        wm,
+        shell,
+        display_handle,
+        loop_handle,
+        compositor_state,
+        xdg_shell_state,
+        xdg_decoration_state,
+        shm_state,
+        seat_state,
+        output_manager_state,
+        data_device_state,
+        xwayland_shell_state,
+        popups: PopupManager::default(),
+        seat,
+        output,
+        xwm: None,
+        xdisplay: None,
+        winit_backend,
+        damage_tracker,
+        pointer_location: (0.0, 0.0).into(),
+        cursor_status: CursorImageStatus::default_named(),
+        default_cursor: build_default_cursor(),
+        theme,
+        start_time: Instant::now(),
+        running: true,
+        restart: false,
+    };
+
+    tracing::info!("entering compositor loop");
+    while comp.running {
+        // Hot-restart marker from `scripts/restart.sh`, polled once
+        // per wakeup exactly as the X11 loop polls it.
+        if restart_requested() {
+            tracing::info!("restart requested — re-executing in place");
+            comp.restart = true;
+            break;
+        }
+        // Blocks on every source at once (wayland clients, winit
+        // input, XWayland) with the housekeeping bound — the calloop
+        // equivalent of the X11 loop's poll-on-the-socket-fd.
+        event_loop.dispatch(Some(HOUSEKEEPING_INTERVAL), &mut comp)?;
+        comp.dispatch_pending();
+    }
+
+    if comp.restart {
+        restart_in_place();
+    }
+    tracing::info!("compositor session over");
+    Ok(())
+}
+
+/// Resolves the theme this session dresses in, mirroring the X11
+/// binary's precedence exactly: the persisted theme-menu choice
+/// (`theme_select`'s state file) wins over the config file's `theme`,
+/// which wins over the flagship default. Duplicated from
+/// `crates/chonkstep/src/main.rs` rather than shared because which
+/// theme wins at startup is *session policy* and session policy lives
+/// with each session owner — see that file's `resolve_theme` docs.
+fn resolve_theme(config_theme: Option<&str>) -> Theme {
+    if !persisted_theme_choice_exists() {
+        if let Some(requested) = config_theme {
+            if let Some(theme) = wm_theme::default_theme::theme_by_id(requested) {
+                return theme;
+            }
+            tracing::warn!(theme = requested, "config names an unknown theme; using the default instead");
+        }
+    }
+    theme_select::load()
+}
+
+/// `true` exactly when `theme_select::load()` would return a persisted
+/// menu choice rather than its flagship fallback — same path and same
+/// stale-id rule as the X11 binary's helper of the same name, and it
+/// must stay in lockstep with `theme_select`'s `state_path`.
+fn persisted_theme_choice_exists() -> bool {
+    let path = if let Some(root) = std::env::var_os("XDG_STATE_HOME") {
+        std::path::PathBuf::from(root).join("chonkstep/theme")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        std::path::PathBuf::from(home).join(".local/state/chonkstep/theme")
+    } else {
+        return false;
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .is_some_and(|id| wm_theme::default_theme::theme_by_id(id.trim()).is_some())
+}
+
+/// `true` at most once per `touch` of `scripts/restart.sh`'s marker
+/// file — `remove_file` both checks and consumes in one step, same as
+/// the X11 binary.
+fn restart_requested() -> bool {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    let path = std::path::PathBuf::from(home).join(".local/state/chonkstep/restart");
+    std::fs::remove_file(path).is_ok()
+}
+
+/// Re-execs the on-disk binary in place — resolved from `argv[0]`, not
+/// `current_exe()`, for the same pick-up-the-fresh-build reason the
+/// X11 binary documents at length. The one behavioral difference is
+/// unavoidable: Wayland clients die with our socket (no SaveSet), so
+/// the fresh process starts with an empty session.
+fn restart_in_place() -> ! {
+    use std::os::unix::process::CommandExt;
+    let bin = std::env::args_os().next().unwrap_or_else(|| "chonkstep-wayland".into());
+    let err = std::process::Command::new(&bin).exec();
+    tracing::error!(?err, bin = ?bin, "re-exec failed; exiting instead of restarting");
+    std::process::exit(1);
+}
+
+/// The built-in pointer: the classic black arrow with a white halo,
+/// matching the scaled cursor the X11 backend draws for the root
+/// window. Hand-authored rather than loaded from an Xcursor theme —
+/// the compositor must have a cursor before any theme machinery could
+/// run, and clients that care set their own via `wl_pointer.set_cursor`
+/// anyway.
+fn build_default_cursor() -> MemoryRenderBuffer {
+    // '#' = black shape, 'o' = white halo, anything else transparent.
+    // Rows may be ragged; missing trailing cells are transparent.
+    const ARROW: [&str; 19] = [
+        "o",
+        "oo",
+        "o#o",
+        "o##o",
+        "o###o",
+        "o####o",
+        "o#####o",
+        "o######o",
+        "o#######o",
+        "o########o",
+        "o#####oooo",
+        "o##o##o",
+        "o#o o##o",
+        "oo  o##o",
+        "o    o##o",
+        "     o##o",
+        "      o##o",
+        "      o##o",
+        "       oo",
+    ];
+    let height = ARROW.len();
+    let width = ARROW.iter().map(|row| row.len()).max().unwrap_or(1);
+    let mut pixels = vec![0u8; width * height * 4];
+    for (y, row) in ARROW.iter().enumerate() {
+        for (x, cell) in row.bytes().enumerate() {
+            let value: Option<[u8; 4]> = match cell {
+                b'#' => Some([0, 0, 0, 0xFF]),
+                b'o' => Some([0xFF, 0xFF, 0xFF, 0xFF]),
+                _ => None,
+            };
+            if let Some(rgba) = value {
+                let at = (y * width + x) * 4;
+                pixels[at..at + 4].copy_from_slice(&rgba);
+            }
+        }
+    }
+    // RGBA byte order is the little-endian DRM fourcc Abgr8888, NOT
+    // Argb8888 — mixing those up swaps red and blue. Fully opaque or
+    // fully transparent pixels only, so these bytes are also already
+    // valid premultiplied alpha, which is what the GLES renderer's
+    // blending expects (and what tiny-skia's `data()` provides for the
+    // decoration buffers `backend_impl` imports the same way).
+    MemoryRenderBuffer::from_slice(
+        &pixels,
+        Fourcc::Abgr8888,
+        (width as i32, height as i32),
+        1,
+        Transform::Normal,
+        None,
+    )
+}

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -1,0 +1,560 @@
+//! Wayland protocol handlers on [`Compositor`]: wl_compositor/wl_shm/
+//! wl_seat/wl_output/wl_data_device plumbing plus the xdg-shell and
+//! xdg-decoration mapping that turns client requests into the exact
+//! `BackendEvent` shapes `wm-core` already speaks (read alongside
+//! `wm-x11`'s `translate_event`/`translate_client_message` — every
+//! event queued here mirrors a translation there).
+//!
+//! The one deliberate divergence from X11's lifecycle: xdg toplevels
+//! have no MapRequest of their own. A toplevel "maps" by committing its
+//! first buffer after the configure handshake, so `commit` below is
+//! where `BackendEvent::MapRequest` is synthesized — and a later
+//! null-buffer commit is the protocol's unmap, translated to
+//! `BackendEvent::Unmapped` the same way `wm-x11` translates
+//! UnmapNotify. `wm-core` cannot tell the difference, by construction.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use smithay::backend::renderer::utils::{on_commit_buffer_handler, with_renderer_surface_state};
+use smithay::desktop::PopupKind;
+use smithay::input::pointer::CursorImageStatus;
+use smithay::input::{Seat, SeatHandler, SeatState};
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols::xdg::decoration::zv1::server::zxdg_toplevel_decoration_v1::Mode as DecorationMode;
+use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
+use smithay::reexports::wayland_server::protocol::wl_output;
+use smithay::reexports::wayland_server::protocol::wl_seat::WlSeat;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::{Client, Resource};
+use smithay::utils::Serial;
+use smithay::wayland::buffer::BufferHandler;
+use smithay::wayland::compositor::{
+    get_parent, with_states, CompositorClientState, CompositorHandler, CompositorState,
+};
+use smithay::wayland::output::OutputHandler;
+use smithay::wayland::selection::data_device::{
+    set_data_device_focus, ClientDndGrabHandler, DataDeviceHandler, DataDeviceState,
+    ServerDndGrabHandler,
+};
+use smithay::wayland::selection::SelectionHandler;
+use smithay::wayland::shell::xdg::decoration::XdgDecorationHandler;
+use smithay::wayland::shell::xdg::{
+    PopupSurface, PositionerState, SurfaceCachedState, ToplevelSurface, XdgShellHandler,
+    XdgShellState, XdgToplevelSurfaceData,
+};
+use smithay::wayland::shm::{ShmHandler, ShmState};
+use smithay::xwayland::XWaylandClientData;
+use smithay::{
+    delegate_compositor, delegate_data_device, delegate_output, delegate_seat, delegate_shm,
+    delegate_xdg_decoration, delegate_xdg_shell,
+};
+
+use wm_core::{BackendEvent, NetState, NetStateAction};
+use wm_theme_api::{Rect, Size};
+
+use crate::state::{ClientState, Compositor, ManagedSurface, WindowRecord, WlFrameId, WlWindowId};
+
+type WmEvent = BackendEvent<WlWindowId, WlFrameId>;
+
+/// Per-surface "MapRequest already emitted" marker, parked on the
+/// surface's user-data map so its lifetime is exactly the surface's —
+/// no cleanup path can forget it. Tracks the mapped/unmapped EDGE:
+/// `wm-x11` gets that edge from the server (MapRequest/UnmapNotify),
+/// here it is derived from buffer-presence transitions across commits.
+#[derive(Default)]
+struct MappedMarker(AtomicBool);
+
+fn mapped_marker(surface: &WlSurface) -> bool {
+    with_states(surface, |states| {
+        states.data_map.insert_if_missing_threadsafe(MappedMarker::default);
+        states.data_map.get::<MappedMarker>().unwrap().0.load(Ordering::Relaxed)
+    })
+}
+
+fn set_mapped_marker(surface: &WlSurface, value: bool) {
+    with_states(surface, |states| {
+        states.data_map.insert_if_missing_threadsafe(MappedMarker::default);
+        states.data_map.get::<MappedMarker>().unwrap().0.store(value, Ordering::Relaxed);
+    });
+}
+
+/// The size the client actually committed: its declared xdg window
+/// geometry when set, else the buffer's logical size. `wm-core` reads
+/// this through `Backend::window_geometry` at map time (how big does
+/// the fresh client want to be), and `commit` compares it against the
+/// record to detect client-side resizes.
+fn committed_content_size(surface: &WlSurface) -> Option<Size> {
+    let geometry = with_states(surface, |states| {
+        let mut guard = states.cached_state.get::<SurfaceCachedState>();
+        guard.current().geometry
+    });
+    if let Some(geometry) = geometry {
+        if geometry.size.w > 0 && geometry.size.h > 0 {
+            return Some(Size::new(geometry.size.w as u32, geometry.size.h as u32));
+        }
+    }
+    with_renderer_surface_state(surface, |state| state.surface_size())
+        .flatten()
+        .filter(|size| size.w > 0 && size.h > 0)
+        .map(|size| Size::new(size.w as u32, size.h as u32))
+}
+
+// -- wl_compositor -------------------------------------------------------
+
+impl CompositorHandler for Compositor {
+    fn compositor_state(&mut self) -> &mut CompositorState {
+        &mut self.compositor_state
+    }
+
+    fn client_compositor_state<'a>(&self, client: &'a Client) -> &'a CompositorClientState {
+        // XWayland connects as a client of this compositor too, with
+        // smithay's own client-data type rather than ours.
+        if let Some(state) = client.get_data::<XWaylandClientData>() {
+            return &state.compositor_state;
+        }
+        if let Some(state) = client.get_data::<ClientState>() {
+            return &state.compositor_state;
+        }
+        panic!("unknown client data type");
+    }
+
+    fn commit(&mut self, surface: &WlSurface) {
+        // Buffer bookkeeping first — everything below (and the
+        // renderer, and the hit-test's subsurface walk) reads the
+        // RendererSurfaceState this maintains.
+        on_commit_buffer_handler::<Self>(surface);
+        self.popups.commit(surface);
+
+        // Role logic runs against the tree's root: a subsurface commit
+        // must not re-trigger toplevel lifecycle.
+        let mut root = surface.clone();
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+
+        let toplevel = self
+            .xdg_shell_state
+            .toplevel_surfaces()
+            .iter()
+            .find(|toplevel| *toplevel.wl_surface() == root)
+            .cloned();
+        if let Some(toplevel) = toplevel {
+            self.toplevel_committed(&toplevel);
+        } else if let Some(PopupKind::Xdg(popup)) = self.popups.find_popup(&root) {
+            // A popup's first commit must be answered with its initial
+            // configure or the client waits forever.
+            if !popup.is_initial_configure_sent() {
+                if let Err(error) = popup.send_configure() {
+                    tracing::warn!(?error, "initial popup configure failed");
+                }
+            }
+        }
+
+        // Every commit can carry fresh pixels (client repaints are the
+        // one damage source no backend verb sees), so the scene
+        // redraws. Full-frame, same correctness-first call as the X11
+        // side made with picom's --no-use-damage.
+        self.wm.backend_mut().mark_damaged();
+    }
+}
+
+impl Compositor {
+    /// The xdg toplevel lifecycle, driven from commits (see the module
+    /// doc): initial configure, then buffer-presence edges into
+    /// MapRequest/Unmapped, then client-side resize drift into
+    /// ConfigureRequest.
+    fn toplevel_committed(&mut self, toplevel: &ToplevelSurface) {
+        let root = toplevel.wl_surface().clone();
+        let initial_configure_sent = with_states(&root, |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .map(|data| data.lock().unwrap().initial_configure_sent)
+        })
+        .unwrap_or(true);
+        if !initial_configure_sent {
+            // The protocol's opening move: the client committed its
+            // (buffer-less) role setup and now awaits a configure. Sent
+            // with no size — the client picks, and its answer becomes
+            // the map-time geometry below.
+            toplevel.send_configure();
+            return;
+        }
+
+        let has_buffer =
+            with_renderer_surface_state(&root, |state| state.buffer().is_some()).unwrap_or(false);
+        let was_mapped = mapped_marker(&root);
+        let committed = committed_content_size(&root);
+
+        let backend = self.wm.backend_mut();
+        let Some(id) = backend.window_for_surface(&root) else {
+            return;
+        };
+        if has_buffer && !was_mapped {
+            set_mapped_marker(&root, true);
+            // Seed the record with the client's own size so
+            // `window_geometry` answers the map-time "how big do you
+            // want to be" with the truth instead of the fallback.
+            if let Some(size) = committed {
+                if let Some(record) = backend.windows.get_mut(&id) {
+                    record.content.size = size;
+                }
+            }
+            backend.queue(WmEvent::MapRequest(id));
+        } else if !has_buffer && was_mapped {
+            // Null-buffer commit: the xdg unmap. The toplevel survives
+            // and may map again — the marker reset arms the next
+            // MapRequest edge, mirroring how an X11 client can unmap
+            // and re-map its window under the same WM bookkeeping.
+            set_mapped_marker(&root, false);
+            backend.queue(WmEvent::Unmapped(id));
+        } else if has_buffer {
+            // A managed client committing a size other than the one on
+            // record is the Wayland spelling of an X11 self-resize
+            // ConfigureRequest (a terminal snapping to its cell grid
+            // after our configure, say) — translated to the same event
+            // so `wm-core` reflows the decoration around the client's
+            // real size. Converges: `wm-core` answers via
+            // `resize_client`, which updates the record to match.
+            if let (Some(size), Some(record)) = (committed, backend.windows.get(&id)) {
+                if record.mapped && size != record.content.size {
+                    let requested = Rect { pos: record.content.pos, size };
+                    backend.queue(WmEvent::ConfigureRequest { window: id, requested });
+                }
+            }
+        }
+    }
+
+    /// Queues a `_NET_WM_STATE`-shaped request — the translation
+    /// `wm-x11` does for EWMH client messages, reused for the xdg
+    /// requests that mean exactly the same thing.
+    fn queue_net_state(
+        &mut self,
+        surface: &WlSurface,
+        action: NetStateAction,
+        first: NetState,
+        second: Option<NetState>,
+    ) {
+        let backend = self.wm.backend_mut();
+        if let Some(window) = backend.window_for_surface(surface) {
+            backend.queue(WmEvent::NetStateRequested { window, action, first, second });
+        }
+    }
+}
+
+impl BufferHandler for Compositor {
+    fn buffer_destroyed(&mut self, _buffer: &WlBuffer) {}
+}
+
+// -- wl_shm --------------------------------------------------------------
+
+impl ShmHandler for Compositor {
+    fn shm_state(&self) -> &ShmState {
+        &self.shm_state
+    }
+}
+
+// -- wl_output -----------------------------------------------------------
+
+impl OutputHandler for Compositor {
+    fn output_bound(&mut self, _output: Output, _wl_output: wl_output::WlOutput) {}
+}
+
+// -- wl_seat -------------------------------------------------------------
+
+impl SeatHandler for Compositor {
+    // Plain wl_surfaces as focus targets: both xdg toplevels and
+    // XWayland's X11 windows resolve to one (see `ManagedSurface`), so
+    // no bespoke focus enum is needed — `wm-core` owns focus POLICY,
+    // and the backend only ever points the seat at a surface.
+    type KeyboardFocus = WlSurface;
+    type PointerFocus = WlSurface;
+    type TouchFocus = WlSurface;
+
+    fn seat_state(&mut self) -> &mut SeatState<Compositor> {
+        &mut self.seat_state
+    }
+
+    fn focus_changed(&mut self, seat: &Seat<Self>, target: Option<&WlSurface>) {
+        // Keyboard focus carries clipboard access with it — without
+        // this, paste silently targets whichever client focused first.
+        let display_handle = self.display_handle.clone();
+        let client = target.and_then(|surface| surface.client());
+        set_data_device_focus(&display_handle, seat, client);
+    }
+
+    fn cursor_image(&mut self, _seat: &Seat<Self>, image: CursorImageStatus) {
+        // The renderer composites the pointer itself (there is no
+        // hardware cursor plane on the winit backend), so a client
+        // changing its cursor is scene damage like any other.
+        self.cursor_status = image;
+        self.wm.backend_mut().mark_damaged();
+    }
+}
+
+// -- selections / drag-and-drop ------------------------------------------
+
+impl SelectionHandler for Compositor {
+    type SelectionUserData = ();
+}
+
+impl DataDeviceHandler for Compositor {
+    fn data_device_state(&self) -> &DataDeviceState {
+        &self.data_device_state
+    }
+}
+
+// Defaults throughout: client-to-client DnD works through the seat's
+// own grab machinery; a rendered drag icon is a follow-up for the
+// renderer (the icon surface arrives in `started`, unused for now).
+impl ClientDndGrabHandler for Compositor {}
+impl ServerDndGrabHandler for Compositor {}
+
+// -- xdg-shell -----------------------------------------------------------
+
+impl XdgShellHandler for Compositor {
+    fn xdg_shell_state(&mut self) -> &mut XdgShellState {
+        &mut self.xdg_shell_state
+    }
+
+    fn new_toplevel(&mut self, surface: ToplevelSurface) {
+        // Chrome is ours: advertise server-side decorations from the
+        // very first configure so toolkits (GTK, Qt) never draw their
+        // own titlebars. Clients that skip xdg-decoration entirely get
+        // framed regardless — same as every X11 client under a
+        // reparenting WM.
+        surface.with_pending_state(|state| {
+            state.decoration_mode = Some(DecorationMode::ServerSide);
+        });
+        // Record now, MapRequest later: the id must exist before the
+        // first commit (which may map immediately), but the initial
+        // configure is only legal in response to that commit — see
+        // `toplevel_committed`.
+        let backend = self.wm.backend_mut();
+        let id = WlWindowId(backend.alloc_id());
+        backend.windows.insert(
+            id,
+            WindowRecord::new(ManagedSurface::Xdg(surface), Rect::default()),
+        );
+    }
+
+    fn new_popup(&mut self, surface: PopupSurface, positioner: PositionerState) {
+        // Position straight from the positioner, parent-relative — the
+        // renderer and the hit-test both resolve it against the
+        // parent's content rect via `PopupManager`. No unconstraining
+        // pass yet: WindowMaker-parity menus hug their parent, and a
+        // popup off the output edge is the client's own placement to
+        // fix. (Initial configure happens at first commit.)
+        surface.with_pending_state(|state| {
+            state.geometry = positioner.get_geometry();
+        });
+        if let Err(error) = self.popups.track_popup(PopupKind::from(surface)) {
+            tracing::warn!(?error, "failed to track xdg popup");
+        }
+    }
+
+    fn reposition_request(
+        &mut self,
+        surface: PopupSurface,
+        positioner: PositionerState,
+        token: u32,
+    ) {
+        surface.with_pending_state(|state| {
+            state.geometry = positioner.get_geometry();
+            state.positioner = positioner;
+        });
+        surface.send_repositioned(token);
+    }
+
+    fn grab(&mut self, _surface: PopupSurface, _seat: WlSeat, _serial: Serial) {
+        // Not granted: smithay's popup-grab machinery needs a focus
+        // type convertible from popups (`KeyboardFocus: From<PopupKind>`),
+        // which the deliberately-plain `WlSurface` focus above isn't.
+        // Menus still open, render, and take pointer input through the
+        // ordinary hit-test; the cost is no popup_done auto-dismissal
+        // on outside clicks (toolkits dismiss on their own focus/click
+        // handling). Strictly the protocol prefers dismissing an
+        // ungranted grab — deliberately not done, since insta-closing
+        // every menu is uselessness dressed up as compliance. Revisit
+        // with a dedicated focus-target enum if it bites.
+    }
+
+    fn move_request(&mut self, _surface: ToplevelSurface, _seat: WlSeat, _serial: Serial) {
+        // A client-initiated interactive move (CSD titlebar drag).
+        // Under server-side decorations moves start from OUR titlebar,
+        // which `wm-core` runs off frame button events — there is no
+        // BackendEvent shape for a client asking, exactly as there was
+        // none for X11's `_NET_WM_MOVERESIZE` (which `wm-x11` also
+        // drops).
+    }
+
+    fn resize_request(
+        &mut self,
+        _surface: ToplevelSurface,
+        _seat: WlSeat,
+        _serial: Serial,
+        _edges: smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::ResizeEdge,
+    ) {
+        // Same rationale as `move_request`.
+    }
+
+    fn maximize_request(&mut self, surface: ToplevelSurface) {
+        // One request toggling both axes — byte-for-byte the
+        // `_NET_WM_STATE` maximize message shape `wm-x11` translates.
+        self.queue_net_state(
+            surface.wl_surface(),
+            NetStateAction::Add,
+            NetState::MaximizedHorz,
+            Some(NetState::MaximizedVert),
+        );
+        // The protocol demands a configure in reply whether or not the
+        // request is honored; `wm-core`'s own reconfigure follows once
+        // it acts on the queued event.
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        }
+    }
+
+    fn unmaximize_request(&mut self, surface: ToplevelSurface) {
+        self.queue_net_state(
+            surface.wl_surface(),
+            NetStateAction::Remove,
+            NetState::MaximizedHorz,
+            Some(NetState::MaximizedVert),
+        );
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        }
+    }
+
+    fn fullscreen_request(
+        &mut self,
+        surface: ToplevelSurface,
+        _output: Option<wl_output::WlOutput>,
+    ) {
+        // Single output today — the output hint has nothing to select.
+        self.queue_net_state(surface.wl_surface(), NetStateAction::Add, NetState::Fullscreen, None);
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        }
+    }
+
+    fn unfullscreen_request(&mut self, surface: ToplevelSurface) {
+        self.queue_net_state(
+            surface.wl_surface(),
+            NetStateAction::Remove,
+            NetState::Fullscreen,
+            None,
+        );
+        if surface.is_initial_configure_sent() {
+            surface.send_configure();
+        }
+    }
+
+    fn minimize_request(&mut self, _surface: ToplevelSurface) {
+        // Miniaturization is a WM gesture (titlebar button, keybinding)
+        // with no request-shaped path into `wm-core` — the X11 backend
+        // had no `_NET_WM_STATE_HIDDEN` request translation either.
+        // Ignoring is protocol-legal: minimize has no required reply.
+    }
+
+    fn title_changed(&mut self, surface: ToplevelSurface) {
+        // Same reason this event exists on X11: most apps set their
+        // real title well after mapping (see
+        // `BackendEvent::TitleChanged`'s doc), so the titlebar must
+        // repaint on the property change, not the map.
+        let title = with_states(surface.wl_surface(), |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .and_then(|data| data.lock().unwrap().title.clone())
+        });
+        let backend = self.wm.backend_mut();
+        if let Some(id) = backend.window_for_surface(surface.wl_surface()) {
+            if let Some(record) = backend.windows.get_mut(&id) {
+                // Keep the record's cache current per its contract
+                // (`WindowRecord::title`'s doc in state.rs).
+                record.title = title;
+            }
+            backend.queue(WmEvent::TitleChanged(id));
+        }
+    }
+
+    fn app_id_changed(&mut self, surface: ToplevelSurface) {
+        let app_id = with_states(surface.wl_surface(), |states| {
+            states
+                .data_map
+                .get::<XdgToplevelSurfaceData>()
+                .and_then(|data| data.lock().unwrap().app_id.clone())
+        });
+        let backend = self.wm.backend_mut();
+        if let Some(id) = backend.window_for_surface(surface.wl_surface()) {
+            if let Some(record) = backend.windows.get_mut(&id) {
+                record.app_id = app_id;
+            }
+        }
+    }
+
+    fn toplevel_destroyed(&mut self, surface: ToplevelSurface) {
+        // The record goes immediately (`wm-x11` drops `known_clients`
+        // on DestroyNotify the same way); `wm-core`'s teardown then
+        // calls backend verbs that all tolerate the missing window.
+        let backend = self.wm.backend_mut();
+        if let Some(id) = backend.window_for_surface(surface.wl_surface()) {
+            backend.windows.remove(&id);
+            backend.queue(WmEvent::Destroyed(id));
+            backend.mark_damaged();
+        }
+    }
+
+    fn popup_destroyed(&mut self, _surface: PopupSurface) {
+        // PopupManager prunes dead popups itself (the loop calls its
+        // `cleanup`); the scene just needs a repaint without it.
+        self.wm.backend_mut().mark_damaged();
+    }
+}
+
+// -- xdg-decoration ------------------------------------------------------
+// The policy is one line long: this desktop draws the chrome, always —
+// WindowMaker parity is the whole point, and a client drawing its own
+// titlebar under our frame would wear two hats. Clients keep asking for
+// ClientSide (GTK does, universally); the answer is configured
+// ServerSide every time, which the protocol explicitly allows the
+// compositor to impose.
+
+impl XdgDecorationHandler for Compositor {
+    fn new_decoration(&mut self, toplevel: ToplevelSurface) {
+        toplevel.with_pending_state(|state| {
+            state.decoration_mode = Some(DecorationMode::ServerSide);
+        });
+        // No configure here: if this races the initial commit, the
+        // initial configure carries the mode; otherwise request_mode/
+        // unset_mode follow immediately and send one.
+    }
+
+    fn request_mode(&mut self, toplevel: ToplevelSurface, _mode: DecorationMode) {
+        toplevel.with_pending_state(|state| {
+            state.decoration_mode = Some(DecorationMode::ServerSide);
+        });
+        if toplevel.is_initial_configure_sent() {
+            let _ = toplevel.send_pending_configure();
+        }
+    }
+
+    fn unset_mode(&mut self, toplevel: ToplevelSurface) {
+        toplevel.with_pending_state(|state| {
+            state.decoration_mode = Some(DecorationMode::ServerSide);
+        });
+        if toplevel.is_initial_configure_sent() {
+            let _ = toplevel.send_pending_configure();
+        }
+    }
+}
+
+delegate_compositor!(Compositor);
+delegate_shm!(Compositor);
+delegate_output!(Compositor);
+delegate_seat!(Compositor);
+delegate_data_device!(Compositor);
+delegate_xdg_shell!(Compositor);
+delegate_xdg_decoration!(Compositor);

--- a/crates/wm-wayland/src/xwayland.rs
+++ b/crates/wm-wayland/src/xwayland.rs
@@ -1,0 +1,312 @@
+//! XWayland: the X11 half of the compositor. `run()` spawns a rootless
+//! Xwayland server and attaches this process as its window manager
+//! (`X11Wm::start_wm`) once it reports ready; the handlers here are
+//! that window manager. Every X11 window enters the SAME `WlWindowId`
+//! space as native toplevels (`ManagedSurface::X11`) — so urxvt gets
+//! the exact chrome, focus, and stacking treatment a Wayland-native
+//! terminal gets, and `wm-core` never learns which protocol a window
+//! spoke.
+//!
+//! The translations here mirror `wm-x11`'s `translate_event` almost
+//! line-for-line — unsurprisingly, since XWM events ARE X11 events:
+//! map request, unmap/destroy notify, configure request, property
+//! notify, and the `_NET_WM_STATE` request family. The differences are
+//! where smithay already digested the protocol (titles and classes come
+//! from `X11Surface` accessors, not GetProperty round-trips).
+
+use smithay::delegate_xwayland_shell;
+use smithay::utils::{Logical, Rectangle};
+use smithay::wayland::xwayland_shell::{XWaylandShellHandler, XWaylandShellState};
+use smithay::xwayland::xwm::{
+    Reorder, ResizeEdge as X11ResizeEdge, WmWindowProperty, X11Window, XwmId,
+};
+use smithay::xwayland::{X11Surface, X11Wm, XwmHandler};
+
+use wm_core::{BackendEvent, NetState, NetStateAction};
+use wm_theme_api::{Point, Rect, Size};
+
+use crate::state::{
+    Compositor, ManagedSurface, WaylandBackend, WindowRecord, WlFrameId, WlWindowId,
+};
+
+type WmEvent = BackendEvent<WlWindowId, WlFrameId>;
+
+/// The association protocol Xwayland uses to tie its X11 windows to
+/// wl_surfaces — `X11Wm::start_wm` requires it, and without it no X11
+/// window ever gets content on screen.
+impl XWaylandShellHandler for Compositor {
+    fn xwayland_shell_state(&mut self) -> &mut XWaylandShellState {
+        &mut self.xwayland_shell_state
+    }
+}
+
+delegate_xwayland_shell!(Compositor);
+
+/// Reverse lookup by X11 surface handle (cheap Arc'd equality). The
+/// wl_surface-based lookup in `state.rs` cannot serve here: an X11
+/// window exists — and needs configure/property routing — before its
+/// wl_surface association ever arrives.
+fn x11_window_id(backend: &WaylandBackend, window: &X11Surface) -> Option<WlWindowId> {
+    backend.windows.iter().find_map(|(id, record)| match &record.surface {
+        ManagedSurface::X11(existing) if existing == window => Some(*id),
+        _ => None,
+    })
+}
+
+/// Finds the record for this X11 window, creating one on first sight —
+/// map request and mapped-override-redirect both funnel through here so
+/// a window that unmaps and remaps keeps its id, like an X11 window
+/// keeps its XID.
+fn ensure_x11_record(backend: &mut WaylandBackend, window: &X11Surface) -> WlWindowId {
+    if let Some(id) = x11_window_id(backend, window) {
+        return id;
+    }
+    let id = WlWindowId(backend.alloc_id());
+    // X11 clients pick their own geometry before mapping (the XWM
+    // tracked their pre-map configures); starting the record from that
+    // truth is what makes `Backend::window_geometry` answer correctly
+    // at map time.
+    backend.windows.insert(
+        id,
+        WindowRecord::new(ManagedSurface::X11(window.clone()), wm_rect(window.geometry())),
+    );
+    id
+}
+
+fn wm_rect(rect: Rectangle<i32, Logical>) -> Rect {
+    Rect {
+        pos: Point::new(rect.loc.x, rect.loc.y),
+        size: Size::new(rect.size.w.max(0) as u32, rect.size.h.max(0) as u32),
+    }
+}
+
+impl XwmHandler for Compositor {
+    fn xwm_state(&mut self, _xwm: XwmId) -> &mut X11Wm {
+        // Smithay only dispatches XWM events after `start_wm` succeeded,
+        // which is the only place `xwm` is set (see `run()`).
+        self.xwm.as_mut().expect("XWM event before start_wm")
+    }
+
+    fn new_window(&mut self, _xwm: XwmId, _window: X11Surface) {
+        // Creation is not management — X11 clients create windows long
+        // before mapping (some never map). The record is made at map
+        // time; pre-map configures are honored below without one.
+    }
+
+    fn new_override_redirect_window(&mut self, _xwm: XwmId, _window: X11Surface) {}
+
+    fn map_window_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        // The X11 map veto is ours now: allow the map (which also lets
+        // Xwayland associate a wl_surface), then hand `wm-core` the
+        // same MapRequest an X server would have routed to `wm-x11` —
+        // decoration policy, placement, and workspace assignment all
+        // run unchanged from there.
+        if let Err(error) = window.set_mapped(true) {
+            tracing::warn!(?error, "X11 map_window_request set_mapped failed");
+        }
+        let backend = self.wm.backend_mut();
+        let id = ensure_x11_record(backend, &window);
+        // Refresh the pre-map geometry — the client may have configured
+        // itself since the record was first created.
+        if let Some(record) = backend.windows.get_mut(&id) {
+            record.content = wm_rect(window.geometry());
+        }
+        backend.queue(WmEvent::MapRequest(id));
+    }
+
+    fn mapped_override_redirect_window(&mut self, _xwm: XwmId, window: X11Surface) {
+        // Menus, tooltips, dropdowns: already mapped by the client (no
+        // request to veto). The MapRequest still flows to `wm-core`,
+        // whose `window_type` read classifies them Unmanaged (the
+        // backend reports override-redirect as such) and maps them
+        // as-is with no frame — the exact path `wm-x11` takes for
+        // these window types.
+        let backend = self.wm.backend_mut();
+        let id = ensure_x11_record(backend, &window);
+        if let Some(record) = backend.windows.get_mut(&id) {
+            record.content = wm_rect(window.geometry());
+        }
+        backend.queue(WmEvent::MapRequest(id));
+    }
+
+    fn unmapped_window(&mut self, _xwm: XwmId, window: X11Surface) {
+        let backend = self.wm.backend_mut();
+        let Some(id) = x11_window_id(backend, &window) else {
+            return;
+        };
+        if let Some(record) = backend.windows.get_mut(&id) {
+            // Stop drawing immediately — matters for override-redirect
+            // windows, which have no frame lifecycle to hide them.
+            record.mapped = false;
+        }
+        backend.mark_damaged();
+        backend.queue(WmEvent::Unmapped(id));
+        // Return the window to withdrawn so a future map restarts the
+        // cycle cleanly; smithay refuses this for override-redirect
+        // windows (they were never ours to unmap).
+        if !window.is_override_redirect() {
+            if let Err(error) = window.set_mapped(false) {
+                tracing::warn!(?error, "X11 unmapped_window set_mapped(false) failed");
+            }
+        }
+    }
+
+    fn destroyed_window(&mut self, _xwm: XwmId, window: X11Surface) {
+        // Record dropped immediately, event queued — the DestroyNotify
+        // translation, matching `wm-x11` removing `known_clients` on
+        // the spot (every later backend verb tolerates the missing id).
+        let backend = self.wm.backend_mut();
+        let Some(id) = x11_window_id(backend, &window) else {
+            return;
+        };
+        backend.windows.remove(&id);
+        backend.mark_damaged();
+        backend.queue(WmEvent::Destroyed(id));
+    }
+
+    fn configure_request(
+        &mut self,
+        _xwm: XwmId,
+        window: X11Surface,
+        x: Option<i32>,
+        y: Option<i32>,
+        w: Option<u32>,
+        h: Option<u32>,
+        _reorder: Option<Reorder>,
+    ) {
+        // Merge the request over the current geometry — X11 configure
+        // requests name only the fields the client cares about.
+        let mut requested = window.geometry();
+        if let Some(x) = x {
+            requested.loc.x = x;
+        }
+        if let Some(y) = y {
+            requested.loc.y = y;
+        }
+        if let Some(w) = w {
+            requested.size.w = w as i32;
+        }
+        if let Some(h) = h {
+            requested.size.h = h as i32;
+        }
+        let backend = self.wm.backend_mut();
+        if let Some(id) = x11_window_id(backend, &window) {
+            // Known window: `wm-core` decides, exactly as it does for
+            // the X11 backend's ConfigureRequest events (it honors
+            // sizes, ignores positions on managed clients, and applies
+            // everything verbatim pre-manage via `configure_unmanaged`).
+            backend.queue(WmEvent::ConfigureRequest { window: id, requested: wm_rect(requested) });
+        } else {
+            // Never mapped, no record yet: honor directly — ICCCM
+            // requires acknowledging pre-map configures or clients
+            // deadlock waiting for their geometry.
+            if let Err(error) = window.configure(requested) {
+                tracing::warn!(?error, "X11 pre-manage configure failed");
+            }
+        }
+    }
+
+    fn configure_notify(
+        &mut self,
+        _xwm: XwmId,
+        window: X11Surface,
+        geometry: Rectangle<i32, Logical>,
+        _above: Option<X11Window>,
+    ) {
+        // Only self-positioning windows matter here: an override-
+        // redirect menu moving itself must carry its scene rect (and
+        // hit-test target) along. Managed windows' geometry is owned by
+        // `wm-core` — their notifies just echo our own configures.
+        if !window.is_override_redirect() {
+            return;
+        }
+        let backend = self.wm.backend_mut();
+        if let Some(id) = x11_window_id(backend, &window) {
+            if let Some(record) = backend.windows.get_mut(&id) {
+                record.content = wm_rect(geometry);
+            }
+            backend.mark_damaged();
+        }
+    }
+
+    fn property_notify(&mut self, _xwm: XwmId, window: X11Surface, property: WmWindowProperty) {
+        // The title watch `wm-x11` keeps via PropertyNotify on
+        // WM_NAME/_NET_WM_NAME — smithay already filtered to the
+        // interesting properties and parsed the value.
+        if property == WmWindowProperty::Title {
+            let backend = self.wm.backend_mut();
+            if let Some(id) = x11_window_id(backend, &window) {
+                if let Some(record) = backend.windows.get_mut(&id) {
+                    // Keep the record's cache current per its contract
+                    // (`WindowRecord::title`'s doc in state.rs); empty
+                    // means never really set, same rule as
+                    // `window_title`.
+                    let title = window.title();
+                    record.title = if title.is_empty() { None } else { Some(title) };
+                }
+                backend.queue(WmEvent::TitleChanged(id));
+            }
+        }
+    }
+
+    fn maximize_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        self.queue_x11_net_state(
+            &window,
+            NetStateAction::Add,
+            NetState::MaximizedHorz,
+            Some(NetState::MaximizedVert),
+        );
+    }
+
+    fn unmaximize_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        self.queue_x11_net_state(
+            &window,
+            NetStateAction::Remove,
+            NetState::MaximizedHorz,
+            Some(NetState::MaximizedVert),
+        );
+    }
+
+    fn fullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        self.queue_x11_net_state(&window, NetStateAction::Add, NetState::Fullscreen, None);
+    }
+
+    fn unfullscreen_request(&mut self, _xwm: XwmId, window: X11Surface) {
+        self.queue_x11_net_state(&window, NetStateAction::Remove, NetState::Fullscreen, None);
+    }
+
+    fn resize_request(
+        &mut self,
+        _xwm: XwmId,
+        _window: X11Surface,
+        _button: u32,
+        _resize_edge: X11ResizeEdge,
+    ) {
+        // `_NET_WM_MOVERESIZE`-style client-initiated drags: no
+        // BackendEvent shape exists and `wm-x11` dropped these client
+        // messages too — interactive move/resize is driven from our own
+        // chrome.
+    }
+
+    fn move_request(&mut self, _xwm: XwmId, _window: X11Surface, _button: u32) {
+        // Same rationale as `resize_request`.
+    }
+}
+
+impl Compositor {
+    /// The `_NET_WM_STATE` translation `wm-x11` does for X11 client
+    /// messages — the XWM already decoded action and property, so this
+    /// just re-queues the same shape against the shared id space.
+    fn queue_x11_net_state(
+        &mut self,
+        window: &X11Surface,
+        action: NetStateAction,
+        first: NetState,
+        second: Option<NetState>,
+    ) {
+        let backend = self.wm.backend_mut();
+        if let Some(id) = x11_window_id(backend, window) {
+            backend.queue(WmEvent::NetStateRequested { window: id, action, first, second });
+        }
+    }
+}


### PR DESCRIPTION
Part 2 of 4. REVIEW ONLY, DO NOT MERGE - already on `main`.

`wm-wayland` implements the same Backend contract the X11 backend
does: window/frame/shell ledgers, xdg-shell, XWayland, input mapped to
the same KeyCombo space, and a scene shared with the X11 side.

NOTE: this is the largest part (13 files, ~5.9k lines) because the
compositor arrives in one commit. If it is still too large to review,
say so and it can be split by file group - state/renderer versus
xdg/input/xwayland.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPsrCnhqdDRnMz1Z7iDUd4