### PR TITLE
Review 3/4: session seam, CI split, installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           sudo apt-get install -y xvfb xterm x11-utils
 
       - name: Build release binaries
-        run: cargo build --release
+        run: cargo build --release -p chonkstep
 
       - name: X11 smoke test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run the workspace test suite
-        run: cargo test --workspace
+        # The Wayland crates are excluded here NOT because they are
+        # untested but because they are the wayland job's whole purpose
+        # (which installs their system libraries and builds+tests them);
+        # compiling Smithay twice per push buys nothing.
+        run: cargo test --workspace --exclude wm-wayland --exclude chonkstep-wayland
 
       - name: Install X11 smoke test dependencies
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,10 +477,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
+name = "drm"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "drm-ffi",
+ "drm-fourcc",
+ "libc",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "drm-ffi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
+dependencies = [
+ "drm-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "drm-fourcc"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
+
+[[package]]
+name = "drm-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.9.4",
+]
 
 [[package]]
 name = "either"
@@ -628,6 +662,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gbm"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce852e998d3ca5e4a97014fb31c940dc5ef344ec7d364984525fd11e8a547e6a"
+dependencies = [
+ "bitflags 2.13.1",
+ "drm",
+ "drm-fourcc",
+ "gbm-sys",
+ "libc",
+]
+
+[[package]]
+name = "gbm-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13a5f2acc785d8fb6bf6b7ab6bfb0ef5dad4f4d97e8e70bb8e470722312f76f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +745,12 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
@@ -701,6 +763,35 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "input"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+dependencies = [
+ "bitflags 2.13.1",
+ "input-sys",
+ "libc",
+ "udev",
+]
+
+[[package]]
+name = "input-sys"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -829,10 +920,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "libseat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6656c69b6e0366ffb83faa232f3e4fda5fc91161722d140f2c95ce2e90b1ef31"
+dependencies = [
+ "errno",
+ "libseat-sys",
+ "log",
+]
+
+[[package]]
+name = "libseat-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a484fa48be5f62a8d3ffed767779d0ab808cfead91de98ef4362d469097dfb"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1234,7 +1361,7 @@ checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -1653,16 +1780,23 @@ dependencies = [
  "atomic_float",
  "bitflags 2.13.1",
  "calloop 0.14.4",
+ "cc",
  "cgmath",
  "cursor-icon",
  "downcast-rs",
+ "drm",
+ "drm-ffi",
  "drm-fourcc",
  "encoding_rs",
  "errno",
+ "gbm",
  "gl_generator",
  "indexmap",
+ "input",
  "libc",
  "libloading",
+ "libseat",
+ "pkg-config",
  "profiling",
  "rand",
  "rustix 1.1.4",
@@ -1672,6 +1806,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tracing",
+ "udev",
  "wayland-client",
  "wayland-cursor",
  "wayland-egl",
@@ -2010,6 +2145,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "udev"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4e37e9ea4401fc841ff54b9ddfc9be1079b1e89434c1a6a865dd68980f7e9f"
+dependencies = [
+ "io-lifetimes",
+ "libc",
+ "libudev-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2327,11 +2474,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2340,7 +2496,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2354,19 +2510,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2376,9 +2553,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2394,9 +2583,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2406,9 +2607,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2532,6 +2745,7 @@ version = "0.1.0"
 dependencies = [
  "chonk-shell",
  "smithay",
+ "tiny-skia",
  "tracing",
  "wm-config",
  "wm-core",

--- a/README.md
+++ b/README.md
@@ -95,20 +95,29 @@ scripts/install.sh
 
 The installer pulls the runtime dependencies with pacman (Xorg,
 rxvt-unicode, picom, wireplumber for the sound instrument, the theme
-fonts, and a Rust toolchain if needed), builds the release binaries,
-installs a `chonkstep.desktop` session entry that points back into the
-checkout, and seeds `~/.config/chonkstep/config.toml` from the
-fully-commented example if you don't have one.
+fonts, the Wayland stack the compositor builds and runs against -
+libxkbcommon, EGL/mesa, Xwayland - and a Rust toolchain if needed),
+builds both release binaries, installs a `chonkstep.desktop` session
+entry that points back into the checkout, and seeds
+`~/.config/chonkstep/config.toml` from the fully-commented example if
+you don't have one.
 
-How you start it depends on the machine:
+How you start it depends on the machine, and on which half you want:
 
-- **Stock Omarchy** boots straight into Hyprland via autologin - there
-  is no login-manager session picker. Switch to a TTY (Ctrl+Alt+F3),
-  log in, and run `startx scripts/xsession.sh` from the checkout. (Or
-  install and enable a display manager such as sddm; the session entry
-  is already in place for it.)
-- **A machine with a display manager** (sddm, gdm, lightdm, ...): log
-  out and pick "chonkstep" in the session list.
+- **The X11 session** is the full daily-driver desktop. On **stock
+  Omarchy** there is no login-manager session picker (it boots straight
+  into Hyprland via autologin), so switch to a TTY (Ctrl+Alt+F3), log
+  in, and run `startx scripts/xsession.sh` from the checkout. On a
+  machine **with a display manager** (sddm, gdm, lightdm, ...), log out
+  and pick "chonkstep" in the session list.
+- **The Wayland compositor** runs nested inside whatever desktop you
+  are already in - `./target/release/chonkstep-wayland` from a
+  terminal - and is a preview rather than a login session today. See
+  [Wayland](#wayland) below for why, and for what it can already do.
+  Being on a Wayland desktop (as Omarchy is) does not change the
+  recommendation yet: until the DRM/KMS session lands, the X11 session
+  is the one you can log into, and the installer deliberately does not
+  register a Wayland session entry that would fail when chosen.
 
 On a HiDPI display, set `scale = 2.0` in
 `~/.config/chonkstep/config.toml` - it scales chrome, dock, cursors,

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -15,11 +15,18 @@ wm-theme-api = { path = "../wm-theme-api" }
 wm-config = { path = "../wm-config" }
 chonk-shell = { path = "../chonk-shell" }
 tracing = "0.1"
+# Screenshot encoding (see `capture.rs`) - the same rasterizer the
+# theme engine draws with, so no second image stack enters the graph.
+tiny-skia = "0.11"
 
 # Smithay 0.7 is the pinned compositor framework. Features are opted
-# into explicitly (default-features = false) so the DRM/KMS, libinput,
-# udev, and Vulkan stacks — all of which want system libraries at build
-# time — stay out of the graph until the `session` feature grows real:
+# into explicitly (default-features = false); both backends — the
+# nested winit one and the real DRM/KMS session — are compiled in on
+# Linux, and which one runs is decided at startup by
+# `state::run` (see `Graphics`), not at build time. That is deliberate:
+# one binary has to serve both "I am logging into chonkstep from a TTY"
+# and "I am previewing it inside my existing desktop", and a build-time
+# split would mean shipping two.
 #
 # - backend_winit: the nested development backend (the compositor runs
 #   inside a window on an existing desktop), which also pulls in
@@ -40,26 +47,29 @@ tracing = "0.1"
 # Keysyms and modifier state come through Smithay's own xkbcommon
 # re-exports (`smithay::input::keyboard::{Keysym, ModifiersState}`), so
 # no direct xkbcommon dependency is needed.
+# The session half needs system libraries at build and run time -
+# libdrm, libgbm, EGL, libinput, libudev, libseat - which every
+# graphical Linux system already carries and `scripts/install.sh`
+# installs explicitly:
+#
+# - backend_drm + backend_gbm + backend_egl: mode setting on the DRM
+#   device, buffer allocation through GBM, and the EGL context the
+#   GLES renderer draws into.
+# - backend_libinput + backend_udev: real keyboards, mice, and
+#   touchpads, discovered and hot-plugged through udev.
+# - backend_session_libseat: seat management, so the compositor opens
+#   DRM and input devices without being root and hands them back
+#   across VT switches.
 smithay = { version = "0.7.0", default-features = false, features = [
     "backend_winit",
+    "backend_drm",
+    "backend_gbm",
+    "backend_egl",
+    "backend_libinput",
+    "backend_udev",
+    "backend_session_libseat",
     "renderer_gl",
     "desktop",
     "wayland_frontend",
     "xwayland",
 ] }
-
-[features]
-default = ["winit"]
-# The nested development backend: the compositor runs inside a window
-# on an existing X11/Wayland desktop. Currently a marker — the winit
-# stack is unconditionally compiled in via the smithay features above —
-# kept so the eventual `--no-default-features --features session` build
-# has a name to exclude.
-winit = []
-# The real-hardware session: DRM/KMS + libinput + libseat. A documented
-# placeholder for now — enabling it does nothing yet. When it grows
-# real it will turn on smithay's backend_drm/backend_libinput/
-# backend_session_libseat features, which need the corresponding system
-# libraries at build time; off by default so CI and the nested dev loop
-# stay light.
-session = []

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -421,8 +421,13 @@ impl Backend for WaylandBackend {
     /// GLES context this needs). The icon/switcher SDK already designs
     /// for missing previews, so the cost of shipping without it is a
     /// generic tile instead of a live thumbnail, not a broken feature.
-    fn capture_window_image(&self, _window: Self::WindowId, _size: Size) -> Option<DecorationBuffer> {
-        None
+    fn capture_window_image(&self, window: Self::WindowId, _size: Size) -> Option<DecorationBuffer> {
+        // Served from the snapshot the renderer keeps refreshing (see
+        // `crate::capture` for why a compositor cannot answer this
+        // synchronously the way the X11 backend does with XGetImage).
+        // `size` is advisory: the shell's icon and switcher renderers
+        // scale whatever preview they are handed into their own wells.
+        self.windows.get(&window).and_then(|record| record.snapshot.clone())
     }
 
     // -- decoration realization -------------------------------------------

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -1,0 +1,38 @@
+//! Window and output capture: the compositor's answer to "what does
+//! that window look like right now".
+//!
+//! X11 could hand `wm-core` a window's pixels on demand (XGetImage on
+//! a live drawable), which is how Alt-Tab thumbnails and miniaturized
+//! icon previews are drawn. A compositor cannot answer that
+//! synchronously from inside the backend - the renderer lives on the
+//! `Compositor`, not on the ledger `wm-core` holds - so the flow is
+//! inverted: rendering keeps a small, throttled snapshot per mapped
+//! window in its `WindowRecord`, and `Backend::capture_window_image`
+//! serves the most recent one. The shell asks for a preview at
+//! miniaturize time, by which point a snapshot is already waiting.
+//!
+//! Interim skeleton: the real offscreen-render implementation is being
+//! built against this exact API. Until it lands, snapshots stay empty
+//! and the shell's own no-preview faces (a plain icon tile, a
+//! titled-but-blank switcher entry) are what shows - the same
+//! graceful degradation those renderers were designed for.
+
+use std::path::Path;
+
+use crate::state::Compositor;
+
+/// Refreshes the per-window snapshots used for previews. Called once
+/// per rendered frame; the implementation throttles its own work, so
+/// this stays affordable at frame rate.
+pub(crate) fn refresh_snapshots(_comp: &mut Compositor) {}
+
+// Staging: the screenshot path lands with the capture implementation
+// and its callers (a keybinding, and headless verification of a real
+// session); the allow keeps the build warning-free until then.
+#[allow(dead_code)]
+/// Writes the current output's contents to `path` as a PNG - the
+/// session's screenshot path, and the way a headless verifier (CI, a
+/// developer over SSH) sees what a DRM session is actually showing.
+pub(crate) fn capture_output_png(_comp: &mut Compositor, _path: &Path) -> Result<(), String> {
+    Err("output capture is not built yet".to_string())
+}

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -24,8 +24,10 @@
 #![cfg(target_os = "linux")]
 
 mod backend_impl;
+mod capture;
 mod input;
 mod renderer;
+mod session;
 mod state;
 mod xdg;
 mod xwayland;

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -38,7 +38,7 @@ use smithay::wayland::compositor::with_states;
 
 use wm_theme_api::Rect;
 
-use crate::state::{Compositor, RootBackground, StackEntry, WaylandBackend};
+use crate::state::{Compositor, Graphics, RootBackground, StackEntry, WaylandBackend};
 
 render_elements! {
     /// Everything one frame is composed of. The macro generates the
@@ -56,128 +56,79 @@ render_elements! {
 /// flag. Failures log and leave the damage flag set — the next wakeup
 /// simply tries again, which is the only sane recovery for a transient
 /// GL hiccup.
-pub(crate) fn render_frame(comp: &mut Compositor) {
-    // Disjoint field borrows: the winit backend (renderer +
-    // framebuffer) mutates while the ledger is read — both live on
-    // `Compositor`, so destructure instead of going through `&mut
-    // self` methods.
-    let Compositor {
-        wm,
-        winit_backend,
-        damage_tracker,
-        output,
+/// The scene, front to back (the damage tracker's convention: earlier
+/// elements occlude later ones) — and the single definition of what a
+/// chonkstep Wayland session looks like. Both backends submit exactly
+/// these elements: the nested winit one and the DRM/KMS session render
+/// the same desktop because they share this function, not because two
+/// implementations were kept in agreement. Returns the elements plus
+/// the clear color the root background asks for.
+pub(crate) fn build_scene(
+    backend: &WaylandBackend,
+    renderer: &mut GlesRenderer,
+    pointer_location: SPoint<f64, smithay::utils::Logical>,
+    cursor_status: &CursorImageStatus,
+    default_cursor: &smithay::backend::renderer::element::memory::MemoryRenderBuffer,
+) -> (Vec<SceneElement<GlesRenderer>>, Color32F) {
+    // Elements are assembled FRONT to BACK — the damage tracker's
+    // convention (first element occludes later ones) — so this walk is
+    // the module-doc composition order reversed: cursor, above-shells,
+    // override-redirect windows, frames, below-shells, wallpaper.
+    let mut elements: Vec<SceneElement<GlesRenderer>> = Vec::new();
+
+    push_cursor_elements(
+        &mut elements,
+        renderer,
         pointer_location,
         cursor_status,
         default_cursor,
-        start_time,
-        ..
-    } = comp;
+    );
 
-    {
-        let (renderer, mut framebuffer) = match winit_backend.bind() {
-            Ok(bound) => bound,
-            Err(error) => {
-                tracing::warn!(?error, "could not bind the winit framebuffer; skipping frame");
-                return;
-            }
-        };
-
-        let backend = wm.backend();
-
-        // Elements are assembled FRONT to BACK — the damage tracker's
-        // convention (first element occludes later ones) — so this
-        // walk is the module-doc composition order reversed: cursor,
-        // above-shells, override-redirect windows, frames, below-
-        // shells, wallpaper.
-        let mut elements: Vec<SceneElement<GlesRenderer>> = Vec::new();
-
-        push_cursor_elements(
-            &mut elements,
-            renderer,
-            *pointer_location,
-            cursor_status,
-            default_cursor,
-        );
-
-        for entry in backend.stacking.iter().rev() {
-            if let StackEntry::Shell(id) = entry {
-                let Some(record) = backend.shells.get(id) else { continue };
-                if record.above && record.mapped {
-                    push_shell_elements(&mut elements, renderer, record);
-                }
+    for entry in backend.stacking.iter().rev() {
+        if let StackEntry::Shell(id) = entry {
+            let Some(record) = backend.shells.get(id) else { continue };
+            if record.above && record.mapped {
+                push_shell_elements(&mut elements, renderer, record);
             }
         }
+    }
 
-        // XWayland override-redirect windows (menus, tooltips —
-        // `WindowType::Unmanaged`, so they own no frame and no
-        // stacking entry) draw above every managed frame, which is
-        // where the X server would put a just-mapped override-redirect
-        // window in practice.
-        for record in backend.windows.values() {
-            if record.window_type == wm_core::WindowType::Unmanaged && record.mapped {
-                push_window_content(&mut elements, renderer, record.content, record);
-            }
+    // XWayland override-redirect windows (menus, tooltips —
+    // `WindowType::Unmanaged`, so they own no frame and no
+    // stacking entry) draw above every managed frame, which is
+    // where the X server would put a just-mapped override-redirect
+    // window in practice.
+    for record in backend.windows.values() {
+        if record.window_type == wm_core::WindowType::Unmanaged && record.mapped {
+            push_window_content(&mut elements, renderer, record.content, record);
         }
+    }
 
-        for entry in backend.stacking.iter().rev() {
-            if let StackEntry::Frame(id) = entry {
-                let Some(frame) = backend.frames.get(id) else { continue };
-                if !frame.mapped {
-                    continue;
-                }
-                let window = backend.windows.get(&frame.window);
-                // Content above chrome: the client's tree first
-                // (front-to-back), then the decoration buffer. A
-                // shaded window keeps its frame mapped with the
-                // content unmapped (`set_client_mapped(false)`), which
-                // falls out naturally here.
-                if let Some(record) = window {
-                    if record.mapped {
-                        push_window_content(&mut elements, renderer, record.content, record);
-                    }
-                }
-                if let Some(buffer) = &frame.buffer {
-                    let location = SPoint::<f64, Physical>::from((
-                        frame.geometry.pos.x as f64,
-                        frame.geometry.pos.y as f64,
-                    ));
-                    match MemoryRenderBufferRenderElement::from_buffer(
-                        renderer,
-                        location,
-                        buffer,
-                        None,
-                        None,
-                        None,
-                        Kind::Unspecified,
-                    ) {
-                        Ok(element) => elements.push(element.into()),
-                        Err(error) => tracing::warn!(?error, "failed to import a decoration buffer"),
-                    }
+    for entry in backend.stacking.iter().rev() {
+        if let StackEntry::Frame(id) = entry {
+            let Some(frame) = backend.frames.get(id) else { continue };
+            if !frame.mapped {
+                continue;
+            }
+            let window = backend.windows.get(&frame.window);
+            // Content above chrome: the client's tree first
+            // (front-to-back), then the decoration buffer. A
+            // shaded window keeps its frame mapped with the
+            // content unmapped (`set_client_mapped(false)`), which
+            // falls out naturally here.
+            if let Some(record) = window {
+                if record.mapped {
+                    push_window_content(&mut elements, renderer, record.content, record);
                 }
             }
-        }
-
-        for entry in backend.stacking.iter().rev() {
-            if let StackEntry::Shell(id) = entry {
-                let Some(record) = backend.shells.get(id) else { continue };
-                if !record.above && record.mapped {
-                    push_shell_elements(&mut elements, renderer, record);
-                }
-            }
-        }
-
-        // Root background. A solid color is simply the clear color —
-        // with full-frame damage every pixel gets cleared, so no
-        // element is needed; a wallpaper image is the bottom-most
-        // element over a black clear.
-        let clear_color = match &backend.root_background {
-            RootBackground::Color((r, g, b)) => {
-                Color32F::new(*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0, 1.0)
-            }
-            RootBackground::Image(buffer) => {
+            if let Some(buffer) = &frame.buffer {
+                let location = SPoint::<f64, Physical>::from((
+                    frame.geometry.pos.x as f64,
+                    frame.geometry.pos.y as f64,
+                ));
                 match MemoryRenderBufferRenderElement::from_buffer(
                     renderer,
-                    SPoint::<f64, Physical>::from((0.0, 0.0)),
+                    location,
                     buffer,
                     None,
                     None,
@@ -185,34 +136,63 @@ pub(crate) fn render_frame(comp: &mut Compositor) {
                     Kind::Unspecified,
                 ) {
                     Ok(element) => elements.push(element.into()),
-                    Err(error) => tracing::warn!(?error, "failed to import the wallpaper buffer"),
+                    Err(error) => tracing::warn!(?error, "failed to import a decoration buffer"),
                 }
-                Color32F::new(0.0, 0.0, 0.0, 1.0)
             }
-        };
-
-        // Age 0 = "assume every pixel stale": the deliberate
-        // full-frame redraw described in the module docs.
-        if let Err(error) =
-            damage_tracker.render_output(renderer, &mut framebuffer, 0, &elements, clear_color)
-        {
-            tracing::warn!(?error, "render failed; keeping damage for a retry");
-            return;
         }
     }
 
-    let size = winit_backend.window_size();
-    if let Err(error) = winit_backend.submit(Some(&[SRect::from_size(size)])) {
-        tracing::warn!(?error, "swap failed; keeping damage for a retry");
-        return;
+    for entry in backend.stacking.iter().rev() {
+        if let StackEntry::Shell(id) = entry {
+            let Some(record) = backend.shells.get(id) else { continue };
+            if !record.above && record.mapped {
+                push_shell_elements(&mut elements, renderer, record);
+            }
+        }
     }
 
+    // Root background. A solid color is simply the clear color —
+    // with full-frame damage every pixel gets cleared, so no
+    // element is needed; a wallpaper image is the bottom-most
+    // element over a black clear.
+    let clear_color = match &backend.root_background {
+        RootBackground::Color((r, g, b)) => {
+            Color32F::new(*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0, 1.0)
+        }
+        RootBackground::Image(buffer) => {
+            match MemoryRenderBufferRenderElement::from_buffer(
+                renderer,
+                SPoint::<f64, Physical>::from((0.0, 0.0)),
+                buffer,
+                None,
+                None,
+                None,
+                Kind::Unspecified,
+            ) {
+                Ok(element) => elements.push(element.into()),
+                Err(error) => tracing::warn!(?error, "failed to import the wallpaper buffer"),
+            }
+            Color32F::new(0.0, 0.0, 0.0, 1.0)
+        }
+    };
+
+    (elements, clear_color)
+}
+
+/// Tells every mapped surface which frame it just appeared in —
+/// clients gate their next commit on these, so a session that never
+/// sends them freezes after one frame. Shared by both backends for
+/// exactly that reason.
+pub(crate) fn send_frame_callbacks(
+    backend: &WaylandBackend,
+    output: &smithay::output::Output,
+    cursor_status: &CursorImageStatus,
+    elapsed: Duration,
+) {
     // Frame callbacks: clients gate their next commit on these, so
     // every mapped window (and its popups, and a client-provided
     // cursor surface) hears about the frame it just appeared in. The
     // throttle mirrors smithay's reference compositors.
-    let elapsed = start_time.elapsed();
-    let backend: &WaylandBackend = wm.backend();
     for record in backend.windows.values() {
         if !record.mapped || !record.surface.alive() {
             continue;
@@ -238,6 +218,76 @@ pub(crate) fn render_frame(comp: &mut Compositor) {
         });
     }
 
+}
+
+/// Draws one frame through whichever backend this session is running
+/// on. The submission halves differ (a winit swap versus a DRM page
+/// flip) and live with their backends; everything visible above them
+/// is [`build_scene`].
+pub(crate) fn render_frame(comp: &mut Compositor) {
+    // Window previews for the switcher and icon tiles, refreshed off
+    // the same cadence as drawing and throttled internally.
+    crate::capture::refresh_snapshots(comp);
+    match comp.graphics {
+        Graphics::Session(_) => crate::session::render_frame_session(comp),
+        Graphics::Winit(_) => render_frame_winit(comp),
+    }
+}
+
+fn render_frame_winit(comp: &mut Compositor) {
+    // Disjoint field borrows: the winit backend (renderer +
+    // framebuffer) mutates while the ledger is read — both live on
+    // `Compositor`, so destructure instead of going through `&mut
+    // self` methods.
+    let Compositor {
+        wm,
+        graphics,
+        damage_tracker,
+        output,
+        pointer_location,
+        cursor_status,
+        default_cursor,
+        start_time,
+        ..
+    } = comp;
+    let Graphics::Winit(winit_backend) = graphics else {
+        return;
+    };
+
+    {
+        let (renderer, mut framebuffer) = match winit_backend.bind() {
+            Ok(bound) => bound,
+            Err(error) => {
+                tracing::warn!(?error, "could not bind the winit framebuffer; skipping frame");
+                return;
+            }
+        };
+
+        let (elements, clear_color) = build_scene(
+            wm.backend(),
+            renderer,
+            *pointer_location,
+            cursor_status,
+            default_cursor,
+        );
+
+        // Age 0 = "assume every pixel stale": the deliberate
+        // full-frame redraw described in the module docs.
+        if let Err(error) =
+            damage_tracker.render_output(renderer, &mut framebuffer, 0, &elements, clear_color)
+        {
+            tracing::warn!(?error, "render failed; keeping damage for a retry");
+            return;
+        }
+    }
+
+    let size = winit_backend.window_size();
+    if let Err(error) = winit_backend.submit(Some(&[SRect::from_size(size)])) {
+        tracing::warn!(?error, "swap failed; keeping damage for a retry");
+        return;
+    }
+
+    send_frame_callbacks(wm.backend(), output, cursor_status, start_time.elapsed());
     wm.backend_mut().damage = false;
 }
 

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -1,0 +1,59 @@
+//! The hardware session: DRM/KMS, GBM, libinput, and libseat - what
+//! makes `chonkstep-wayland` a desktop you log into from a TTY rather
+//! than a window inside somebody else's.
+//!
+//! This module owns everything about running on real hardware and
+//! nothing about how the desktop looks: it opens the seat, finds the
+//! graphics device, drives mode setting and page flips, pumps input
+//! devices, and hands VT switches back and forth with logind. The
+//! pixels come from [`crate::renderer::build_scene`], the same
+//! function the nested backend submits, which is why the two sessions
+//! cannot drift apart visually.
+//!
+//! Interim skeleton: the real implementation is being built against
+//! this exact API, and until it lands `init` fails cleanly so a TTY
+//! launch says what is missing instead of crashing.
+
+use smithay::output::Output;
+use smithay::reexports::calloop::LoopHandle;
+use smithay::reexports::wayland_server::DisplayHandle;
+use wm_theme_api::Size;
+
+use crate::state::{Compositor, Graphics};
+
+/// Everything the session backend owns while it runs: the seat, the
+/// DRM device and its GBM allocator, the EGL/GLES renderer, the
+/// per-output DRM compositors, and the input backend. Opaque to the
+/// rest of the crate on purpose - only [`init`] and
+/// [`render_frame_session`] reach inside.
+pub(crate) struct SessionGraphics {
+    _private: (),
+}
+
+/// What [`init`] hands back to `run`: the graphics stack plus the
+/// output it discovered, already configured with its mode. Any event
+/// sources the session needs (DRM page flips, libinput devices, udev
+/// hot-plug, seat activation) are registered on the loop by `init`
+/// itself.
+pub(crate) struct SessionInit {
+    pub graphics: Graphics,
+    pub output: Output,
+    pub output_size: Size,
+}
+
+/// Opens the seat and the graphics device and prepares the session.
+/// Errors here are fatal but explicable - no seat, no DRM device, no
+/// usable connector - and the binary reports them instead of dying
+/// silently on a black screen.
+pub(crate) fn init(
+    _loop_handle: &LoopHandle<'static, Compositor>,
+    _display_handle: &DisplayHandle,
+) -> Result<SessionInit, Box<dyn std::error::Error>> {
+    Err("the DRM/KMS session backend is not built yet; run nested inside an existing desktop, \
+         or set CHONKSTEP_BACKEND=winit"
+        .into())
+}
+
+/// Draws one frame onto the hardware: [`crate::renderer::build_scene`]
+/// through the session's renderer, submitted as a page flip.
+pub(crate) fn render_frame_session(_comp: &mut Compositor) {}

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -67,7 +67,7 @@ use wm_core::{
     Backend, BackendEvent, FocusPolicy, KeyCombo, MouseButton, WindowManager, WindowType,
 };
 use wm_theme::{RasterThemeEngine, Theme};
-use wm_theme_api::{Point, Rect, Size};
+use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
 
 use chonk_shell::shell::{Shell, ShellOutcome};
 use chonk_shell::theme_select;
@@ -181,6 +181,12 @@ pub(crate) struct WindowRecord {
     /// XWayland windows (menus, tooltips) come through as `Unmanaged`
     /// and are rendered as-is with no frame.
     pub window_type: WindowType,
+    /// Most recent preview of this window's contents, refreshed by
+    /// [`crate::capture`] while rendering and served back through
+    /// `Backend::capture_window_image`. `None` until the first
+    /// snapshot (or forever, for a window that never maps), which the
+    /// shell's icon and switcher renderers already handle.
+    pub snapshot: Option<DecorationBuffer>,
 }
 
 impl WindowRecord {
@@ -195,6 +201,7 @@ impl WindowRecord {
             title: None,
             app_id: None,
             window_type: WindowType::Normal,
+            snapshot: None,
         }
     }
 }
@@ -374,6 +381,21 @@ const HOUSEKEEPING_INTERVAL: Duration = Duration::from_millis(16);
 /// must live on a single struct. Fields are `pub` (not `pub(crate)`)
 /// only where the re-exported API surface needs them; the protocol
 /// handler modules are in-crate and reach everything either way.
+/// Which graphics stack this session is driving. The two arms are the
+/// same desktop with different plumbing underneath: `Winit` renders
+/// into a window on somebody else's desktop (the development and
+/// preview mode), `Session` owns a DRM/KMS device, its outputs, and
+/// its input devices through libseat (the real login session). The
+/// scene they draw is one function, [`crate::renderer::build_scene`],
+/// so the choice never reaches anything visual.
+pub(crate) enum Graphics {
+    Winit(WinitGraphicsBackend<GlesRenderer>),
+    // Constructed by `session::init` once the DRM backend lands; the
+    // allow keeps the staged build warning-free until then.
+    #[allow(dead_code)]
+    Session(Box<crate::session::SessionGraphics>),
+}
+
 pub struct Compositor {
     /// The policy brain, owning the [`WaylandBackend`] ledger. Protocol
     /// handlers reach the ledger through `self.wm.backend_mut()`.
@@ -417,9 +439,8 @@ pub struct Compositor {
     /// the shell spawns find it.
     pub xdisplay: Option<u32>,
 
-    /// The nested development backend: the host window this session
-    /// renders into, with its EGL context and GLES renderer.
-    pub winit_backend: WinitGraphicsBackend<GlesRenderer>,
+    /// The graphics stack: a host window, or the hardware itself.
+    pub(crate) graphics: Graphics,
     pub damage_tracker: OutputDamageTracker,
 
     /// Latest pointer position in compositor space, maintained by
@@ -639,20 +660,19 @@ impl Compositor {
 /// place on a requested restart. The Wayland analogue of everything
 /// `crates/chonkstep/src/main.rs` does after config load — read that
 /// file for the loop-order rationale this mirrors.
+/// Whether some other desktop is already running here to nest inside.
+/// A bare TTY login has neither variable set; a terminal inside
+/// Hyprland, GNOME, or an X session has at least one.
+fn nesting_desktop_present() -> bool {
+    std::env::var_os("WAYLAND_DISPLAY").is_some() || std::env::var_os("DISPLAY").is_some()
+}
+
 pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut event_loop: EventLoop<Compositor> = EventLoop::try_new()?;
     let loop_handle = event_loop.handle();
 
     let display: Display<Compositor> = Display::new()?;
     let display_handle = display.handle();
-
-    // The nested development backend: a host window with an EGL
-    // context and GLES renderer. Real-hardware DRM/KMS waits on the
-    // `session` feature.
-    let (winit_backend, winit_source) =
-        winit::init::<GlesRenderer>().map_err(|error| format!("winit backend init failed: {error}"))?;
-    let window_size = winit_backend.window_size();
-    let output_size = Size::new(window_size.w.max(0) as u32, window_size.h.max(0) as u32);
 
     // Wayland globals. Each `new::<Compositor>` registers the global
     // against the delegate impls in `xdg.rs`/`input.rs`/`xwayland.rs`.
@@ -671,28 +691,98 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let mut seat: Seat<Compositor> = seat_state.new_wl_seat(&display_handle, "chonkstep");
     // Keyboard and pointer are assumed present — this is a desktop
     // compositor; hot-plug tracking can come with the session backend.
-    seat.add_keyboard(XkbConfig::default(), 200, 25)
+    // Keyboard layout from the environment, using libxkbcommon's own
+    // XKB_DEFAULT_* convention: a session started from a TTY has no
+    // desktop settings daemon to ask, and a compositor that hardcodes
+    // a US layout is unusable for everyone else. `scripts/wayland-
+    // session.sh` is where a login session sets these; the nested
+    // backend inherits whatever the host desktop already exported.
+    let xkb_env = |name: &str| std::env::var(name).ok().filter(|value| !value.is_empty());
+    let xkb_rules = xkb_env("XKB_DEFAULT_RULES").unwrap_or_default();
+    let xkb_model = xkb_env("XKB_DEFAULT_MODEL").unwrap_or_default();
+    let xkb_layout = xkb_env("XKB_DEFAULT_LAYOUT").unwrap_or_default();
+    let xkb_variant = xkb_env("XKB_DEFAULT_VARIANT").unwrap_or_default();
+    let xkb_options = xkb_env("XKB_DEFAULT_OPTIONS");
+    let xkb_config = XkbConfig {
+        rules: &xkb_rules,
+        model: &xkb_model,
+        layout: &xkb_layout,
+        variant: &xkb_variant,
+        options: xkb_options.clone(),
+    };
+    seat.add_keyboard(xkb_config, 200, 25)
         .map_err(|error| format!("failed to initialize the seat keyboard: {error}"))?;
     seat.add_pointer();
 
-    // The single output, mirroring the winit window. Flipped180 is
-    // deliberately copied from Smithay's own winit references (anvil,
-    // smallvil): the winit EGL surface's coordinate origin differs
-    // from the output's, and this transform is how upstream squares
-    // the two.
-    let mode = Mode { size: window_size, refresh: 60_000 };
-    let output = Output::new(
-        "chonkstep".to_string(),
-        PhysicalProperties {
-            size: (0, 0).into(),
-            subpixel: Subpixel::Unknown,
-            make: "chonkstep".into(),
-            model: "winit".into(),
-        },
-    );
+    // Which kind of session this process is. Owning the hardware and
+    // living in a window on somebody else's desktop are the same
+    // desktop with different plumbing, so the choice is made here, at
+    // startup, rather than at build time - one binary has to serve
+    // both "I am logging in from a TTY" and "I am previewing this
+    // inside my existing desktop". `CHONKSTEP_BACKEND` forces the
+    // decision ("drm"/"session" or "winit"/"nested"); otherwise an
+    // existing `WAYLAND_DISPLAY` or `DISPLAY` means there is already a
+    // desktop here to nest inside, and their absence means a bare TTY.
+    let nested = match std::env::var("CHONKSTEP_BACKEND").ok().as_deref() {
+        Some("winit") | Some("nested") => true,
+        Some("drm") | Some("session") => false,
+        Some(other) => {
+            tracing::warn!(backend = other, "unknown CHONKSTEP_BACKEND value; deciding automatically");
+            nesting_desktop_present()
+        }
+        None => nesting_desktop_present(),
+    };
+
+    let (graphics, output, output_size) = if nested {
+        tracing::info!("nested backend: rendering into a window on the host desktop");
+        let (winit_backend, winit_source) = winit::init::<GlesRenderer>()
+            .map_err(|error| format!("winit backend init failed: {error}"))?;
+        let window_size = winit_backend.window_size();
+
+        // Flipped180 is deliberately copied from Smithay's own winit
+        // references (anvil, smallvil): the winit EGL surface's
+        // coordinate origin differs from the output's, and this
+        // transform is how upstream squares the two. The session
+        // backend's outputs need no such correction, which is why the
+        // transform lives in this arm and not in the shared scene.
+        let mode = Mode { size: window_size, refresh: 60_000 };
+        let output = Output::new(
+            "chonkstep".to_string(),
+            PhysicalProperties {
+                size: (0, 0).into(),
+                subpixel: Subpixel::Unknown,
+                make: "chonkstep".into(),
+                model: "winit".into(),
+            },
+        );
+        output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
+        output.set_preferred(mode);
+
+        // Host-window events: input feeds the translation layer in
+        // `input.rs` (the seam where raw winit input becomes seat
+        // events plus `BackendEvent`s per the wm-x11 contract);
+        // everything else is resize/redraw/close plumbing.
+        loop_handle
+            .insert_source(winit_source, |event, _, comp| match event {
+                WinitEvent::Resized { size, .. } => comp.on_output_resized(size),
+                WinitEvent::Input(event) => crate::input::process_input_event(comp, event),
+                // The host asked us to repaint (the window was exposed
+                // or resized): full-frame damage, same as any scene
+                // change.
+                WinitEvent::Redraw => comp.wm.backend_mut().mark_damaged(),
+                WinitEvent::CloseRequested => comp.running = false,
+                WinitEvent::Focus(_) => {}
+            })
+            .map_err(|error| format!("failed to register the winit event source: {error}"))?;
+
+        let size = Size::new(window_size.w.max(0) as u32, window_size.h.max(0) as u32);
+        (Graphics::Winit(winit_backend), output, size)
+    } else {
+        tracing::info!("session backend: taking over the DRM device and input");
+        let init = crate::session::init(&loop_handle, &display_handle)?;
+        (init.graphics, init.output, init.output_size)
+    };
     let _global = output.create_global::<Compositor>(&display_handle);
-    output.change_current_state(Some(mode), Some(Transform::Flipped180), None, Some((0, 0).into()));
-    output.set_preferred(mode);
     let damage_tracker = OutputDamageTracker::from_output(&output);
 
     // The listening socket clients connect to, plus the display's own
@@ -770,22 +860,6 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     wm.set_placement_policy(config.placement);
     wm.set_snap_threshold(config.edge_resistance);
 
-    // Host-window events: input feeds the translation layer in
-    // `input.rs` (the seam where raw winit input becomes seat events
-    // plus `BackendEvent`s per the wm-x11 contract); everything else
-    // is resize/redraw/close plumbing handled right here.
-    loop_handle
-        .insert_source(winit_source, |event, _, comp| match event {
-            WinitEvent::Resized { size, .. } => comp.on_output_resized(size),
-            WinitEvent::Input(event) => crate::input::process_input_event(comp, event),
-            // The host asked us to repaint (the window was exposed or
-            // resized): full-frame damage, same as any scene change.
-            WinitEvent::Redraw => comp.wm.backend_mut().mark_damaged(),
-            WinitEvent::CloseRequested => comp.running = false,
-            WinitEvent::Focus(_) => {}
-        })
-        .map_err(|error| format!("failed to register the winit event source: {error}"))?;
-
     // XWayland: spawned here, attached (X11Wm::start_wm) when it
     // reports ready. Failure to start is a degraded session — X11
     // apps unavailable — not a dead one, so it logs instead of
@@ -847,7 +921,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         output,
         xwm: None,
         xdisplay: None,
-        winit_backend,
+        graphics,
         damage_tracker,
         pointer_location: (0.0, 0.0).into(),
         cursor_status: CursorImageStatus::default_named(),

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,18 +1,23 @@
 #!/usr/bin/env bash
-# Installs chonkstep on an Omarchy (or any Arch-based) system as a
-# selectable X11 session alongside the existing desktop. Nothing is
-# copied out of this checkout: the session entry points back into the
-# repo, so scripts/update.sh (git pull + rebuild + hot-restart) is the
-# whole upgrade story.
+# Installs chonkstep on an Omarchy (or any Arch-based) system, both
+# halves of it: the X11 session (a selectable session alongside the
+# existing desktop) and the Wayland compositor (nested, for now - see
+# the closing notes this prints). Nothing is copied out of this
+# checkout: the session entry points back into the repo, so
+# scripts/update.sh (git pull + rebuild + hot-restart) is the whole
+# upgrade story.
 #
 # What this does:
 #   1. Installs runtime dependencies with pacman (Xorg, the terminal,
-#      the compositor, the theme fonts) and a Rust toolchain if the
+#      the session compositor, the theme fonts, the Wayland stack the
+#      compositor builds and runs against) and a Rust toolchain if the
 #      system has none.
-#   2. Builds the release binaries.
+#   2. Builds the release binaries - chonkstep and chonkstep-wayland.
 #   3. Installs /usr/share/xsessions/chonkstep.desktop pointing at this
 #      checkout's scripts/xsession.sh, so chonkstep appears in the
-#      login manager's session picker.
+#      login manager's session picker. No wayland-sessions entry: the
+#      compositor has no DRM/KMS backend yet, so a login entry for it
+#      would fail the moment it was chosen.
 #
 # Usage: scripts/install.sh
 set -euo pipefail
@@ -38,10 +43,20 @@ echo "Installing dependencies (sudo)..."
 # The link instrument needs nothing extra: it prefers nmcli when the
 # system has NetworkManager and falls back to /sys/class/net on
 # anything else (Omarchy's iwd setup included).
+#
+# The last line is the Wayland half's build and runtime needs, and it
+# is not optional even for an X11-only user: the workspace build below
+# compiles wm-wayland on any Linux host, and that links against
+# libxkbcommon and EGL. libxkbcommon (keyboard layouts), libglvnd/mesa
+# (EGL/GLES for the compositor's renderer), xorg-xwayland (the
+# Xwayland binary the compositor spawns so X11 apps run in a Wayland
+# session). All four are already present on essentially any graphical
+# Arch system; --needed makes listing them free.
 sudo pacman -S --needed --noconfirm \
     xorg-server xorg-xinit xorg-xauth \
     rxvt-unicode picom wireplumber \
-    ttf-dejavu gsfonts ttf-jetbrains-mono-nerd noto-fonts
+    ttf-dejavu gsfonts ttf-jetbrains-mono-nerd noto-fonts \
+    libxkbcommon libglvnd mesa xorg-xwayland
 
 if ! command -v cargo >/dev/null 2>&1; then
     echo "Installing Rust toolchain..."
@@ -86,28 +101,58 @@ for dm in sddm gdm lightdm greetd lemurs ly; do
     fi
 done
 
+# Which display stack the user is on right now, so the advice below
+# names the path they can actually take today. Deliberately NOT used to
+# pick "the Wayland version" as their session: see the note printed
+# below - the compositor has no DRM/KMS backend yet, so it cannot own
+# a TTY the way Xorg does, and installing a wayland-sessions entry
+# would put a session in the login picker that fails the moment it is
+# chosen. That entry lands with the session feature, not before.
+session_type="${XDG_SESSION_TYPE:-}"
+if [ -z "$session_type" ] && [ -n "${WAYLAND_DISPLAY:-}" ]; then
+    session_type="wayland"
+fi
+
 cat <<DONE
 
-chonkstep is installed.
+chonkstep is installed - both binaries: chonkstep (X11) and
+chonkstep-wayland (the Smithay compositor).
 
 DONE
 if [ -n "$has_dm" ]; then
     cat <<DONE
-  - Log out and pick "chonkstep" in ${has_dm}'s session list.
+  - X11 session (the full desktop): log out and pick "chonkstep" in
+    ${has_dm}'s session list.
 DONE
 else
     cat <<DONE
-  - No display manager detected (stock Omarchy boots straight into
-    Hyprland). Switch to a TTY (Ctrl+Alt+F3), log in, and run:
+  - X11 session (the full desktop): no display manager is enabled
+    (stock Omarchy boots straight into Hyprland), so switch to a TTY
+    (Ctrl+Alt+F3), log in, and run:
       startx ${repo}/scripts/xsession.sh
-    To make chonkstep appear in a graphical session picker instead,
-    install and enable a display manager (e.g. sddm) - the session
-    entry is already in place.
+    To get a graphical session picker instead, install and enable a
+    display manager (e.g. sddm) - the session entry is already in place.
+DONE
+fi
+cat <<DONE
+  - Wayland: run the compositor nested inside your current desktop -
+      ${repo}/target/release/chonkstep-wayland
+    It opens a window that is its screen: same chrome, dock, menus, and
+    themes as the X11 session, with X11 apps running through XWayland.
+    Nested is the whole story today - the DRM/KMS session that would
+    make it a login option of its own is not built yet, which is why
+    this installer deliberately does not add a wayland-sessions entry.
+DONE
+if [ "$session_type" = "wayland" ]; then
+    cat <<DONE
+    (You are on a Wayland session right now, so the nested compositor
+    will run here as-is; the X11 session above needs the TTY route.)
 DONE
 fi
 cat <<DONE
   - HiDPI: set "scale = 2.0" in ${config}
-    (the whole file is optional and every line is documented).
+    (the whole file is optional and every line is documented; both
+    backends read it).
   - Update later with: scripts/update.sh
   - The session entry points at this checkout (${repo});
     moving the checkout means re-running scripts/install.sh.


### PR DESCRIPTION
Part 3 of 4. REVIEW ONLY, DO NOT MERGE - already on `main`.

`build_scene` becomes the single definition of the desktop's
appearance and the graphics backend is chosen at startup rather than
at build time; CI splits so the Wayland crates build where their
system libraries exist; the installer learns about the Wayland half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPsrCnhqdDRnMz1Z7iDUd4