### PR TITLE
Review 4/4: the DRM/KMS login session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,18 +86,29 @@ jobs:
 
   # The Wayland half of the dual architecture. There is no Xvfb
   # equivalent to smoke-test a compositor on a headless runner (the
-  # nested backend needs a host display), so this job's gate is the
-  # strictest thing CI can still do: build the compositor backend and
-  # its binary against the real system libraries, then run the
-  # backend's unit tests. The build step is the load-bearing one — the
-  # -sys crates under Smithay's winit/GLES path (libxkbcommon for the
-  # keymap machinery, EGL/GLES for the renderer, the Wayland client
-  # libraries winit itself links) resolve and link at build time, so a
-  # plain `cargo build` on Linux already proves what the macOS dev
-  # host, where this crate is cfg-empty, structurally cannot. Only the
-  # nested-session dependencies are installed: the `session` feature
-  # (DRM/KMS, libinput, libseat) is off by default and stays off here,
-  # which keeps this job light and honest about what it exercises.
+  # nested backend needs a host display, and the session backend needs
+  # a DRM device and a seat), so this job's gate is the strictest
+  # thing CI can still do: build the compositor backend and its binary
+  # against the real system libraries, then run the backend's unit
+  # tests. The build step is the load-bearing one — every -sys crate
+  # under the Smithay features this compositor pins resolves and links
+  # at build time, so a plain `cargo build` on Linux already proves
+  # what the macOS dev host, where this crate is cfg-empty,
+  # structurally cannot.
+  #
+  # Both backends are compiled in unconditionally (there is no cargo
+  # feature gating the session half — see wm-wayland/Cargo.toml), so
+  # this job installs the union of what they link: the nested/rendering
+  # set (libxkbcommon for the keymap machinery, EGL/GLES for the
+  # renderer, the Wayland client libraries winit itself links) plus the
+  # hardware-session set (libdrm for mode setting, libgbm for buffer
+  # allocation, libinput for devices, libudev for discovering them,
+  # libseat for opening them without root). The names are taken from
+  # Smithay 0.7.0's own CI, minus the ones for features this compositor
+  # does not enable — no libsystemd-dev/libdbus-1-dev (the logind
+  # session backend is not used; libseat's own logind support needs no
+  # build-time dependency), no libpixman-1-dev (renderer_pixman is
+  # off), no libdisplay-info-dev.
   wayland:
     runs-on: ubuntu-latest
     steps:
@@ -108,7 +119,9 @@ jobs:
       - name: Install Wayland build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libxkbcommon-dev libegl-dev libgles-dev libwayland-dev
+          sudo apt-get install -y \
+            libxkbcommon-dev libegl-dev libgles-dev libwayland-dev \
+            libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev
 
       # --locked: the compositor pins Smithay 0.7.0, and a silent
       # re-resolution here would test a different dependency tree than

--- a/README.md
+++ b/README.md
@@ -95,29 +95,36 @@ scripts/install.sh
 
 The installer pulls the runtime dependencies with pacman (Xorg,
 rxvt-unicode, picom, wireplumber for the sound instrument, the theme
-fonts, the Wayland stack the compositor builds and runs against -
-libxkbcommon, EGL/mesa, Xwayland - and a Rust toolchain if needed),
-builds both release binaries, installs a `chonkstep.desktop` session
-entry that points back into the checkout, and seeds
+fonts, the stack the Wayland compositor builds and runs against -
+libxkbcommon, EGL/mesa, Xwayland, and libdrm/libinput/libudev/libseat
+for the hardware session - and a Rust toolchain if needed), builds both
+release binaries, installs **two** session entries that point back into
+the checkout - `/usr/share/xsessions/chonkstep.desktop` and
+`/usr/share/wayland-sessions/chonkstep.desktop` - and seeds
 `~/.config/chonkstep/config.toml` from the fully-commented example if
 you don't have one.
 
-How you start it depends on the machine, and on which half you want:
+Both halves are real login sessions. How you start one depends on the
+machine, and on which you want:
 
-- **The X11 session** is the full daily-driver desktop. On **stock
-  Omarchy** there is no login-manager session picker (it boots straight
-  into Hyprland via autologin), so switch to a TTY (Ctrl+Alt+F3), log
-  in, and run `startx scripts/xsession.sh` from the checkout. On a
-  machine **with a display manager** (sddm, gdm, lightdm, ...), log out
-  and pick "chonkstep" in the session list.
-- **The Wayland compositor** runs nested inside whatever desktop you
-  are already in - `./target/release/chonkstep-wayland` from a
-  terminal - and is a preview rather than a login session today. See
-  [Wayland](#wayland) below for why, and for what it can already do.
-  Being on a Wayland desktop (as Omarchy is) does not change the
-  recommendation yet: until the DRM/KMS session lands, the X11 session
-  is the one you can log into, and the installer deliberately does not
-  register a Wayland session entry that would fail when chosen.
+- **With a display manager** (sddm, gdm, lightdm, ...), log out and
+  pick either "chonkstep" (X11) or "chonkstep (Wayland)" from the
+  session list.
+- **On stock Omarchy** there is no session picker at all (it boots
+  straight into Hyprland via autologin), so switch to a TTY
+  (Ctrl+Alt+F3), log in, and run either `startx scripts/xsession.sh`
+  or `exec scripts/wayland-session.sh` from the checkout. The Wayland
+  one needs no `startx`: the compositor *is* the display server, and it
+  takes the graphics device, the input devices, and the VT for itself.
+- **Nested**, for development or a look before you log in:
+  `./target/release/chonkstep-wayland` from a terminal inside your
+  current desktop opens a window that is its screen. See
+  [Wayland](#wayland) below.
+
+Seat access needs no setup on any systemd machine, Omarchy included -
+logind already hands the active session its devices. On a machine
+without logind, enable `seatd` and join the `seat` group; the installer
+prints this only when it finds logind missing.
 
 On a HiDPI display, set `scale = 2.0` in
 `~/.config/chonkstep/config.toml` - it scales chrome, dock, cursors,
@@ -146,29 +153,83 @@ is what keeps the two sessions identical: a feature or a fix lands
 once, in the shared crates, and both stacks get it by construction
 rather than by porting discipline.
 
-The Wayland side is the younger half, and its current shape is stated
-honestly: it runs today as a *nested* session for development. The
-compositor opens a regular window on your existing desktop (Wayland or
-X11, via Smithay's winit backend), and that window is its screen -
-chrome, dock, root menu, themes, and all. A true DRM/KMS session that
-owns the hardware from a TTY, the way Xorg does for the X11 side, is
-planned behind the crate's `session` feature but is not built yet.
+The Wayland side is the younger half, and it runs in two shapes from
+one binary. Which one it takes is decided at startup, not at build
+time: if there is already a desktop here to nest inside (an existing
+`WAYLAND_DISPLAY` or `DISPLAY`) it opens a window; if there is not - a
+bare TTY, a display manager's Wayland session - it takes the hardware.
+`CHONKSTEP_BACKEND=winit` or `=session` forces the choice.
 
-To run it nested, from a terminal on any desktop:
+**As a login session**, the compositor owns the machine the way Xorg
+does for the X11 side: it opens the seat through libseat (logind, or
+seatd where there is no logind), sets a mode on the DRM device, drives
+page flips through GBM and EGL, and reads real keyboards, mice, and
+touchpads through libinput and udev. Ctrl+Alt+F1..F12 switches VTs and
+the session hands its devices back and comes alive again on the way
+in, so the console is never more than a keystroke away. Pick
+"chonkstep (Wayland)" in your display manager's session list, or from a
+TTY:
+
+```sh
+exec scripts/wayland-session.sh
+```
+
+That script is the Wayland twin of `scripts/xsession.sh` - it is what
+the `wayland-sessions` entry points at, and it is also where you set
+your keyboard layout for a TTY login (`XKB_DEFAULT_LAYOUT` and
+friends; there is no settings daemon on a bare VT to ask). It starts no
+compositing manager, unlike the X11 script: the compositor composites
+itself, so the themes' translucent terminals are true alpha in the same
+GLES scene that draws the chrome.
+
+What the session backend does not do yet, stated plainly:
+
+- **One GPU, one output.** The primary DRM device and its first
+  connected connector are the session; a second monitor stays dark.
+  Nothing hot-plugs either: a GPU or a connector that appears
+  mid-session is logged and ignored, so docking a laptop means
+  restarting the session.
+- **No hardware cursor plane.** The pointer is drawn into the frame
+  like every other scene element rather than handed to the display
+  controller's own cursor plane, so it moves at the frame rate rather
+  than the mouse's.
+- **Restart costs you your clients.** The compositor does re-exec in
+  place - that is how the theme menu and `scripts/restart.sh` apply
+  changes on both backends - but Wayland clients die with the socket
+  they were connected to, and there is no SaveSet equivalent to adopt
+  them afterwards. The X11 session keeps your windows across a
+  restart; this one keeps only itself.
+- **No EWMH-analog protocols.** `wlr-foreign-toplevel-management`,
+  `wlr-output-management`, layer-shell, screencopy, idle-inhibit, and
+  DRM leasing are all absent, so external taskbars, pagers, bars,
+  screen recorders, and remote-desktop tools have nothing to talk to.
+  The X11 side's EWMH surface - which `wmctrl`, `xdotool`, and pagers
+  drive - has no counterpart here yet. The desktop's own dock, Clip,
+  and menus need none of it: they are drawn by the compositor, not by
+  clients.
+
+**Nested** remains the way to develop the compositor, and the way to
+look at it without logging out: it opens a regular window on your
+existing desktop (Wayland or X11, via Smithay's winit backend) and
+that window is its screen - chrome, dock, root menu, themes, and all.
+The two modes render through the same scene-building code and the same
+GLES renderer, which is why what you see nested is what you get on the
+hardware. From a terminal on any desktop:
 
 ```sh
 cargo build --release -p chonkstep-wayland
 ./target/release/chonkstep-wayland
 ```
 
-The compositor allocates its own Wayland socket and sets
+Either way, the compositor allocates its own Wayland socket and sets
 `WAYLAND_DISPLAY` (and `DISPLAY`, through XWayland) for everything it
 spawns, so applications launched from the root menu or the themed
-terminal land inside the nested session automatically. To aim a client
-at it from an outside terminal instead, point these variables at the
-socket names from the startup log - the Wayland socket is typically
-the first free slot (`wayland-1` when your host desktop holds
-`wayland-0`), and XWayland's display number is printed alongside it:
+terminal land inside the session automatically. To aim a client at a
+nested one from an outside terminal instead, point these variables at
+the socket names from the startup log - the Wayland socket is
+typically the first free slot (`wayland-1` when your host desktop
+holds `wayland-0`), and XWayland's display number is printed alongside
+it:
 
 ```sh
 WAYLAND_DISPLAY=wayland-1 some-wayland-app

--- a/crates/chonk-shell/src/lib.rs
+++ b/crates/chonk-shell/src/lib.rs
@@ -20,6 +20,7 @@ pub mod desktop;
 pub mod launchdock;
 pub mod shell;
 pub mod spawn;
+pub mod startup;
 pub mod theme_select;
 pub mod wallpaper;
 pub mod widgets;

--- a/crates/chonk-shell/src/startup.rs
+++ b/crates/chonk-shell/src/startup.rs
@@ -1,0 +1,219 @@
+//! Session policy: the handful of decisions a chonkstep session makes
+//! before it draws anything - how big the UI is, which theme it wears,
+//! whether focus follows the mouse - and, deliberately, the one place
+//! both binaries make them.
+//!
+//! These rules are the kind that quietly diverge. Each resolver
+//! combines an environment variable, a config-file value, and a
+//! built-in default, and every one of them was written for the X11
+//! session first; when the Wayland compositor grew its own startup it
+//! reimplemented two of them and dropped the environment layer from a
+//! third, so a machine with `CHONKSTEP_SCALE=2` in `/etc/environment`
+//! got a HiDPI X session and a tiny Wayland one. That is exactly the
+//! class of difference the shared-shell architecture exists to
+//! prevent, so the policy lives here with the rest of the shared
+//! desktop rather than in either binary.
+//!
+//! Every resolver splits into a thin `read_*` that touches the process
+//! environment and a pure `resolve_*` that does not: precedence logic
+//! stays unit-testable without `set_var`, which tests running in
+//! parallel threads of one process cannot use safely.
+
+use wm_theme::Theme;
+
+use crate::theme_select;
+
+/// UI scale. Precedence: `CHONKSTEP_SCALE` beats the config file's
+/// `scale`, which beats 1.0 (no scaling). The environment stays on top
+/// because session launchers and dev scripts use it to override a
+/// user's baseline per invocation.
+pub fn read_scale_factor(config_scale: Option<f32>) -> f32 {
+    resolve_scale(std::env::var("CHONKSTEP_SCALE").ok().as_deref(), config_scale)
+}
+
+/// Pure core of [`read_scale_factor`]. A value that fails validation -
+/// unparseable, non-finite, zero, or negative - is *skipped*, not
+/// clamped: a broken env var falls through to the config value and a
+/// broken config value falls through to 1.0, so a typo degrades to the
+/// next-best answer instead of a garbage scale or a dead session.
+pub fn resolve_scale(env: Option<&str>, config: Option<f32>) -> f32 {
+    let valid = |s: &f32| s.is_finite() && *s > 0.0;
+    env.and_then(|s| s.trim().parse::<f32>().ok())
+        .filter(valid)
+        .or_else(|| config.filter(valid))
+        .unwrap_or(1.0)
+}
+
+/// Whether to switch from click-to-focus to focus-follows-mouse.
+/// `CHONKSTEP_FOCUS_FOLLOWS_MOUSE` wins over the config file in *both*
+/// directions: set to anything other than `1` it forces the policy off
+/// even when the config asks for it, so a session script can pin
+/// either behavior. Only its total absence lets the config value
+/// apply.
+pub fn read_focus_follows_mouse(config_value: bool) -> bool {
+    resolve_focus_follows_mouse(
+        std::env::var("CHONKSTEP_FOCUS_FOLLOWS_MOUSE").ok().as_deref(),
+        config_value,
+    )
+}
+
+/// Pure core of [`read_focus_follows_mouse`].
+pub fn resolve_focus_follows_mouse(env: Option<&str>, config: bool) -> bool {
+    match env {
+        Some(value) => value == "1",
+        None => config,
+    }
+}
+
+/// The theme this session dresses in. Precedence: the persisted
+/// theme-menu choice wins over the config file's `theme`, which wins
+/// over the flagship default - the menu is the more recent, more
+/// deliberate gesture (picking a theme from it restarts on the spot),
+/// so a config line written once must not keep overriding it forever.
+///
+/// [`theme_select::load`] already implements the outer two layers
+/// (state file, else flagship); the config layer slots between them
+/// here rather than inside that module, which is a pure persist/recall
+/// mechanism the menu itself also uses. Which theme wins at *startup*
+/// is session policy.
+pub fn resolve_theme(config_theme: Option<&str>) -> Theme {
+    if !persisted_theme_choice_exists() {
+        if let Some(theme) = config_theme_fallback(config_theme) {
+            return theme;
+        }
+    }
+    theme_select::load()
+}
+
+/// The config-file layer of [`resolve_theme`], kept free of filesystem
+/// access so its edges are testable: `None` when no theme is
+/// configured, and - critically - `None` with a warning, not an error,
+/// when the configured id names a theme this build does not ship. A
+/// misspelled theme must cost the user the flagship look for one
+/// session, never the session itself.
+pub fn config_theme_fallback(config_theme: Option<&str>) -> Option<Theme> {
+    let requested = config_theme?;
+    let theme = wm_theme::default_theme::theme_by_id(requested);
+    if theme.is_none() {
+        tracing::warn!(theme = requested, "config names an unknown theme; using the default instead");
+    }
+    theme
+}
+
+/// `true` exactly when [`theme_select::load`] would return a persisted
+/// menu choice rather than its flagship fallback: the state file
+/// exists and names a theme this build still ships. Must stay in
+/// lockstep with `theme_select`'s own state path.
+pub fn persisted_theme_choice_exists() -> bool {
+    let path = if let Some(root) = std::env::var_os("XDG_STATE_HOME") {
+        std::path::PathBuf::from(root).join("chonkstep/theme")
+    } else if let Some(home) = std::env::var_os("HOME") {
+        std::path::PathBuf::from(home).join(".local/state/chonkstep/theme")
+    } else {
+        return false;
+    };
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|id| id.trim().to_string())
+        .is_some_and(|id| wm_theme::default_theme::theme_by_id(&id).is_some())
+}
+
+/// Sets `XCURSOR_SIZE` on this process (inherited by every app the
+/// session spawns) unless it is already set. Both sessions scale their
+/// own chrome and their own pointer, but an application that draws its
+/// *own* cursor through Xcursor - most toolkits, and every X11 client
+/// under XWayland - has no way to learn about that scale and reads
+/// this variable instead. Without it, such an app's cursor is visibly
+/// out of proportion the instant the pointer crosses onto its content.
+/// 24px is Xcursor's own conventional 1x base size.
+pub fn ensure_xcursor_size(scale: f32) {
+    if std::env::var_os("XCURSOR_SIZE").is_some() {
+        return;
+    }
+    let size = (24.0 * scale).round().max(1.0) as u32;
+    // SAFETY: called once at the very start of a session's startup,
+    // before any other thread exists, so no concurrent env access is
+    // possible.
+    unsafe {
+        std::env::set_var("XCURSOR_SIZE", size.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scale_defaults_to_one_with_neither_source() {
+        assert_eq!(resolve_scale(None, None), 1.0);
+    }
+    #[test]
+    fn unparseable_env_scale_falls_through_to_config() {
+        // A typo'd env var must degrade to the next-best answer, not to
+        // the hard default — the config value is still a deliberate
+        // user choice.
+        assert_eq!(resolve_scale(Some("garbage"), Some(1.5)), 1.5);
+    }
+    #[test]
+    fn out_of_range_env_scale_falls_through_to_config() {
+        assert_eq!(resolve_scale(Some("0"), Some(1.5)), 1.5);
+        assert_eq!(resolve_scale(Some("-2"), Some(1.5)), 1.5);
+        // `parse::<f32>` accepts these spellings; the validity filter
+        // must still reject them (a NaN scale poisons every pixel
+        // computation downstream).
+        assert_eq!(resolve_scale(Some("inf"), Some(1.5)), 1.5);
+        assert_eq!(resolve_scale(Some("NaN"), Some(1.5)), 1.5);
+    }
+    #[test]
+    fn invalid_config_scale_falls_through_to_default() {
+        assert_eq!(resolve_scale(None, Some(0.0)), 1.0);
+        assert_eq!(resolve_scale(None, Some(-1.0)), 1.0);
+        assert_eq!(resolve_scale(None, Some(f32::NAN)), 1.0);
+        assert_eq!(resolve_scale(None, Some(f32::INFINITY)), 1.0);
+    }
+    #[test]
+    fn both_sources_invalid_still_yields_a_usable_scale() {
+        // The end-to-end graceful-degradation guarantee: no combination
+        // of broken inputs may leave the session without a scale.
+        assert_eq!(resolve_scale(Some("bogus"), Some(-3.0)), 1.0);
+    }
+    #[test]
+    fn whitespace_around_env_scale_is_tolerated() {
+        assert_eq!(resolve_scale(Some(" 1.5 "), None), 1.5);
+    }
+    #[test]
+    fn env_focus_var_enables_over_config_off() {
+        assert!(resolve_focus_follows_mouse(Some("1"), false));
+    }
+    #[test]
+    fn env_focus_var_disables_over_config_on() {
+        // The env var wins in BOTH directions: any present value other
+        // than "1" pins the policy off regardless of the config.
+        assert!(!resolve_focus_follows_mouse(Some("0"), true));
+        assert!(!resolve_focus_follows_mouse(Some(""), true));
+        assert!(!resolve_focus_follows_mouse(Some("true"), true));
+    }
+    #[test]
+    fn config_focus_value_applies_without_env() {
+        assert!(resolve_focus_follows_mouse(None, true));
+        assert!(!resolve_focus_follows_mouse(None, false));
+    }
+    #[test]
+    fn config_theme_resolves_known_ids() {
+        for id in ["window-maker", "amber-phosphor", "teal-blueprint", "graphite", "next-lavender"] {
+            let theme = config_theme_fallback(Some(id));
+            assert_eq!(theme.map(|t| t.id), Some(id.to_string()), "built-in theme id {id} must resolve from config");
+        }
+    }
+    #[test]
+    fn unknown_config_theme_degrades_to_none() {
+        // `resolve_theme` then falls through to the flagship — a
+        // misspelled theme name must never cost the user the session.
+        assert!(config_theme_fallback(Some("no-such-theme")).is_none());
+        assert!(config_theme_fallback(Some("")).is_none());
+    }
+    #[test]
+    fn absent_config_theme_is_not_an_error() {
+        assert!(config_theme_fallback(None).is_none());
+    }
+}

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -12,11 +12,12 @@
 use std::time::Duration;
 
 use wm_core::{Backend, BackendEvent, FocusPolicy, WindowManager};
-use wm_theme::{RasterThemeEngine, Theme};
+use wm_theme::RasterThemeEngine;
 use wm_x11::X11Backend;
 
 use chonk_shell::shell::{Shell, ShellOutcome};
-use chonk_shell::{spawn, theme_select};
+use chonk_shell::startup::{ensure_xcursor_size, read_focus_follows_mouse, read_scale_factor, resolve_theme};
+use chonk_shell::spawn;
 
 fn main() {
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
@@ -310,142 +311,13 @@ fn exit_requested(outcome: ShellOutcome) -> bool {
     }
 }
 
-/// The UI scale multiplies every pixel dimension in the theme and the
-/// shell's own dock/icon chrome — for HiDPI displays (a nested X
-/// server has no display-scaling of its own, so the WM's native ~1990s
-/// pixel sizes read as tiny on a modern high-density panel).
-/// Precedence: the `CHONKSTEP_SCALE` env var wins over the config
-/// file's `scale`, which wins over 1.0 (no scaling) — the env var stays
-/// on top because scripts (`dev-nested.sh`, per-display session
-/// launchers) use it to override a user's baseline per invocation.
-fn read_scale_factor(config_scale: Option<f32>) -> f32 {
-    resolve_scale(std::env::var("CHONKSTEP_SCALE").ok().as_deref(), config_scale)
-}
 
-/// Pure core of [`read_scale_factor`], split out so the precedence
-/// rules are unit-testable without mutating process-global env vars
-/// (tests share one process and run on parallel threads; `set_var`
-/// races between them). A value that fails validation — unparseable,
-/// non-finite, zero, or negative — is *skipped*, not clamped: a broken
-/// env var falls through to the config value and a broken config value
-/// falls through to 1.0, so a typo degrades to the next-best answer
-/// instead of either a garbage scale or a dead session.
-fn resolve_scale(env: Option<&str>, config: Option<f32>) -> f32 {
-    let valid = |s: &f32| s.is_finite() && *s > 0.0;
-    env.and_then(|s| s.trim().parse::<f32>().ok())
-        .filter(valid)
-        .or_else(|| config.filter(valid))
-        .unwrap_or(1.0)
-}
 
-/// Sets `XCURSOR_SIZE` on *this* process (so it's inherited by every
-/// app chonkstep spawns, and by the hot-restarted process itself — see
-/// `restart_in_place`, which `exec`s in place and so keeps whatever env
-/// this process already has) unless it's already set. chonkstep scales
-/// its own chrome, decorations, and root cursor by `CHONKSTEP_SCALE`
-/// (see `wm-x11`'s `create_scaled_cursor`), but apps that draw their
-/// *own* cursor via the standard Xcursor mechanism (most modern
-/// toolkits — GTK, Qt, winit) have no way to know about that; they read
-/// this env var instead. Without it, such an app's cursor stays
-/// whatever Xcursor's own DPI-unaware default is — visibly out of
-/// proportion the instant the pointer crosses from chonkstep's chrome
-/// onto that app's own content. Doing this here, not only in
-/// `scripts/xsession.sh`, means it applies from the very first launch
-/// (including inside `dev-nested.sh`) rather than depending on every
-/// launcher remembering to set it — the shell scripts still set it too,
-/// for the rare case something else spawns before chonkstep does, but
-/// this is the one guaranteed to actually run.
-fn ensure_xcursor_size(scale: f32) {
-    if std::env::var_os("XCURSOR_SIZE").is_some() {
-        return;
-    }
-    let size = (24.0 * scale).round().max(1.0) as u32;
-    // SAFETY: called once, at the very start of `main`, before any
-    // other thread exists — no concurrent env access is possible yet.
-    unsafe {
-        std::env::set_var("XCURSOR_SIZE", size.to_string());
-    }
-}
 
-/// Whether to switch from the default click-to-focus to focus-follows-
-/// mouse. Precedence: the `CHONKSTEP_FOCUS_FOLLOWS_MOUSE` env var wins
-/// over the config file's `focus_follows_mouse` — and it wins in *both*
-/// directions: setting it to anything other than `1` forces the policy
-/// off even when the config asks for it, so a session script can pin
-/// either behavior regardless of what the user's config says. Only
-/// when the env var is absent entirely does the config value apply.
-fn read_focus_follows_mouse(config_value: bool) -> bool {
-    resolve_focus_follows_mouse(std::env::var("CHONKSTEP_FOCUS_FOLLOWS_MOUSE").ok().as_deref(), config_value)
-}
 
-/// Pure core of [`read_focus_follows_mouse`] — same testability
-/// rationale as [`resolve_scale`]: precedence logic stays out of reach
-/// of process-global env state so tests can cover every branch without
-/// racing each other on `set_var`.
-fn resolve_focus_follows_mouse(env: Option<&str>, config: bool) -> bool {
-    match env {
-        Some(value) => value == "1",
-        None => config,
-    }
-}
 
-/// Resolves the theme this session dresses in. Precedence: the
-/// persisted theme-menu choice (`theme_select`'s state file) wins over
-/// the config file's `theme`, which wins over the flagship default —
-/// the menu is the more recent, more deliberate gesture (picking a
-/// theme from it hot-restarts on the spot), so a config line written
-/// once must not keep overriding it on every subsequent restart.
-///
-/// `theme_select::load()` already implements the outer two layers
-/// (state file, else flagship); the config layer slots between them
-/// here rather than inside `theme_select` because that module is a pure
-/// persist/recall mechanism also used by the menu itself — which theme
-/// wins at *startup* is session policy, and session policy lives in
-/// the binary.
-fn resolve_theme(config_theme: Option<&str>) -> Theme {
-    if !persisted_theme_choice_exists() {
-        if let Some(theme) = config_theme_fallback(config_theme) {
-            return theme;
-        }
-    }
-    theme_select::load()
-}
 
-/// The config-file layer of [`resolve_theme`], split out (and kept free
-/// of filesystem access) so its edges are unit-testable: `None` when no
-/// theme is configured, and — critically — `None` with a warning, not a
-/// panic or an error, when the configured id names a theme this build
-/// does not ship. A misspelled theme must cost the user the flagship
-/// look for one session, never the session itself.
-fn config_theme_fallback(config_theme: Option<&str>) -> Option<Theme> {
-    let requested = config_theme?;
-    let theme = wm_theme::default_theme::theme_by_id(requested);
-    if theme.is_none() {
-        tracing::warn!(theme = requested, "config names an unknown theme; using the default instead");
-    }
-    theme
-}
 
-/// `true` exactly when `theme_select::load()` would return a persisted
-/// menu choice rather than its flagship fallback: the state file exists
-/// *and* names a theme this build ships (a stale id from another
-/// version does not count — it should fall through to the config layer,
-/// same as no file at all). The path mirrors `theme_select`'s own
-/// `state_path` on purpose and must stay in lockstep with it;
-/// `theme_select` deliberately does not expose "was it persisted?"
-/// because no other caller distinguishes the fallback from a choice.
-fn persisted_theme_choice_exists() -> bool {
-    let path = if let Some(root) = std::env::var_os("XDG_STATE_HOME") {
-        std::path::PathBuf::from(root).join("chonkstep/theme")
-    } else if let Some(home) = std::env::var_os("HOME") {
-        std::path::PathBuf::from(home).join(".local/state/chonkstep/theme")
-    } else {
-        return false;
-    };
-    std::fs::read_to_string(path)
-        .ok()
-        .is_some_and(|id| wm_theme::default_theme::theme_by_id(id.trim()).is_some())
-}
 
 /// Path to the marker file `scripts/restart.sh` touches to ask a
 /// running chonkstep to hot-restart itself — polled once per event-loop
@@ -489,112 +361,10 @@ fn restart_in_place() -> ! {
     std::process::exit(1);
 }
 
-// The precedence helpers are tested through their pure cores
-// (`resolve_scale`, `resolve_focus_follows_mouse`,
-// `config_theme_fallback`) rather than the env-reading wrappers: tests
-// share one process and run on parallel threads, so `set_var`-based
-// tests race each other — the split exists precisely so every branch is
-// reachable without touching process-global state.
 #[cfg(test)]
 mod tests {
-    use super::*;
     use wm_config::Action;
     use wm_core::KeyCombo;
-
-    #[test]
-    fn env_scale_wins_over_config_scale() {
-        assert_eq!(resolve_scale(Some("2.0"), Some(1.5)), 2.0);
-    }
-
-    #[test]
-    fn config_scale_applies_without_env() {
-        assert_eq!(resolve_scale(None, Some(1.5)), 1.5);
-    }
-
-    #[test]
-    fn scale_defaults_to_one_with_neither_source() {
-        assert_eq!(resolve_scale(None, None), 1.0);
-    }
-
-    #[test]
-    fn unparseable_env_scale_falls_through_to_config() {
-        // A typo'd env var must degrade to the next-best answer, not to
-        // the hard default — the config value is still a deliberate
-        // user choice.
-        assert_eq!(resolve_scale(Some("garbage"), Some(1.5)), 1.5);
-    }
-
-    #[test]
-    fn out_of_range_env_scale_falls_through_to_config() {
-        assert_eq!(resolve_scale(Some("0"), Some(1.5)), 1.5);
-        assert_eq!(resolve_scale(Some("-2"), Some(1.5)), 1.5);
-        // `parse::<f32>` accepts these spellings; the validity filter
-        // must still reject them (a NaN scale poisons every pixel
-        // computation downstream).
-        assert_eq!(resolve_scale(Some("inf"), Some(1.5)), 1.5);
-        assert_eq!(resolve_scale(Some("NaN"), Some(1.5)), 1.5);
-    }
-
-    #[test]
-    fn invalid_config_scale_falls_through_to_default() {
-        assert_eq!(resolve_scale(None, Some(0.0)), 1.0);
-        assert_eq!(resolve_scale(None, Some(-1.0)), 1.0);
-        assert_eq!(resolve_scale(None, Some(f32::NAN)), 1.0);
-        assert_eq!(resolve_scale(None, Some(f32::INFINITY)), 1.0);
-    }
-
-    #[test]
-    fn both_sources_invalid_still_yields_a_usable_scale() {
-        // The end-to-end graceful-degradation guarantee: no combination
-        // of broken inputs may leave the session without a scale.
-        assert_eq!(resolve_scale(Some("bogus"), Some(-3.0)), 1.0);
-    }
-
-    #[test]
-    fn whitespace_around_env_scale_is_tolerated() {
-        assert_eq!(resolve_scale(Some(" 1.5 "), None), 1.5);
-    }
-
-    #[test]
-    fn env_focus_var_enables_over_config_off() {
-        assert!(resolve_focus_follows_mouse(Some("1"), false));
-    }
-
-    #[test]
-    fn env_focus_var_disables_over_config_on() {
-        // The env var wins in BOTH directions: any present value other
-        // than "1" pins the policy off regardless of the config.
-        assert!(!resolve_focus_follows_mouse(Some("0"), true));
-        assert!(!resolve_focus_follows_mouse(Some(""), true));
-        assert!(!resolve_focus_follows_mouse(Some("true"), true));
-    }
-
-    #[test]
-    fn config_focus_value_applies_without_env() {
-        assert!(resolve_focus_follows_mouse(None, true));
-        assert!(!resolve_focus_follows_mouse(None, false));
-    }
-
-    #[test]
-    fn config_theme_resolves_known_ids() {
-        for id in ["window-maker", "amber-phosphor", "teal-blueprint", "graphite", "next-lavender"] {
-            let theme = config_theme_fallback(Some(id));
-            assert_eq!(theme.map(|t| t.id), Some(id.to_string()), "built-in theme id {id} must resolve from config");
-        }
-    }
-
-    #[test]
-    fn unknown_config_theme_degrades_to_none() {
-        // `resolve_theme` then falls through to the flagship — a
-        // misspelled theme name must never cost the user the session.
-        assert!(config_theme_fallback(Some("no-such-theme")).is_none());
-        assert!(config_theme_fallback(Some("")).is_none());
-    }
-
-    #[test]
-    fn absent_config_theme_is_not_an_error() {
-        assert!(config_theme_fallback(None).is_none());
-    }
 
     /// Keeps `docs/config.example.toml` honest: the example is parsed
     /// with the real parser, must restate exactly the default bindings

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -11,28 +11,566 @@
 //! serves the most recent one. The shell asks for a preview at
 //! miniaturize time, by which point a snapshot is already waiting.
 //!
-//! Interim skeleton: the real offscreen-render implementation is being
-//! built against this exact API. Until it lands, snapshots stay empty
-//! and the shell's own no-preview faces (a plain icon tile, a
-//! titled-but-blank switcher entry) are what shows - the same
-//! graceful degradation those renderers were designed for.
+//! Both jobs here are the same three steps - build render elements,
+//! draw them into an offscreen GLES buffer, read the pixels back -
+//! and both run through `GlesRenderer`, which is the renderer on
+//! *both* graphics arms, so the nested backend and the DRM session
+//! share this code the way they share
+//! [`crate::renderer::build_scene`].
+//!
+//! Three facts about that readback, each of which costs an afternoon
+//! to rediscover:
+//!
+//! - **No vertical flip is needed.** `GlesRenderer::render` bakes a
+//!   180-degree flip into its projection, so scene y=0 lands at the
+//!   framebuffer's *bottom* in GL's coordinate system; `glReadPixels`
+//!   then reads bottom-up and hands back the scene's top row first.
+//!   The two cancel, which is exactly why smithay's `GlesMapping`
+//!   reports `flipped() == true`. The `Flipped180` transform the winit
+//!   output carries is a property of presenting to an EGL *surface*,
+//!   not of the scene, so an offscreen capture must not apply it - a
+//!   capture that copies the output transform comes out upside down on
+//!   the nested backend and correct on hardware, which is the worst
+//!   possible failure mode.
+//! - **`Fourcc::Abgr8888` is the RGBA byte order**, mapping to
+//!   `GL_RGBA`/`GL_UNSIGNED_BYTE`. `Argb8888` is BGRA and silently
+//!   swaps red and blue - the same trap `state.rs` documents for the
+//!   built-in cursor.
+//! - **The pixels come out premultiplied**, because the GLES frame
+//!   blends `ONE, ONE_MINUS_SRC_ALPHA` over a cleared buffer. That is
+//!   what `DecorationBuffer` means everywhere else in this codebase
+//!   and what `tiny_skia::Pixmap::from_vec` expects, so no conversion
+//!   pass is needed in either direction.
+//!
+//! Screenshots are poll-triggered from a marker file, the same
+//! mechanism (and for the same reason - no keybinding, no client, no
+//! X server required) as the hot-restart marker the dispatch loop
+//! polls:
+//!
+//! ```text
+//! touch ~/.local/state/chonkstep/screenshot
+//! ```
+//!
+//! is the whole interface. That writes `screenshot.png` next to the
+//! marker; writing a path into the marker instead
+//! (`echo /tmp/desk.png > ~/.local/state/chonkstep/screenshot`) sends
+//! the PNG there. This is how a developer over SSH sees what a DRM
+//! session is actually showing, with no X server and no Wayland client
+//! in the picture.
 
-use std::path::Path;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
-use crate::state::Compositor;
+use smithay::backend::allocator::Fourcc;
+use smithay::backend::renderer::damage::OutputDamageTracker;
+use smithay::backend::renderer::element::surface::render_elements_from_surface_tree;
+use smithay::backend::renderer::element::Kind;
+use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
+use smithay::backend::renderer::{Bind, Color32F, ExportMem, Offscreen};
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::utils::{Buffer as BufferCoords, Physical, Point as SPoint, Rectangle as SRect};
+use smithay::utils::{Size as SSize, Transform};
+
+use wm_core::WindowType;
+use wm_theme_api::{DecorationBuffer, Size};
+
+use crate::renderer::{build_scene, SceneElement};
+use crate::state::{Compositor, Graphics, WlWindowId};
+
+/// Longest edge of a stored snapshot. These feed 56-112px icon tiles
+/// and switcher thumbnails, both of which letterbox-scale whatever
+/// they are handed, so anything past this is pixels the shell will
+/// throw away - a full-resolution copy of every window once a second
+/// would be several megabytes of readback per second for no visible
+/// gain. Bilinear downscaling happens on the GPU during the capture
+/// render, not afterwards on the CPU.
+const MAX_SNAPSHOT_EDGE: u32 = 256;
+
+/// Minimum age of a snapshot before it is taken again. A preview is
+/// consumed at miniaturize time and in the switcher, neither of which
+/// needs live video; one second keeps a thumbnail plausibly current
+/// while costing one small offscreen render per window per second.
+const SNAPSHOT_INTERVAL: Duration = Duration::from_secs(1);
+
+/// How many windows may be captured in one frame. Reading pixels back
+/// out of the GPU is a synchronous stall, so a desktop with a dozen
+/// windows must not pay a dozen of them in the frame where their
+/// snapshots all come due at once. Capping the batch also staggers the
+/// fleet permanently: each window is stamped when it is actually
+/// captured, so windows that started in lockstep drift into separate
+/// frames and stay there.
+const MAX_SNAPSHOTS_PER_FRAME: usize = 2;
+
+thread_local! {
+    /// When each window was last snapshotted. This is throttle policy,
+    /// not ledger state - `wm-core` and the shell have no business
+    /// knowing the capture cadence, and `WindowRecord` should not grow
+    /// a field that only this module reads - so it lives here, keyed
+    /// by the same id the ledger uses, and is pruned against the
+    /// ledger on every pass so dead windows cannot accumulate.
+    /// Thread-local rather than a field because the compositor is
+    /// single-threaded by construction (one calloop, one data type).
+    static LAST_SNAPSHOT: RefCell<HashMap<WlWindowId, Instant>> = RefCell::new(HashMap::new());
+}
 
 /// Refreshes the per-window snapshots used for previews. Called once
 /// per rendered frame; the implementation throttles its own work, so
 /// this stays affordable at frame rate.
-pub(crate) fn refresh_snapshots(_comp: &mut Compositor) {}
+pub(crate) fn refresh_snapshots(comp: &mut Compositor) {
+    poll_screenshot_marker(comp);
 
-// Staging: the screenshot path lands with the capture implementation
-// and its callers (a keybinding, and headless verification of a real
-// session); the allow keeps the build warning-free until then.
-#[allow(dead_code)]
+    let now = Instant::now();
+    let due = due_windows(comp, now);
+    if due.is_empty() {
+        return;
+    }
+
+    // Disjoint field borrows: the renderer lives in `graphics` and the
+    // records live under `wm`, and both are needed at once - the same
+    // destructure `renderer::render_frame_winit` does, for the same
+    // reason (there is no `&mut self` method that could hand out both).
+    let Compositor { wm, graphics, .. } = comp;
+    let renderer = graphics_renderer(graphics);
+    for (window, surface, size) in due {
+        // Stamp before rendering, not after: a window whose capture
+        // fails (a client that just died, an unimportable buffer) must
+        // wait out the interval like any other, or it retries at frame
+        // rate forever.
+        LAST_SNAPSHOT.with(|last| last.borrow_mut().insert(window, now));
+        let Some(buffer) = snapshot_window(renderer, &surface, size) else {
+            continue;
+        };
+        if let Some(record) = wm.backend_mut().windows.get_mut(&window) {
+            record.snapshot = Some(buffer);
+        }
+    }
+}
+
 /// Writes the current output's contents to `path` as a PNG - the
 /// session's screenshot path, and the way a headless verifier (CI, a
 /// developer over SSH) sees what a DRM session is actually showing.
-pub(crate) fn capture_output_png(_comp: &mut Compositor, _path: &Path) -> Result<(), String> {
-    Err("output capture is not built yet".to_string())
+pub(crate) fn capture_output_png(comp: &mut Compositor, path: &Path) -> Result<(), String> {
+    let Compositor {
+        wm,
+        graphics,
+        pointer_location,
+        cursor_status,
+        default_cursor,
+        ..
+    } = comp;
+    let renderer = graphics_renderer(graphics);
+    let size = wm.backend().output_size;
+
+    // The same scene the frame about to be drawn will submit - cursor
+    // included, because "what is the session showing" includes where
+    // the pointer is.
+    let (elements, clear_color) = build_scene(
+        wm.backend(),
+        renderer,
+        *pointer_location,
+        cursor_status,
+        default_cursor,
+    );
+    let buffer = render_offscreen(renderer, &elements, size, 1.0, clear_color)
+        .ok_or_else(|| "offscreen render of the output failed".to_string())?;
+    write_png(buffer, path)
+}
+
+/// The GLES renderer behind whichever graphics stack is running —
+/// there is always exactly one, which is what makes capture
+/// backend-blind: a snapshot taken on hardware and one taken in a
+/// nested window go through identical code. `dmabuf.rs` carries the
+/// same three lines for the same reason; a shared helper would belong
+/// on `Graphics` itself, in `state.rs`.
+fn graphics_renderer(graphics: &mut Graphics) -> &mut GlesRenderer {
+    match graphics {
+        Graphics::Winit(backend) => backend.renderer(),
+        Graphics::Session(session) => session.renderer(),
+    }
+}
+
+/// The windows whose snapshot is stale - at most
+/// [`MAX_SNAPSHOTS_PER_FRAME`] of them - with everything the capture
+/// needs pulled out of the ledger up front (an owned surface handle
+/// and a size) so the render loop needs no further look-ups while the
+/// renderer is borrowed. Which windows a truncated batch picks is
+/// unspecified (hash order), and it does not need to be fair:
+/// everything left over is still due on the very next frame.
+///
+/// `Unmanaged` windows are skipped: XWayland override-redirect
+/// surfaces are menus and tooltips that own no frame, never
+/// miniaturize, and never appear in the switcher, so a preview of one
+/// could not be asked for.
+fn due_windows(comp: &Compositor, now: Instant) -> Vec<(WlWindowId, WlSurface, Size)> {
+    let backend = comp.wm.backend();
+    LAST_SNAPSHOT.with(|last| {
+        let mut last = last.borrow_mut();
+        last.retain(|window, _| backend.windows.contains_key(window));
+        backend
+            .windows
+            .iter()
+            .filter(|(_, record)| {
+                record.mapped
+                    && record.window_type != WindowType::Unmanaged
+                    && record.surface.alive()
+            })
+            .filter(|(window, _)| {
+                last.get(window)
+                    .is_none_or(|taken| now.duration_since(*taken) >= SNAPSHOT_INTERVAL)
+            })
+            .filter_map(|(window, record)| {
+                Some((*window, record.surface.wl_surface()?, record.content.size))
+            })
+            .take(MAX_SNAPSHOTS_PER_FRAME)
+            .collect()
+    })
+}
+
+/// Renders one window's client content into a downscaled RGBA buffer.
+///
+/// Only the toplevel's own surface tree is drawn - no decoration, and
+/// no xdg popups. That is the X11 contract this substitutes for:
+/// `XGetImage` on the *client* drawable returns the client's pixels,
+/// with the frame and any override-redirect menu being separate
+/// windows it never sees.
+///
+/// `source` is the ledger's content rect, so the capture covers what
+/// `wm-core` believes the window occupies rather than what the client
+/// most recently committed: a buffer that overruns the content rect
+/// (an unacknowledged resize) is cropped to it, and one that falls
+/// short leaves the remainder transparent. Both beat rescaling the
+/// thumbnail's aspect ratio out from under the shell mid-resize.
+fn snapshot_window(
+    renderer: &mut GlesRenderer,
+    surface: &WlSurface,
+    source: Size,
+) -> Option<DecorationBuffer> {
+    let (size, scale) = snapshot_target(source, MAX_SNAPSHOT_EDGE)?;
+    // The scene's own constructor, at capture scale: the GPU does the
+    // downscale as part of drawing, so there is exactly one code path
+    // that turns a wayland surface into pixels.
+    let elements: Vec<SceneElement<GlesRenderer>> = render_elements_from_surface_tree(
+        renderer,
+        surface,
+        SPoint::<i32, Physical>::from((0, 0)),
+        scale,
+        1.0,
+        Kind::Unspecified,
+    );
+    if elements.is_empty() {
+        // Nothing importable yet (a mapped window whose first buffer
+        // has not committed). Leave the previous snapshot in place.
+        return None;
+    }
+    // Transparent clear: whatever the surface tree does not cover
+    // stays empty, which the icon tile composites over its well floor
+    // and the switcher over its own backing - both better than a black
+    // border baked into the thumbnail.
+    render_offscreen(renderer, &elements, size, scale, Color32F::new(0.0, 0.0, 0.0, 0.0))
+}
+
+/// Draws `elements` into a fresh offscreen texture and downloads the
+/// result. `scale` must be the scale the elements were built at - the
+/// damage tracker re-derives each element's on-target geometry from
+/// it, so a mismatch silently crops or shrinks the capture.
+///
+/// A fresh [`OutputDamageTracker`] per call, at age 0, is deliberate:
+/// the target texture is new and therefore entirely stale, and a
+/// tracker carried across calls would compute incremental damage
+/// against a buffer that no longer exists and skip drawing outright.
+fn render_offscreen(
+    renderer: &mut GlesRenderer,
+    elements: &[SceneElement<GlesRenderer>],
+    size: Size,
+    scale: f64,
+    clear_color: Color32F,
+) -> Option<DecorationBuffer> {
+    if size.w == 0 || size.h == 0 {
+        return None;
+    }
+    let width = size.w as i32;
+    let height = size.h as i32;
+
+    let mut texture: GlesTexture = match renderer
+        .create_buffer(Fourcc::Abgr8888, SSize::<i32, BufferCoords>::from((width, height)))
+    {
+        Ok(texture) => texture,
+        Err(error) => {
+            tracing::warn!(?error, width, height, "could not allocate an offscreen capture buffer");
+            return None;
+        }
+    };
+    let mut framebuffer = match renderer.bind(&mut texture) {
+        Ok(framebuffer) => framebuffer,
+        Err(error) => {
+            tracing::warn!(?error, "could not bind the offscreen capture buffer");
+            return None;
+        }
+    };
+
+    let mut damage_tracker = OutputDamageTracker::new(
+        SSize::<i32, Physical>::from((width, height)),
+        scale,
+        Transform::Normal,
+    );
+    if let Err(error) =
+        damage_tracker.render_output(renderer, &mut framebuffer, 0, elements, clear_color)
+    {
+        tracing::warn!(?error, "offscreen capture render failed");
+        return None;
+    }
+
+    let region = SRect::from_size(SSize::<i32, BufferCoords>::from((width, height)));
+    let mapping = match renderer.copy_framebuffer(&framebuffer, region, Fourcc::Abgr8888) {
+        Ok(mapping) => mapping,
+        Err(error) => {
+            tracing::warn!(?error, "could not read back the offscreen capture buffer");
+            return None;
+        }
+    };
+    let pixels = match renderer.map_texture(&mapping) {
+        Ok(pixels) => pixels.to_vec(),
+        Err(error) => {
+            tracing::warn!(?error, "could not map the captured pixels");
+            return None;
+        }
+    };
+    Some(DecorationBuffer { width: size.w, height: size.h, pixels })
+}
+
+/// Encodes a captured buffer as a PNG. `tiny-skia` is already the
+/// rasterizer the theme engine draws with and takes premultiplied
+/// RGBA8 directly, so this needs no second image stack and no pixel
+/// conversion.
+fn write_png(buffer: DecorationBuffer, path: &Path) -> Result<(), String> {
+    let size = tiny_skia::IntSize::from_wh(buffer.width, buffer.height)
+        .ok_or_else(|| format!("captured size {}x{} is not encodable", buffer.width, buffer.height))?;
+    let pixmap = tiny_skia::Pixmap::from_vec(buffer.pixels, size)
+        .ok_or_else(|| "captured pixels do not match the captured size".to_string())?;
+    if let Some(parent) = path.parent() {
+        // A relative request resolves under the state directory, which
+        // may name a subdirectory that does not exist yet.
+        if let Err(error) = std::fs::create_dir_all(parent) {
+            return Err(format!("could not create {}: {error}", parent.display()));
+        }
+    }
+    pixmap
+        .save_png(path)
+        .map_err(|error| format!("could not write {}: {error}", path.display()))
+}
+
+/// Checks the screenshot marker and services it. Polled once per
+/// rendered frame, which means a session drawing nothing at all also
+/// answers nothing - in practice the shell's clock keeps frames coming
+/// on an otherwise idle desktop, and any session worth screenshotting
+/// is one where something is happening.
+///
+/// The marker is consumed *before* the capture runs, exactly as
+/// `state.rs`'s restart marker is: a capture that fails (an
+/// unwritable path, a renderer hiccup) must not re-fire on every
+/// frame until someone notices.
+fn poll_screenshot_marker(comp: &mut Compositor) {
+    let Some(state_dir) = state_dir(std::env::var_os("XDG_STATE_HOME"), std::env::var_os("HOME"))
+    else {
+        return;
+    };
+    let marker = state_dir.join("screenshot");
+    let Ok(request) = std::fs::read_to_string(&marker) else {
+        return;
+    };
+    if let Err(error) = std::fs::remove_file(&marker) {
+        // Left in place, the marker would fire again next frame.
+        tracing::warn!(?error, path = %marker.display(), "could not consume the screenshot marker");
+        return;
+    }
+
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let target = screenshot_target(&request, &state_dir, home.as_deref());
+    match capture_output_png(comp, &target) {
+        Ok(()) => tracing::info!(path = %target.display(), "screenshot written"),
+        Err(error) => tracing::warn!(%error, path = %target.display(), "screenshot failed"),
+    }
+}
+
+/// chonkstep's state directory, by the same precedence
+/// `state.rs`'s theme and restart markers use: `XDG_STATE_HOME` when
+/// set, else `~/.local/state`. Takes its environment as arguments so
+/// the precedence is testable without mutating process state.
+fn state_dir(xdg_state_home: Option<OsString>, home: Option<OsString>) -> Option<PathBuf> {
+    if let Some(root) = xdg_state_home.filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(root).join("chonkstep"));
+    }
+    home.filter(|value| !value.is_empty())
+        .map(|home| PathBuf::from(home).join(".local/state/chonkstep"))
+}
+
+/// Where a marker's contents ask the PNG to go. Empty (the `touch`
+/// case) means `screenshot.png` beside the marker; an absolute path is
+/// taken as-is; `~/...` expands against `home`; anything else resolves
+/// under the state directory rather than the compositor's working
+/// directory, which for a session started by a display manager is
+/// nowhere the user can predict.
+fn screenshot_target(request: &str, state_dir: &Path, home: Option<&Path>) -> PathBuf {
+    let request = request.trim();
+    if request.is_empty() {
+        return state_dir.join("screenshot.png");
+    }
+    if let Some(rest) = request.strip_prefix("~/") {
+        if let Some(home) = home {
+            return home.join(rest);
+        }
+    }
+    let path = PathBuf::from(request);
+    if path.is_absolute() {
+        path
+    } else {
+        state_dir.join(path)
+    }
+}
+
+/// The capture size and render scale for a window of `source` size:
+/// aspect preserved, longest edge capped at `max_edge`, never scaled
+/// up (a 64x64 window is worth exactly 64x64 of thumbnail). `None` for
+/// a degenerate window - a zero-sized capture has no valid GL
+/// framebuffer and nothing to show.
+fn snapshot_target(source: Size, max_edge: u32) -> Option<(Size, f64)> {
+    if source.w == 0 || source.h == 0 || max_edge == 0 {
+        return None;
+    }
+    let longest = source.w.max(source.h);
+    if longest <= max_edge {
+        return Some((source, 1.0));
+    }
+    let scale = max_edge as f64 / longest as f64;
+    // Rounding can take a very thin window's short edge to zero;
+    // clamping to one pixel keeps the buffer allocatable and the
+    // aspect ratio as close as a pixel grid allows.
+    let width = ((source.w as f64 * scale).round() as u32).max(1);
+    let height = ((source.h as f64 * scale).round() as u32).max(1);
+    Some((Size::new(width, height), scale))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The GPU halves of this module (the offscreen render, the
+    // readback, the PNG encode of a real frame) are not unit-testable
+    // here: they need an EGL context, which needs a graphics device.
+    // They are exercised by taking an actual screenshot of a running
+    // session - which is precisely the marker interface these tests
+    // cover the addressing half of.
+
+    #[test]
+    fn a_touched_marker_writes_beside_itself() {
+        let dir = Path::new("/home/ada/.local/state/chonkstep");
+        assert_eq!(
+            screenshot_target("", dir, None),
+            PathBuf::from("/home/ada/.local/state/chonkstep/screenshot.png")
+        );
+        // `touch` leaves an empty file, but an `echo` with nothing to
+        // say leaves a newline - both mean "the default place".
+        assert_eq!(
+            screenshot_target("\n  \n", dir, None),
+            PathBuf::from("/home/ada/.local/state/chonkstep/screenshot.png")
+        );
+    }
+
+    #[test]
+    fn an_absolute_request_is_taken_as_written() {
+        let dir = Path::new("/state/chonkstep");
+        // Trailing newline: `echo path > marker` is the whole gesture.
+        assert_eq!(
+            screenshot_target("/tmp/desk.png\n", dir, None),
+            PathBuf::from("/tmp/desk.png")
+        );
+    }
+
+    #[test]
+    fn a_tilde_request_expands_against_home() {
+        let dir = Path::new("/state/chonkstep");
+        let home = PathBuf::from("/home/ada");
+        assert_eq!(
+            screenshot_target("~/shots/desk.png", dir, Some(&home)),
+            PathBuf::from("/home/ada/shots/desk.png")
+        );
+        // With no home to expand against, the request stays relative
+        // and lands under the state directory rather than being
+        // silently dropped.
+        assert_eq!(
+            screenshot_target("~/shots/desk.png", dir, None),
+            PathBuf::from("/state/chonkstep/~/shots/desk.png")
+        );
+    }
+
+    #[test]
+    fn a_relative_request_resolves_under_the_state_directory() {
+        let dir = Path::new("/state/chonkstep");
+        assert_eq!(
+            screenshot_target("shots/now.png", dir, None),
+            PathBuf::from("/state/chonkstep/shots/now.png")
+        );
+    }
+
+    #[test]
+    fn the_state_directory_prefers_xdg_state_home() {
+        assert_eq!(
+            state_dir(Some("/xdg/state".into()), Some("/home/ada".into())),
+            Some(PathBuf::from("/xdg/state/chonkstep"))
+        );
+        assert_eq!(
+            state_dir(None, Some("/home/ada".into())),
+            Some(PathBuf::from("/home/ada/.local/state/chonkstep"))
+        );
+        // An empty variable is an unset variable here, not a request
+        // to write into the filesystem root.
+        assert_eq!(
+            state_dir(Some("".into()), Some("/home/ada".into())),
+            Some(PathBuf::from("/home/ada/.local/state/chonkstep"))
+        );
+        assert_eq!(state_dir(None, None), None);
+    }
+
+    #[test]
+    fn a_small_window_is_captured_at_its_own_size() {
+        let (size, scale) = snapshot_target(Size::new(200, 100), 256).unwrap();
+        assert_eq!(size, Size::new(200, 100));
+        assert_eq!(scale, 1.0);
+        // Exactly at the cap is still no upscale and no downscale.
+        let (size, scale) = snapshot_target(Size::new(256, 128), 256).unwrap();
+        assert_eq!(size, Size::new(256, 128));
+        assert_eq!(scale, 1.0);
+    }
+
+    #[test]
+    fn a_large_window_is_capped_on_its_long_edge_with_aspect_kept() {
+        let (size, scale) = snapshot_target(Size::new(1024, 768), 256).unwrap();
+        assert_eq!(size, Size::new(256, 192));
+        assert_eq!(scale, 0.25);
+
+        // Portrait caps on height, and the short edge rounds.
+        let (size, _) = snapshot_target(Size::new(1000, 2000), 256).unwrap();
+        assert_eq!(size, Size::new(128, 256));
+
+        let (size, _) = snapshot_target(Size::new(300, 100), 256).unwrap();
+        assert_eq!(size, Size::new(256, 85));
+    }
+
+    #[test]
+    fn an_extreme_aspect_ratio_still_yields_an_allocatable_buffer() {
+        // 1/5000 of 256 rounds to zero pixels; a zero-height GL
+        // framebuffer is not a thing.
+        let (size, _) = snapshot_target(Size::new(5000, 1), 256).unwrap();
+        assert_eq!(size, Size::new(256, 1));
+    }
+
+    #[test]
+    fn a_degenerate_window_is_not_captured() {
+        assert_eq!(snapshot_target(Size::new(0, 600), 256), None);
+        assert_eq!(snapshot_target(Size::new(800, 0), 256), None);
+        assert_eq!(snapshot_target(Size::new(800, 600), 0), None);
+    }
 }

--- a/crates/wm-wayland/src/dmabuf.rs
+++ b/crates/wm-wayland/src/dmabuf.rs
@@ -1,0 +1,275 @@
+//! Hardware buffers: the `zwp_linux_dmabuf_v1` global, which is how a
+//! GPU-accelerated client (Chromium, Firefox, mpv, anything drawing
+//! through GBM/EGL) hands us a *handle* to video memory instead of a
+//! CPU copy of it. Without this global those clients fall back to
+//! `wl_shm` — a full-frame readback and re-upload every frame, which
+//! is exactly what makes a compositor feel slow under video — and a
+//! few refuse outright, because their EGL platform code reads "no
+//! linux-dmabuf global" as "this compositor has no GPU".
+//!
+//! # Integration contract
+//!
+//! One call and one field, both in `state.rs`. Nothing else in the
+//! crate needs to know this module exists — the protocol side is
+//! entirely `delegate_dmabuf!` plus the [`DmabufHandler`] impl below,
+//! and the *render* side already works: `GlesRenderer` implements
+//! `ImportAll`, so a dmabuf-backed `wl_buffer` is imported by the
+//! ordinary `WaylandSurfaceRenderElement` path in `renderer.rs`
+//! without a line of special-casing.
+//!
+//! 1. In `run`, make the graphics binding mutable
+//!    (`let (mut graphics, output, output_size) = ...`) and add one
+//!    line directly after that `if nested { ... } else { ... }` block —
+//!    it must land *before* the `ListeningSocketSource` is inserted,
+//!    since a global that does not exist when a client binds might as
+//!    well not exist at all:
+//!
+//!    ```ignore
+//!    let dmabuf = crate::dmabuf::init_for_graphics(&display_handle, &mut graphics);
+//!    ```
+//!
+//! 2. `Compositor` gains one field, moved in from that local:
+//!
+//!    ```ignore
+//!    /// linux-dmabuf: the format set we advertise and the protocol
+//!    /// state behind it. Always present; "this renderer cannot do
+//!    /// dmabuf" is represented inside, not by an `Option`.
+//!    pub(crate) dmabuf: crate::dmabuf::DmabufSupport,
+//!    ```
+//!
+//! [`init_for_graphics`] never fails: a renderer with no dmabuf
+//! support yields a [`DmabufSupport`] that registered no global, so
+//! [`DmabufHandler::dmabuf_state`] can hand back a real `&mut` with no
+//! `expect` in the path. That is why the field is not an `Option` —
+//! an unreachable panic in a login session's protocol dispatch is a
+//! black screen with no console to read it on.
+//!
+//! # Where the format list comes from
+//!
+//! `renderer.dmabuf_formats()` — which for `GlesRenderer` is the EGL
+//! display's `dmabuf_texture_formats`, i.e. the (fourcc, modifier)
+//! pairs the driver will actually turn into an `EGLImage`. Advertising
+//! anything else would be a lie the client discovers at the worst
+//! moment: modern clients allocate against the advertised set and use
+//! `create_immed`, and a compositor that then rejects the buffer kills
+//! them (see [`ImportNotifier::failed`]'s two behaviours, and the
+//! comment on [`DmabufHandler::dmabuf_imported`] below).
+//!
+//! Both backends reach this the same way, because both own a
+//! `GlesRenderer` — the winit backend's behind `renderer()`, the DRM
+//! session's in `SessionGraphics::renderer`. So one code path serves
+//! both, and a hardware session advertises whatever its actual GPU can
+//! import rather than a curated guess.
+//!
+//! # Feedback (protocol version 4)
+//!
+//! Advertised whenever the render node can be identified, which on a
+//! single-GPU machine it always can: one main device, one main
+//! tranche, no preference tranches. Preference tranches exist to steer
+//! clients toward buffers a *plane* can scan out directly, and the
+//! session composites every frame through the GLES renderer instead
+//! (`session.rs`'s `FRAME_FLAGS` is empty) — so there is no scanout
+//! tranche to declare, and one advertising formats the main device
+//! cannot render would be actively wrong. That ordering is deliberate:
+//! this global is the prerequisite for direct scan-out, so scan-out is
+//! now a `session.rs` question, and a scanout tranche belongs in the
+//! same change that answers it. Multi-GPU is feedback's other reason
+//! to exist, and it waits on multi-GPU support generally.
+//!
+//! When the render node cannot be identified, or the feedback's sealed
+//! format-table memfd cannot be created, the global drops to version 3
+//! (a flat format list, no feedback). Clients handle that fine; it is
+//! what every compositor advertised before 2022.
+
+use smithay::backend::allocator::dmabuf::Dmabuf;
+use smithay::backend::allocator::format::FormatSet;
+use smithay::backend::allocator::Buffer;
+use smithay::backend::egl::EGLDevice;
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::ImportDma;
+use smithay::delegate_dmabuf;
+use smithay::reexports::wayland_server::DisplayHandle;
+use smithay::wayland::dmabuf::{
+    DmabufFeedback, DmabufFeedbackBuilder, DmabufGlobal, DmabufHandler, DmabufState, ImportNotifier,
+};
+
+use crate::state::{Compositor, Graphics};
+
+/// The linux-dmabuf protocol state plus the format set it was built
+/// from. The `DmabufGlobal` handle the constructor gets back is
+/// deliberately dropped: it is a `Copy` id (so it provably has no
+/// `Drop` behaviour), and its only uses are withdrawing the global or
+/// swapping the default feedback — neither of which a session does
+/// while it is alive. What must survive is `state`, since every
+/// `zwp_linux_dmabuf_v1` request dispatches through it.
+pub(crate) struct DmabufSupport {
+    state: DmabufState,
+    /// Exactly what was advertised to clients, kept for the import
+    /// check in [`DmabufHandler::dmabuf_imported`]. Empty means no
+    /// global was registered and no client can ever reach that check.
+    formats: FormatSet,
+}
+
+impl DmabufSupport {
+    /// The no-hardware-buffers state: protocol machinery allocated (so
+    /// the handler always has something to return) but no global
+    /// registered, so no client ever sees the protocol.
+    fn disabled() -> Self {
+        DmabufSupport { state: DmabufState::new(), formats: FormatSet::default() }
+    }
+}
+
+/// The one call `run` makes — see the module docs. Picks the renderer
+/// out of whichever graphics stack this session ended up with and
+/// defers to [`init`].
+pub(crate) fn init_for_graphics(
+    display_handle: &DisplayHandle,
+    graphics: &mut Graphics,
+) -> DmabufSupport {
+    init(display_handle, graphics_renderer(graphics))
+}
+
+/// Registers the linux-dmabuf global for `renderer`'s formats.
+///
+/// Split out from [`init_for_graphics`] so the renderer, not the
+/// graphics enum, is the dependency: `session::init` builds its
+/// renderer before any `Graphics` exists, and can call this directly
+/// if it ever needs the global up earlier than `run` puts it up.
+///
+/// Never fails: a renderer that cannot import dmabufs at all gets a
+/// state with no global rather than an error, because "this GPU stack
+/// is software-only" is a degraded session, not a broken one — the
+/// same call every other optional piece of this compositor makes
+/// (XWayland missing, a theme that will not load).
+pub(crate) fn init(display_handle: &DisplayHandle, renderer: &mut GlesRenderer) -> DmabufSupport {
+    let formats = renderer.dmabuf_formats();
+    if formats.indexset().is_empty() {
+        // llvmpipe without the dmabuf import extensions, or an EGL
+        // display that came up without `EGL_EXT_image_dma_buf_import`.
+        // Advertising an empty global is worse than advertising none:
+        // clients that see it negotiate, find nothing, and have to
+        // discover the dead end themselves.
+        tracing::warn!("the renderer reports no dmabuf formats; not advertising linux-dmabuf");
+        return DmabufSupport::disabled();
+    }
+
+    let mut state = DmabufState::new();
+    match default_feedback(renderer, &formats) {
+        Some(feedback) => {
+            let _global =
+                state.create_global_with_default_feedback::<Compositor>(display_handle, &feedback);
+            tracing::info!(formats = formats.indexset().len(), "linux-dmabuf v4 advertised");
+        }
+        None => {
+            let _global = state.create_global::<Compositor>(display_handle, formats.clone());
+            tracing::info!(formats = formats.indexset().len(), "linux-dmabuf v3 advertised");
+        }
+    }
+    DmabufSupport { state, formats }
+}
+
+/// Builds the version-4 default feedback, or `None` to fall back to a
+/// version-3 format list.
+///
+/// Feedback is keyed by the render node's `dev_t`, so it needs the DRM
+/// node behind the EGL display. Two things can deny us that and
+/// neither is fatal: an EGL implementation without the
+/// `EGL_EXT_device_drm*` extensions (software rendering, some nested
+/// setups), and a `build()` that cannot create the sealed memfd the
+/// format table is sent over.
+fn default_feedback(renderer: &GlesRenderer, formats: &FormatSet) -> Option<DmabufFeedback> {
+    let node = match EGLDevice::device_for_display(renderer.egl_context().display())
+        .and_then(|device| device.try_get_render_node())
+    {
+        Ok(Some(node)) => node,
+        Ok(None) => {
+            tracing::warn!("EGL reports no DRM render node; linux-dmabuf drops to v3");
+            return None;
+        }
+        Err(error) => {
+            tracing::warn!(?error, "could not query the EGL device; linux-dmabuf drops to v3");
+            return None;
+        }
+    };
+
+    // One tranche, the main one — the single-GPU, always-composite
+    // case argued in the module docs.
+    match DmabufFeedbackBuilder::new(node.dev_id(), formats.clone()).build() {
+        Ok(feedback) => Some(feedback),
+        Err(error) => {
+            tracing::warn!(?error, "could not build dmabuf feedback; linux-dmabuf drops to v3");
+            None
+        }
+    }
+}
+
+/// The session's `GlesRenderer`, whichever graphics stack is running —
+/// there is always exactly one, which is the whole reason a single
+/// dmabuf implementation covers both backends.
+///
+/// `capture.rs` carries the same three lines for the same reason;
+/// neither module owns the other's file, and a shared helper belongs
+/// on `Graphics` itself (in `state.rs`) if anyone ever consolidates.
+fn graphics_renderer(graphics: &mut Graphics) -> &mut GlesRenderer {
+    match graphics {
+        Graphics::Winit(backend) => backend.renderer(),
+        Graphics::Session(session) => &mut session.renderer,
+    }
+}
+
+impl DmabufHandler for Compositor {
+    fn dmabuf_state(&mut self) -> &mut DmabufState {
+        &mut self.dmabuf.state
+    }
+
+    /// Smithay's contract: decide whether this buffer can become a
+    /// texture, and say so through `notifier` exactly once.
+    ///
+    /// The asymmetry that shapes this is [`ImportNotifier::failed`]:
+    /// for a buffer created with `create` it sends a `failed` event
+    /// the client recovers from, but for `create_immed` — what
+    /// Mesa/GBM clients use in the common path — it posts a protocol
+    /// error and *kills the client*. So a false rejection is far more
+    /// expensive than a false acceptance, whose worst case is one
+    /// surface that renders empty because `ImportAll` declines it
+    /// later in `renderer.rs`.
+    ///
+    /// Hence: reject up front only what we never advertised (a client
+    /// that invented a format/modifier pair is already outside the
+    /// negotiation, and gets a log line naming it rather than an
+    /// opaque EGL error), then let the renderer's own import be the
+    /// judge. That import is not just a test — `GlesRenderer` caches
+    /// the resulting texture against the dmabuf, so the first frame
+    /// that uses this buffer costs nothing extra.
+    ///
+    /// The pre-check is safe against legacy clients because smithay's
+    /// EGL format query inserts a `Modifier::Invalid` entry for every
+    /// fourcc it finds, so implicit-modifier (version 3) buffers are
+    /// always inside the advertised set.
+    fn dmabuf_imported(&mut self, _global: &DmabufGlobal, dmabuf: Dmabuf, notifier: ImportNotifier) {
+        if !self.dmabuf.formats.contains(&dmabuf.format()) {
+            tracing::debug!(format = ?dmabuf.format(), "rejecting a dmabuf in an unadvertised format");
+            notifier.failed();
+            return;
+        }
+
+        match graphics_renderer(&mut self.graphics).import_dmabuf(&dmabuf, None) {
+            Ok(_texture) => {
+                let _ = notifier.successful::<Compositor>();
+            }
+            Err(error) => {
+                tracing::debug!(?error, format = ?dmabuf.format(), "renderer refused a dmabuf import");
+                notifier.failed();
+            }
+        }
+    }
+
+    // `new_surface_feedback` is deliberately left at its default
+    // (`None` — use the global's default feedback). Per-surface
+    // feedback earns its keep by telling a client "allocate this one
+    // differently and a plane can scan it out", and there are no
+    // planes in play here; a single-GPU compositing session has
+    // exactly one right answer for every surface.
+}
+
+delegate_dmabuf!(Compositor);

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -45,7 +45,7 @@ use smithay::backend::input::{
 };
 use smithay::desktop::utils::under_from_surface_tree;
 use smithay::desktop::{PopupManager, WindowSurfaceType};
-use smithay::input::keyboard::{FilterResult, Keycode, ModifiersState};
+use smithay::input::keyboard::{keysyms, FilterResult, Keycode, Keysym, ModifiersState};
 use smithay::input::pointer::{AxisFrame, ButtonEvent, MotionEvent};
 use smithay::input::Seat;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -171,6 +171,25 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
         let combo = KeyCombo { keysym: keysym.raw(), modifiers: combo_modifiers(mods) };
         match key_state {
             KeyState::Pressed => {
+                // VT switching outranks every other binding, including
+                // the modal keyboard grab: a user who logged into
+                // chonkstep from a TTY has no other way back to one, and
+                // a compositor that can wedge the machine is a trap. The
+                // seat handle lives on the session backend, reachable
+                // only through `&mut Compositor` from in here — see
+                // `session::change_vt`, which is also what decides that
+                // a nested session should forward these combos instead
+                // (it owns no seat to switch).
+                if let Some(vt) = vt_switch_target(mods, keysym, handle.modified_sym()) {
+                    if crate::session::change_vt(data, vt) {
+                        // Suppress the matching release too: the client
+                        // never saw the press, and after a successful
+                        // switch the release is usually delivered to
+                        // whoever owns the VT now anyway.
+                        with_input(&seat, |input| input.suppressed_keys.push(keycode));
+                        return FilterResult::Intercept(());
+                    }
+                }
                 let backend = data.wm.backend_mut();
                 if backend.keyboard_grabbed || backend.grabbed_combos.contains(&combo) {
                     backend.queue(WmEvent::KeyPress(combo));
@@ -202,6 +221,32 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
             }
         }
     });
+}
+
+/// Which virtual terminal a press asks for, if any: 1-12, or `None`.
+///
+/// Both spellings of the gesture are accepted because which one arrives
+/// depends on the keymap, not on the user:
+///
+/// - `XF86Switch_VT_n` is what a layout with the standard VT-switch
+///   mapping produces for Ctrl+Alt+Fn, and it only appears in the
+///   *modified* keysym — the modifiers are already baked into it, so no
+///   modifier test applies.
+/// - Plain `Fn` with Ctrl+Alt held is the fallback for keymaps that
+///   never map the XF86 symbols (a bare `us` layout loaded without the
+///   `srvrkeys` rules, which is what a minimal TTY session often gets).
+///   This is tested against the *raw* keysym for the same reason
+///   bindings are: the level-0 symbol is stable under modifiers.
+fn vt_switch_target(mods: &ModifiersState, raw: Keysym, modified: Keysym) -> Option<i32> {
+    let modified = modified.raw();
+    if (keysyms::KEY_XF86Switch_VT_1..=keysyms::KEY_XF86Switch_VT_12).contains(&modified) {
+        return Some((modified - keysyms::KEY_XF86Switch_VT_1 + 1) as i32);
+    }
+    let raw = raw.raw();
+    if mods.ctrl && mods.alt && (keysyms::KEY_F1..=keysyms::KEY_F12).contains(&raw) {
+        return Some((raw - keysyms::KEY_F1 + 1) as i32);
+    }
+    None
 }
 
 /// xkb modifier state -> the backend-agnostic `Modifiers` `wm-core`

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -25,6 +25,7 @@
 
 mod backend_impl;
 mod capture;
+mod dmabuf;
 mod input;
 mod renderer;
 mod session;

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -10,30 +10,196 @@
 //! function the nested backend submits, which is why the two sessions
 //! cannot drift apart visually.
 //!
-//! Interim skeleton: the real implementation is being built against
-//! this exact API, and until it lands `init` fails cleanly so a TTY
-//! launch says what is missing instead of crashing.
+//! Scope, stated up front so the omissions read as decisions rather
+//! than gaps:
+//!
+//! - **One GPU, one output.** [`init`] picks the primary DRM device and
+//!   the first connected connector on it, and that is the session. A
+//!   second monitor is dark. Multi-output is not hard here - it is a
+//!   second `DrmCompositor` keyed by crtc plus real coordinates in
+//!   `wm-core`'s `Backend::monitors` - but `wm-core` and `chonk-shell`
+//!   still reason about a single screen rectangle (see
+//!   `backend_impl.rs`'s `monitors`), so growing the compositor first
+//!   would buy nothing.
+//! - **No GPU hot-plug.** The udev source logs device add/remove and
+//!   does not act on it. Adopting a GPU that appeared after startup
+//!   means re-running every step of [`init`] against it while the old
+//!   one is still scanning out; a laptop being docked is a session
+//!   restart today.
+//! - **No connector hot-plug.** Plugging a monitor in mid-session logs
+//!   a udev `Changed` event and nothing else, for the same reason as
+//!   multi-output above.
+//! - **No hardware cursor plane.** The pointer is composited into the
+//!   primary plane like every other element, exactly as the nested
+//!   backend does it. A cursor plane would save a full-frame repaint
+//!   per pointer motion, but only once the scene stops repainting
+//!   fully anyway (see [`crate::renderer`]'s module docs).
+//! - **No direct scan-out.** Every frame is composited through the
+//!   GLES renderer and page-flipped from the swapchain, the same path
+//!   the nested backend takes. See [`FRAME_FLAGS`].
+//! - **No DRM leasing and no screencopy.** VR headsets and remote
+//!   desktop are not part of this session.
 
-use smithay::output::Output;
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
+use smithay::backend::allocator::{Format, Fourcc};
+use smithay::backend::drm::compositor::{DrmCompositor, FrameError, FrameFlags, PrimaryPlaneElement};
+use smithay::backend::drm::exporter::gbm::GbmFramebufferExporter;
+use smithay::backend::drm::{DrmDevice, DrmDeviceFd, DrmDeviceNotifier, DrmEvent};
+use smithay::backend::egl::{EGLContext, EGLDisplay};
+use smithay::backend::libinput::{LibinputInputBackend, LibinputSessionInterface};
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::session::libseat::LibSeatSession;
+use smithay::backend::session::{Event as SessionEvent, Session};
+use smithay::backend::udev::{all_gpus, primary_gpu, UdevBackend, UdevEvent};
+use smithay::output::{Mode as OutputMode, Output, PhysicalProperties};
 use smithay::reexports::calloop::LoopHandle;
+use smithay::reexports::drm::control::{
+    connector, crtc, Device as ControlDevice, Mode as DrmMode, ModeTypeFlags, ResourceHandles,
+};
+use smithay::reexports::input::Libinput;
+use smithay::reexports::rustix::fs::OFlags;
 use smithay::reexports::wayland_server::DisplayHandle;
+use smithay::utils::{DeviceFd, Transform};
+
 use wm_theme_api::Size;
 
 use crate::state::{Compositor, Graphics};
 
+/// The concrete [`DrmCompositor`] this session drives. Spelled out
+/// once because the four type parameters (allocator, framebuffer
+/// exporter, per-frame user data, device fd) appear in every signature
+/// that touches it. The user-data slot is `()`: it exists to carry
+/// presentation feedback back from the page-flip event, and chonkstep
+/// advertises no `wp_presentation` global for that feedback to reach.
+type SessionDrmCompositor =
+    DrmCompositor<GbmAllocator<DrmDeviceFd>, GbmFramebufferExporter<DrmDeviceFd>, (), DrmDeviceFd>;
+
+/// Framebuffer formats offered to the primary plane, in preference
+/// order; [`DrmCompositor::new`] takes the first the hardware and the
+/// renderer agree on. Both are 8-bit with alpha, which every KMS
+/// driver worth the name scans out — 10-bit (`Abgr2101010`) buys
+/// nothing here because every pixel in the scene originates from an
+/// 8-bit-per-channel source (tiny-skia decoration buffers, shm client
+/// surfaces), so the extra bits would carry no extra information.
+const COLOR_FORMATS: &[Fourcc] = &[Fourcc::Abgr8888, Fourcc::Argb8888];
+
+/// Every frame is composited into the swapchain buffer and page-flipped
+/// from there; no element is ever handed straight to a plane.
+///
+/// Direct scan-out would let a fullscreen client's own buffer become
+/// the scanout buffer, skipping the GLES pass entirely — a real win for
+/// video and games. It is off because it cannot pay yet: this backend
+/// repaints the whole output every frame on purpose (see
+/// [`render_frame_session`]), which is precisely the case where
+/// composition costs the same either way, and turning it on adds a
+/// second, hardware-dependent path through the frame that the nested
+/// backend has no counterpart for — so a scan-out-only bug would be
+/// invisible until someone logged in from a TTY. Enable it together
+/// with per-element damage, and with an import node on the framebuffer
+/// exporter (see [`init`]), not before.
+const FRAME_FLAGS: FrameFlags = FrameFlags::empty();
+
+/// Flags every DRM node is opened with: read-write mode setting, closed
+/// across `exec` so a spawned terminal cannot inherit the GPU, detached
+/// from any controlling terminal, and non-blocking because the fd
+/// becomes a calloop source and a blocking read on it would park the
+/// whole compositor — input, clients and all — until the next vblank.
+///
+/// Worth knowing before debugging an fd-flags problem here: libseat's
+/// `Session::open` ignores this argument entirely and opens the device
+/// with seatd's own flags. It is passed anyway because the `Session`
+/// trait takes it and other implementations honor it, and because the
+/// intent is what a reader needs.
+const DEVICE_FLAGS: OFlags = OFlags::RDWR
+    .union(OFlags::CLOEXEC)
+    .union(OFlags::NOCTTY)
+    .union(OFlags::NONBLOCK);
+
+/// How long a page flip may stay in flight before the session says so.
+///
+/// The kernel promises a completion event for every atomic commit it
+/// accepted, so exceeding this is a driver bug rather than a case to
+/// recover from — and "recovery" would mean rendering into a buffer the
+/// display engine still owns, which corrupts the screen instead of
+/// fixing it. So this only produces a log line, but that line is the
+/// difference between a frozen desktop that explains itself over SSH
+/// and one that says nothing at all. Two seconds is far beyond any real
+/// refresh interval, including a 24Hz cinema mode.
+const FLIP_STALL_WARNING: Duration = Duration::from_secs(2);
+
 /// Everything the session backend owns while it runs: the seat, the
-/// DRM device and its GBM allocator, the EGL/GLES renderer, the
-/// per-output DRM compositors, and the input backend. Opaque to the
-/// rest of the crate on purpose - only [`init`] and
-/// [`render_frame_session`] reach inside.
+/// DRM device and its GBM allocator, the EGL/GLES renderer, the one
+/// output's DRM compositor, and the libinput context.
+///
+/// The event-source callbacks registered by [`init`] reach this struct
+/// the same way [`render_frame_session`] does — by matching
+/// `comp.graphics` against [`Graphics::Session`] — because calloop
+/// hands every callback `&mut Compositor` and nothing else. That is
+/// also the path [`change_vt`] takes on behalf of `input.rs`.
 pub(crate) struct SessionGraphics {
-    _private: (),
+    /// Seat handle for opening devices and for [`change_vt`]. Cloned
+    /// from the notifier that calloop owns; if that notifier were ever
+    /// dropped this handle's inner `Weak` would go dangling and every
+    /// operation on it would start failing, which is why the notifier
+    /// is inserted into the loop and never touched again.
+    seat_session: LibSeatSession,
+    /// The KMS device. Held for `pause`/`activate` across VT switches
+    /// and for the `is_active` guard on the render path — the surface
+    /// inside the DRM compositor keeps its own reference for
+    /// commits.
+    drm: DrmDevice,
+    /// The GLES renderer every scene element is imported into and
+    /// drawn with. `pub(crate)` because it is the one piece of this
+    /// struct the rest of the crate legitimately needs: `capture.rs`
+    /// renders the same scene offscreen through it, and `dmabuf.rs`
+    /// asks it which hardware buffer formats to advertise. Also
+    /// reachable as [`SessionGraphics::renderer`], which is the
+    /// spelling backend-blind code uses so both arms of
+    /// [`Graphics`] read the same.
+    pub(crate) renderer: GlesRenderer,
+    /// Swapchain, mode setting, and page flips for the one output.
+    /// `pub(crate)` for the same capture reason.
+    pub(crate) drm_compositor: SessionDrmCompositor,
+    /// The libinput context, kept so the session notifier can suspend
+    /// and resume it. The `LibinputInputBackend` calloop owns holds its
+    /// own clone of the same underlying context.
+    libinput: Libinput,
+    /// The page flip in flight, if any — set on a successful
+    /// `queue_frame`, cleared by the completion event that answers it.
+    /// While it is `Some`, [`render_frame_session`] refuses to draw: the
+    /// swapchain has at most a couple of slots, and rendering ahead of
+    /// the display either exhausts them or throws away work nobody will
+    /// ever see.
+    frame_pending: Option<PendingFlip>,
+}
+
+/// A page flip the kernel has accepted and not yet reported back.
+struct PendingFlip {
+    queued_at: Instant,
+    /// Whether this flip has already been named in the log as stalled,
+    /// so [`FLIP_STALL_WARNING`] produces one line per stuck frame
+    /// rather than one per event-loop wakeup.
+    stall_reported: bool,
+}
+
+impl SessionGraphics {
+    /// The renderer, named the way `WinitGraphicsBackend::renderer`
+    /// is, so code that has to work on either backend can match the
+    /// two arms of [`Graphics`] into one expression instead of
+    /// branching on a method here and a field there.
+    pub(crate) fn renderer(&mut self) -> &mut GlesRenderer {
+        &mut self.renderer
+    }
 }
 
 /// What [`init`] hands back to `run`: the graphics stack plus the
 /// output it discovered, already configured with its mode. Any event
 /// sources the session needs (DRM page flips, libinput devices, udev
-/// hot-plug, seat activation) are registered on the loop by `init`
+/// hot-plug, seat activation) are registered on the loop by [`init`]
 /// itself.
 pub(crate) struct SessionInit {
     pub graphics: Graphics,
@@ -45,15 +211,620 @@ pub(crate) struct SessionInit {
 /// Errors here are fatal but explicable - no seat, no DRM device, no
 /// usable connector - and the binary reports them instead of dying
 /// silently on a black screen.
+///
+/// Nothing in here panics on hardware state. A TTY session has no
+/// terminal left to print a backtrace to and no window manager to
+/// survive it, so every fallible probe either produces a message that
+/// names the device and the reason or is skipped in favor of the next
+/// candidate.
 pub(crate) fn init(
-    _loop_handle: &LoopHandle<'static, Compositor>,
+    loop_handle: &LoopHandle<'static, Compositor>,
     _display_handle: &DisplayHandle,
-) -> Result<SessionInit, Box<dyn std::error::Error>> {
-    Err("the DRM/KMS session backend is not built yet; run nested inside an existing desktop, \
-         or set CHONKSTEP_BACKEND=winit"
-        .into())
+) -> Result<SessionInit, Box<dyn Error>> {
+    // 1. The seat. libseat (or logind behind it) is what lets an
+    //    unprivileged process open DRM and input devices at all, and
+    //    what tells us when another session takes the VT away.
+    let (mut seat_session, notifier) = LibSeatSession::new()
+        .map_err(|error| format!("could not take a seat (is seatd or logind running?): {error:?}"))?;
+    let seat_name = seat_session.seat();
+    tracing::info!(seat = %seat_name, "session backend: seat acquired");
+
+    // 2. The graphics device. Every candidate is opened *through the
+    //    seat* so libseat owns the fd and can revoke it on a VT switch;
+    //    opening `/dev/dri/cardN` directly would work as root and then
+    //    strand the device on the first VT switch.
+    let (device_path, device) = open_first_usable_device(&mut seat_session, &seat_name)?;
+    let Device { mut drm, notifier: drm_notifier, gbm, connector, crtc, mode } = device;
+    let connector_name = connector_name(&connector);
+    tracing::info!(
+        device = %device_path.display(),
+        output = %connector_name,
+        mode = %format!("{}x{}@{}", mode.size().0, mode.size().1, mode.vrefresh()),
+        "session backend: driving one output"
+    );
+
+    // 3. The render stack. EGL is created on the GBM device rather than
+    //    on the DRM node directly: GBM is what turns "a scanout buffer"
+    //    into "something EGL can render into", and the same device then
+    //    backs the allocator that fills the swapchain.
+    let egl_display = unsafe { EGLDisplay::new(gbm.clone()) }
+        .map_err(|error| format!("EGL display init failed on {}: {error}", device_path.display()))?;
+    let egl_context = EGLContext::new(&egl_display)
+        .map_err(|error| format!("EGL context creation failed on {}: {error}", device_path.display()))?;
+    // SAFETY: the context was just created on this thread, is not
+    // current anywhere else, and `GlesRenderer` takes ownership of it —
+    // the conditions its `new` documents.
+    let renderer = unsafe { GlesRenderer::new(egl_context) }
+        .map_err(|error| format!("GLES renderer init failed on {}: {error}", device_path.display()))?;
+    // Which dmabuf formats the renderer can draw into; intersected
+    // against the primary plane's formats by `DrmCompositor::new` to
+    // choose the swapchain format. Collected eagerly so the borrow of
+    // the renderer ends here.
+    let render_formats: Vec<Format> =
+        renderer.egl_context().dmabuf_render_formats().iter().copied().collect();
+
+    // 4. The output, in wayland terms. No `Transform::Flipped180`: that
+    //    correction belongs to the winit backend, whose EGL surface
+    //    disagrees with the output about where the origin is (see
+    //    `state.rs`'s `run`). A KMS scanout buffer's origin is the
+    //    screen's, so any transform here would visibly flip the
+    //    desktop.
+    let wl_mode = OutputMode::from(mode);
+    let (physical_w, physical_h) = connector.size().unwrap_or((0, 0));
+    let output = Output::new(
+        connector_name.clone(),
+        PhysicalProperties {
+            size: (physical_w as i32, physical_h as i32).into(),
+            subpixel: connector.subpixel().into(),
+            // The manufacturer and model live in the connector's EDID
+            // blob, and parsing EDID means either a parser in this
+            // crate or the `smithay-drm-extras` dependency — neither
+            // worth it for two strings clients only ever show in an
+            // about box. The connector name is at least true and
+            // stable.
+            make: "Unknown".into(),
+            model: connector_name.clone(),
+        },
+    );
+    output.set_preferred(wl_mode);
+    output.change_current_state(Some(wl_mode), Some(Transform::Normal), None, Some((0, 0).into()));
+    let output_size = Size::new(wl_mode.size.w.max(0) as u32, wl_mode.size.h.max(0) as u32);
+
+    // The DRM surface binds crtc + connector + mode; the compositor
+    // wraps it with the swapchain and the damage tracking that turn a
+    // list of render elements into a page flip.
+    let surface = drm
+        .create_surface(crtc, mode, &[connector.handle()])
+        .map_err(|error| format!("could not drive {connector_name} from {crtc:?}: {error}"))?;
+    let allocator = GbmAllocator::new(
+        gbm.clone(),
+        // RENDERING: the buffer is an EGL render target. SCANOUT: it is
+        // also handed to the display engine. Both are required — a
+        // buffer allocated for only one of the two is rejected by the
+        // other.
+        GbmBufferFlags::RENDERING | GbmBufferFlags::SCANOUT,
+    );
+    // `None` for the import node: that argument only enables direct
+    // scan-out of *client* buffers, which cannot happen here (see
+    // [`FRAME_FLAGS`]).
+    let framebuffer_exporter = GbmFramebufferExporter::new(gbm, None);
+    let drm_compositor = SessionDrmCompositor::new(
+        &output,
+        surface,
+        // `None` planes: take whatever the surface reports. With
+        // scan-out off, overlay and cursor planes are never assigned
+        // anything anyway.
+        None,
+        allocator,
+        framebuffer_exporter,
+        COLOR_FORMATS.iter().copied(),
+        render_formats,
+        drm.cursor_size(),
+        // No GBM device for the cursor plane: no hardware cursor (see
+        // the module docs).
+        None,
+    )
+    .map_err(|error| format!("could not set up scanout on {connector_name}: {error}"))?;
+
+    // 5. Event sources. All four are registered before `run` builds the
+    //    `Compositor`, which is safe because calloop only fires them
+    //    from inside `event_loop.dispatch`, long after that struct
+    //    exists.
+
+    // Page-flip completions. The handler does not render: it clears the
+    // in-flight flag and returns, and the loop's `dispatch_pending`
+    // (which runs right after `dispatch` returns) draws the next frame
+    // if the ledger is still dirty. Keeping the decision in one place
+    // means the session and nested backends schedule redraws by exactly
+    // the same rule — "damage, then draw".
+    loop_handle
+        .insert_source(drm_notifier, |event, _metadata, comp: &mut Compositor| {
+            // `_metadata` carries the vblank timestamp and sequence,
+            // which only matter for `wp_presentation` feedback we do
+            // not advertise.
+            let Graphics::Session(session) = &mut comp.graphics else {
+                return;
+            };
+            match event {
+                DrmEvent::VBlank(crtc) => {
+                    if session.drm_compositor.crtc() != crtc {
+                        tracing::debug!(?crtc, "page flip completed on a crtc we do not drive");
+                        return;
+                    }
+                    session.frame_pending = None;
+                    if let Err(error) = session.drm_compositor.frame_submitted() {
+                        // The swapchain slot could not be recycled.
+                        // Rendering continues; if this repeats the next
+                        // frame will fail with `NoFreeSlotsError`, which
+                        // is the loud version of the same problem.
+                        tracing::warn!(?error, "page-flip completion was rejected by the DRM compositor");
+                    }
+                }
+                DrmEvent::Error(error) => {
+                    tracing::error!(?error, "the DRM device reported an error");
+                }
+            }
+        })
+        .map_err(|error| format!("failed to register the DRM event source: {error}"))?;
+
+    // udev. Watched but not acted on: see the module docs on GPU and
+    // connector hot-plug. Logging it is still worth the source, because
+    // "the screen went black" and "the kernel took your GPU away" look
+    // identical over SSH otherwise.
+    let udev_backend = UdevBackend::new(&seat_name)
+        .map_err(|error| format!("could not watch udev for seat {seat_name}: {error}"))?;
+    loop_handle
+        .insert_source(udev_backend, |event, _, _comp: &mut Compositor| match event {
+            UdevEvent::Added { device_id, path } => {
+                tracing::info!(?device_id, path = %path.display(), "a DRM device appeared; chonkstep drives a single GPU and will not adopt it");
+            }
+            UdevEvent::Changed { device_id } => {
+                tracing::info!(?device_id, "a DRM device changed (connector hot-plug?); the session keeps its startup output");
+            }
+            UdevEvent::Removed { device_id } => {
+                tracing::warn!(?device_id, "a DRM device went away; if it is ours the session will stop painting");
+            }
+        })
+        .map_err(|error| format!("failed to register the udev event source: {error}"))?;
+
+    // Input. The context opens devices through the same seat as the
+    // GPU, so a VT switch revokes both together, and the events land in
+    // `crate::input::process_input_event` — the identical routing the
+    // nested backend feeds with winit events, because that function is
+    // generic over the input backend.
+    let mut libinput = Libinput::new_with_udev::<LibinputSessionInterface<LibSeatSession>>(
+        seat_session.clone().into(),
+    );
+    libinput
+        .udev_assign_seat(&seat_name)
+        .map_err(|()| format!("libinput could not take seat {seat_name}; no keyboard or mouse would work"))?;
+    loop_handle
+        .insert_source(LibinputInputBackend::new(libinput.clone()), |event, _, comp: &mut Compositor| {
+            crate::input::process_input_event(comp, event);
+        })
+        .map_err(|error| format!("failed to register the libinput event source: {error}"))?;
+
+    // Seat activation. This is the half of VT switching we do not
+    // initiate: another session (or a `chvt` from anywhere) takes the
+    // seat, and we have to stop touching the hardware before the kernel
+    // revokes it, then rebuild our idea of the crtc when it comes back.
+    loop_handle
+        .insert_source(notifier, |event, &mut (), comp: &mut Compositor| {
+            let Compositor { graphics, wm, .. } = comp;
+            let Graphics::Session(session) = graphics else {
+                return;
+            };
+            match event {
+                SessionEvent::PauseSession => {
+                    tracing::info!("session paused: releasing the DRM device and input");
+                    session.libinput.suspend();
+                    session.drm.pause();
+                    // A flip queued before the pause will never complete
+                    // — the device is gone — so dropping it keeps the
+                    // render path from waiting forever for a vblank that
+                    // cannot arrive.
+                    session.frame_pending = None;
+                }
+                SessionEvent::ActivateSession => {
+                    tracing::info!("session resumed: reclaiming the DRM device and input");
+                    // libinput reports failure as a bare `()`; there is
+                    // nothing to log but the fact.
+                    if session.libinput.resume().is_err() {
+                        tracing::error!("could not resume libinput; keyboard and mouse are dead until restart");
+                    }
+                    // `true` = reset the device state (all connectors
+                    // and planes disabled) instead of assuming the
+                    // foreign session left our crtc/connector binding
+                    // intact. It costs one modeset's worth of flicker
+                    // and rules out the atomic-commit test failures that
+                    // an optimistic resume produces when the other
+                    // session rearranged things.
+                    if let Err(error) = session.drm.activate(true) {
+                        tracing::error!(?error, "could not reactivate the DRM device; the screen will stay dark");
+                    }
+                    if let Err(error) = session.drm_compositor.reset_state() {
+                        tracing::error!(?error, "could not reset the crtc state after resuming");
+                    }
+                    // Buffer contents and buffer ages both survived the
+                    // switch but mean nothing now: the foreign session
+                    // painted over the screen.
+                    session.drm_compositor.reset_buffers();
+                    session.frame_pending = None;
+                    wm.backend_mut().mark_damaged();
+                }
+            }
+        })
+        .map_err(|error| format!("failed to register the seat session source: {error}"))?;
+
+    // 6. Hand the assembled stack back to `run`, which registers the
+    //    output global and builds the damage tracker from it.
+    Ok(SessionInit {
+        graphics: Graphics::Session(Box::new(SessionGraphics {
+            seat_session,
+            drm,
+            renderer,
+            drm_compositor,
+            libinput,
+            frame_pending: None,
+        })),
+        output,
+        output_size,
+    })
+}
+
+/// Switches the seat to virtual terminal `vt`, reporting whether this
+/// process is a hardware session at all.
+///
+/// `input.rs` calls this from inside the seat keyboard's filter, where
+/// the only thing in reach is `&mut Compositor` — hence the lookup
+/// through [`Graphics`] rather than a handle passed down. A `false`
+/// return means the nested backend is running and the key combo should
+/// be forwarded to clients like any other; `true` means it was consumed
+/// (whether or not the switch itself succeeded — a session that swallows
+/// Ctrl+Alt+F2 and then fails is confusing, but forwarding a VT combo to
+/// a text editor is worse).
+pub(crate) fn change_vt(comp: &mut Compositor, vt: i32) -> bool {
+    let Graphics::Session(session) = &mut comp.graphics else {
+        return false;
+    };
+    match session.seat_session.change_vt(vt) {
+        Ok(()) => tracing::info!(vt, "switching virtual terminal"),
+        Err(error) => tracing::warn!(?error, vt, "the seat refused the VT switch"),
+    }
+    true
 }
 
 /// Draws one frame onto the hardware: [`crate::renderer::build_scene`]
 /// through the session's renderer, submitted as a page flip.
-pub(crate) fn render_frame_session(_comp: &mut Compositor) {}
+///
+/// Deliberately shaped like `render_frame_winit`: bind, build the one
+/// shared scene, submit, then send frame callbacks and clear the damage
+/// flag *only on success*. Every early return leaves `damage` set, so a
+/// transient failure costs one frame and retries on the next wakeup
+/// instead of wedging the desktop.
+pub(crate) fn render_frame_session(comp: &mut Compositor) {
+    // Disjoint field borrows: the graphics stack mutates while the
+    // ledger is read. Both live on `Compositor`, so destructure rather
+    // than going through `&mut self` methods.
+    let Compositor {
+        wm,
+        graphics,
+        output,
+        pointer_location,
+        cursor_status,
+        default_cursor,
+        start_time,
+        ..
+    } = comp;
+    let Graphics::Session(session) = graphics else {
+        return;
+    };
+
+    if let Some(flip) = session.frame_pending.as_mut() {
+        // A page flip is in flight. Rendering now would burn a
+        // swapchain slot on a frame the display cannot show before the
+        // one already queued, so leave `damage` set and let the vblank
+        // handler's clearing of this flag be what schedules the redraw.
+        let waited = flip.queued_at.elapsed();
+        if !flip.stall_reported && waited > FLIP_STALL_WARNING {
+            flip.stall_reported = true;
+            tracing::error!(
+                ?waited,
+                "no page-flip completion from the DRM device; the desktop is frozen until one \
+                 arrives (driver bug — switch VTs to get a console back)"
+            );
+        }
+        return;
+    }
+    if !session.drm.is_active() {
+        // Someone else owns the VT. Every commit would fail with
+        // `DeviceInactive`; the resume handler marks damage again.
+        return;
+    }
+
+    let SessionGraphics { renderer, drm_compositor, frame_pending, .. } = &mut **session;
+
+    // Force full-frame damage, the session-side equivalent of the winit
+    // path's `age = 0`: with every buffer age reset the internal damage
+    // tracker treats the whole output as stale. Same trade the X11
+    // session made by running picom with `--no-use-damage` — a little
+    // GPU fill in exchange for never chasing a partial-damage artifact.
+    // Revisit only with evidence, and revisit both backends together.
+    drm_compositor.reset_buffer_ages();
+
+    let (elements, clear_color) = crate::renderer::build_scene(
+        wm.backend(),
+        renderer,
+        *pointer_location,
+        cursor_status,
+        default_cursor,
+    );
+
+    let rendered = match drm_compositor.render_frame(renderer, &elements, clear_color, FRAME_FLAGS) {
+        Ok(result) => {
+            // The GPU may still be drawing into the buffer we are about
+            // to hand the scanout engine. Where the driver supports
+            // fencing the DRM compositor passes the fence along with the
+            // commit and this is skipped; where it does not, waiting on
+            // the CPU is the only thing standing between us and a
+            // half-drawn frame on screen.
+            if result.needs_sync() {
+                if let PrimaryPlaneElement::Swapchain(element) = &result.primary_element {
+                    if let Err(error) = element.sync.wait() {
+                        tracing::warn!(?error, "interrupted waiting on the render fence; the frame may tear");
+                    }
+                }
+            }
+            !result.is_empty
+        }
+        Err(error) => {
+            // Includes the atomic test failures a returning VT switch
+            // can produce; the seat-activation handler above resets the
+            // device and marks damage, so the recovery path is there
+            // rather than duplicated here.
+            tracing::warn!(?error, "DRM render failed; keeping damage for a retry");
+            return;
+        }
+    };
+
+    if rendered {
+        match drm_compositor.queue_frame(()) {
+            Ok(()) => {
+                *frame_pending = Some(PendingFlip { queued_at: Instant::now(), stall_reported: false })
+            }
+            // Nothing on the crtc actually changed. Not an error, and
+            // not worth a retry: the scene is already on screen.
+            Err(FrameError::EmptyFrame) => {
+                tracing::trace!("frame produced no crtc changes; no page flip queued");
+            }
+            Err(error) => {
+                tracing::warn!(?error, "queueing the page flip failed; keeping damage for a retry");
+                return;
+            }
+        }
+    }
+
+    crate::renderer::send_frame_callbacks(wm.backend(), output, cursor_status, start_time.elapsed());
+    wm.backend_mut().damage = false;
+}
+
+/// One opened, mode-set-capable DRM device together with the output it
+/// will drive. Produced by [`probe_device`] and consumed by [`init`].
+struct Device {
+    drm: DrmDevice,
+    notifier: DrmDeviceNotifier,
+    gbm: GbmDevice<DrmDeviceFd>,
+    connector: connector::Info,
+    crtc: crtc::Handle,
+    mode: DrmMode,
+}
+
+/// Walks the candidate DRM nodes in preference order and returns the
+/// first that opens, does mode setting, and has something plugged into
+/// it. Failures accumulate into one error message rather than the last
+/// one winning: on a machine with an integrated and a discrete GPU,
+/// "card0 has no connected output, card1 is not permitted" is the
+/// diagnosis, and either half alone is misleading.
+fn open_first_usable_device(
+    seat_session: &mut LibSeatSession,
+    seat_name: &str,
+) -> Result<(PathBuf, Device), Box<dyn Error>> {
+    let candidates = candidate_devices(seat_name);
+    if candidates.is_empty() {
+        return Err(format!(
+            "no DRM device found for seat {seat_name}: is a graphics driver loaded, and does this \
+             seat own a GPU?"
+        )
+        .into());
+    }
+
+    let mut failures = Vec::new();
+    for path in candidates {
+        match probe_device(seat_session, &path) {
+            Ok(device) => return Ok((path, device)),
+            Err(reason) => {
+                tracing::info!(device = %path.display(), %reason, "skipping DRM device");
+                failures.push(format!("{}: {reason}", path.display()));
+            }
+        }
+    }
+    Err(format!("no usable DRM device on seat {seat_name} ({})", failures.join("; ")).into())
+}
+
+/// Candidate DRM nodes, best first and deduplicated: an explicit
+/// override, then udev's idea of the primary GPU for this seat, then
+/// every other GPU on the seat, then a raw directory scan.
+///
+/// The directory scan is the fallback the udev queries cannot replace:
+/// a device with no `ID_SEAT` property and no `boot_vga` PCI parent —
+/// most virtual machines, some ARM SoCs where the display controller
+/// is not on a PCI bus at all — is invisible to `primary_gpu` and
+/// `all_gpus` but is still the only screen the machine has.
+fn candidate_devices(seat_name: &str) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    let push = |path: PathBuf, candidates: &mut Vec<PathBuf>| {
+        if !candidates.contains(&path) {
+            candidates.push(path);
+        }
+    };
+
+    // An explicit override, for bringing the session up on a machine
+    // where the automatic choice picks the wrong card — the one thing a
+    // developer debugging over SSH cannot work around otherwise.
+    if let Some(path) = std::env::var_os("CHONKSTEP_DRM_DEVICE") {
+        push(PathBuf::from(path), &mut candidates);
+    }
+    match primary_gpu(seat_name) {
+        Ok(Some(path)) => push(path, &mut candidates),
+        Ok(None) => tracing::debug!(seat = seat_name, "udev names no primary GPU for this seat"),
+        Err(error) => tracing::warn!(?error, "could not ask udev for the primary GPU"),
+    }
+    match all_gpus(seat_name) {
+        Ok(paths) => {
+            for path in paths {
+                push(path, &mut candidates);
+            }
+        }
+        Err(error) => tracing::warn!(?error, "could not enumerate GPUs through udev"),
+    }
+    match std::fs::read_dir("/dev/dri") {
+        Ok(entries) => {
+            let mut cards: Vec<PathBuf> = entries
+                .filter_map(|entry| entry.ok())
+                .map(|entry| entry.path())
+                .filter(|path| {
+                    path.file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.starts_with("card"))
+                })
+                .collect();
+            // `read_dir` order is whatever the filesystem hands back, so
+            // sort for a stable choice across boots. Lexicographic, so
+            // card10 lands before card2 — which does not matter, because
+            // by the time this fallback runs any KMS-capable node will
+            // do and only the determinism is worth having.
+            cards.sort();
+            for path in cards {
+                push(path, &mut candidates);
+            }
+        }
+        Err(error) => tracing::warn!(?error, "could not scan /dev/dri"),
+    }
+    candidates
+}
+
+/// Opens one DRM node through the seat and decides whether it can carry
+/// this session: it must do mode setting and it must have a connected
+/// connector with a mode and a crtc to drive it.
+///
+/// On failure the fd is dropped rather than handed back to libseat with
+/// `close`. libseat forgets it when the session ends; the alternative is
+/// threading a close through every early return of a function that runs
+/// at most a handful of times before the process either has a screen or
+/// exits.
+fn probe_device(seat_session: &mut LibSeatSession, path: &Path) -> Result<Device, String> {
+    let fd = seat_session
+        .open(path, DEVICE_FLAGS)
+        .map_err(|error| format!("the seat would not open it: {error:?}"))?;
+    let fd = DrmDeviceFd::new(DeviceFd::from(fd));
+
+    // `true`: start with every connector disabled. smithay enables the
+    // ones it drives when a surface is attached, so anything we do not
+    // use stays dark instead of showing whatever the previous session
+    // left in its scanout buffer.
+    let (drm, notifier) = DrmDevice::new(fd.clone(), true)
+        .map_err(|error| format!("not a usable DRM device: {error}"))?;
+    let (connector, crtc, mode) = pick_output(&drm)?;
+    let gbm = GbmDevice::new(fd).map_err(|error| format!("GBM init failed: {error}"))?;
+
+    Ok(Device { drm, notifier, gbm, connector, crtc, mode })
+}
+
+/// Picks the connector this session paints on: the first connected one
+/// that has both a mode and a crtc available. "First" is the kernel's
+/// enumeration order, which is stable across boots on a given machine —
+/// good enough while the session is single-output, and the thing to
+/// replace with a real policy (primary connector, saved layout) when it
+/// is not.
+fn pick_output(drm: &DrmDevice) -> Result<(connector::Info, crtc::Handle, DrmMode), String> {
+    let resources = drm
+        .resource_handles()
+        .map_err(|error| format!("no KMS resources (a render-only node?): {error}"))?;
+
+    // Why each connector was passed over, so a black screen is
+    // diagnosable from one log line instead of a bisect.
+    let mut skipped: Vec<String> = Vec::new();
+    for handle in resources.connectors() {
+        let info = match drm.get_connector(*handle, true) {
+            Ok(info) => info,
+            Err(error) => {
+                skipped.push(format!("{handle:?} could not be read: {error}"));
+                continue;
+            }
+        };
+        let name = connector_name(&info);
+        if info.state() != connector::State::Connected {
+            skipped.push(format!("{name} is {:?}", info.state()));
+            continue;
+        }
+        let Some(mode) = preferred_mode(&info) else {
+            skipped.push(format!("{name} is connected but reports no modes"));
+            continue;
+        };
+        let Some(crtc) = crtc_for(drm, &resources, &info) else {
+            skipped.push(format!("{name} has no crtc able to drive it"));
+            continue;
+        };
+        return Ok((info, crtc, mode));
+    }
+
+    Err(if skipped.is_empty() {
+        "the device exposes no connectors at all".to_string()
+    } else {
+        format!("no connector is usable ({})", skipped.join(", "))
+    })
+}
+
+/// The connector's own preferred mode — the panel's native resolution
+/// on a laptop, the monitor's EDID preference on a desktop — falling
+/// back to the first mode listed. Never guesses a resolution: a mode
+/// the connector did not advertise is a mode the display will refuse.
+fn preferred_mode(connector: &connector::Info) -> Option<DrmMode> {
+    connector
+        .modes()
+        .iter()
+        .find(|mode| mode.mode_type().contains(ModeTypeFlags::PREFERRED))
+        .or_else(|| connector.modes().first())
+        .copied()
+}
+
+/// Finds a crtc — the scanout engine — able to drive this connector.
+/// The encoder already attached to it is tried first because reusing
+/// the kernel's existing routing avoids disturbing a working
+/// configuration; failing that, any crtc that any of the connector's
+/// possible encoders can reach will do.
+fn crtc_for(
+    drm: &DrmDevice,
+    resources: &ResourceHandles,
+    connector: &connector::Info,
+) -> Option<crtc::Handle> {
+    connector
+        .current_encoder()
+        .and_then(|handle| drm.get_encoder(handle).ok())
+        .and_then(|encoder| encoder.crtc())
+        .or_else(|| {
+            connector
+                .encoders()
+                .iter()
+                .filter_map(|handle| drm.get_encoder(*handle).ok())
+                .flat_map(|encoder| resources.filter_crtcs(encoder.possible_crtcs()))
+                .next()
+        })
+}
+
+/// The name every other tool shows for this output — `eDP-1`, `HDMI-A-2`
+/// — assembled the way the kernel and every other compositor assemble
+/// it, so logs here line up with `drm_info` and `wayland-info` output.
+fn connector_name(connector: &connector::Info) -> String {
+    format!("{}-{}", connector.interface().as_str(), connector.interface_id())
+}

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -70,7 +70,6 @@ use wm_theme::{RasterThemeEngine, Theme};
 use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
 
 use chonk_shell::shell::{Shell, ShellOutcome};
-use chonk_shell::theme_select;
 
 /// A managed client window (an xdg toplevel or an XWayland surface) in
 /// the id space `wm-core` reasons about. Plain integers rather than
@@ -441,6 +440,12 @@ pub struct Compositor {
 
     /// The graphics stack: a host window, or the hardware itself.
     pub(crate) graphics: Graphics,
+    /// linux-dmabuf: the format set we advertise and the protocol
+    /// state behind it. Always present; "this renderer cannot do
+    /// dmabuf" is represented inside, not by an `Option`, so protocol
+    /// dispatch in a login session never has an unreachable panic on
+    /// a screen with no console to read it from.
+    pub(crate) dmabuf: crate::dmabuf::DmabufSupport,
     pub damage_tracker: OutputDamageTracker,
 
     /// Latest pointer position in compositor space, maintained by
@@ -733,7 +738,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         None => nesting_desktop_present(),
     };
 
-    let (graphics, output, output_size) = if nested {
+    let (mut graphics, output, output_size) = if nested {
         tracing::info!("nested backend: rendering into a window on the host desktop");
         let (winit_backend, winit_source) = winit::init::<GlesRenderer>()
             .map_err(|error| format!("winit backend init failed: {error}"))?;
@@ -785,6 +790,12 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let _global = output.create_global::<Compositor>(&display_handle);
     let damage_tracker = OutputDamageTracker::from_output(&output);
 
+    // linux-dmabuf, before the listening socket exists: a global that
+    // is missing when a client binds might as well never exist, and
+    // GPU clients read its absence as "this compositor has no GPU".
+    // Both backends own a `GlesRenderer`, so one call serves both.
+    let dmabuf = crate::dmabuf::init_for_graphics(&display_handle, &mut graphics);
+
     // The listening socket clients connect to, plus the display's own
     // fd so wayland-server processes client requests — both plain
     // calloop sources.
@@ -828,9 +839,16 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // consumers are the nested-Xephyr dev scripts); theme precedence
     // is identical to the X11 binary: persisted theme-menu choice,
     // else the config's theme, else the flagship.
-    let scale = config.scale.filter(|s| s.is_finite() && *s > 0.0).unwrap_or(1.0);
-    tracing::info!(scale, "UI scale (config `scale`)");
-    let theme = resolve_theme(config.theme.as_deref()).scaled(scale);
+    // Session policy comes from `chonk_shell::startup`, shared with the
+    // X11 binary: same env-over-config precedence, same theme
+    // resolution, same cursor sizing. A compositor that resolved these
+    // its own way is exactly how the two sessions would drift.
+    let scale = chonk_shell::startup::read_scale_factor(config.scale);
+    tracing::info!(scale, "UI scale (config `scale`; CHONKSTEP_SCALE overrides)");
+    // XWayland clients draw their own Xcursor pointers and have no way
+    // to learn this session's scale otherwise.
+    chonk_shell::startup::ensure_xcursor_size(scale);
+    let theme = chonk_shell::startup::resolve_theme(config.theme.as_deref()).scaled(scale);
     tracing::info!(theme = %theme.id, "theme loaded");
     let engine = RasterThemeEngine::new(theme.clone());
 
@@ -853,8 +871,8 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     for (combo, _) in &config.keybindings {
         wm.grab_key(*combo);
     }
-    if config.focus_follows_mouse {
-        tracing::info!("focus-follows-mouse enabled (config `focus_follows_mouse`)");
+    if chonk_shell::startup::read_focus_follows_mouse(config.focus_follows_mouse) {
+        tracing::info!("focus-follows-mouse enabled (config `focus_follows_mouse`; CHONKSTEP_FOCUS_FOLLOWS_MOUSE overrides)");
         wm.set_focus_policy(FocusPolicy::FocusFollowsMouse);
     }
     wm.set_placement_policy(config.placement);
@@ -922,6 +940,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         xwm: None,
         xdisplay: None,
         graphics,
+        dmabuf,
         damage_tracker,
         pointer_location: (0.0, 0.0).into(),
         cursor_status: CursorImageStatus::default_named(),
@@ -955,41 +974,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
-/// Resolves the theme this session dresses in, mirroring the X11
-/// binary's precedence exactly: the persisted theme-menu choice
-/// (`theme_select`'s state file) wins over the config file's `theme`,
-/// which wins over the flagship default. Duplicated from
-/// `crates/chonkstep/src/main.rs` rather than shared because which
-/// theme wins at startup is *session policy* and session policy lives
-/// with each session owner — see that file's `resolve_theme` docs.
-fn resolve_theme(config_theme: Option<&str>) -> Theme {
-    if !persisted_theme_choice_exists() {
-        if let Some(requested) = config_theme {
-            if let Some(theme) = wm_theme::default_theme::theme_by_id(requested) {
-                return theme;
-            }
-            tracing::warn!(theme = requested, "config names an unknown theme; using the default instead");
-        }
-    }
-    theme_select::load()
-}
 
-/// `true` exactly when `theme_select::load()` would return a persisted
-/// menu choice rather than its flagship fallback — same path and same
-/// stale-id rule as the X11 binary's helper of the same name, and it
-/// must stay in lockstep with `theme_select`'s `state_path`.
-fn persisted_theme_choice_exists() -> bool {
-    let path = if let Some(root) = std::env::var_os("XDG_STATE_HOME") {
-        std::path::PathBuf::from(root).join("chonkstep/theme")
-    } else if let Some(home) = std::env::var_os("HOME") {
-        std::path::PathBuf::from(home).join(".local/state/chonkstep/theme")
-    } else {
-        return false;
-    };
-    std::fs::read_to_string(path)
-        .ok()
-        .is_some_and(|id| wm_theme::default_theme::theme_by_id(id.trim()).is_some())
-}
 
 /// `true` at most once per `touch` of `scripts/restart.sh`'s marker
 /// file — `remove_file` both checks and consumes in one step, same as

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,23 +1,24 @@
 #!/usr/bin/env bash
 # Installs chonkstep on an Omarchy (or any Arch-based) system, both
-# halves of it: the X11 session (a selectable session alongside the
-# existing desktop) and the Wayland compositor (nested, for now - see
-# the closing notes this prints). Nothing is copied out of this
-# checkout: the session entry points back into the repo, so
-# scripts/update.sh (git pull + rebuild + hot-restart) is the whole
+# halves of it: the X11 session and the Wayland session, each a real
+# login session selectable from a display manager. Nothing is copied
+# out of this checkout: the session entries point back into the repo,
+# so scripts/update.sh (git pull + rebuild + hot-restart) is the whole
 # upgrade story.
 #
 # What this does:
 #   1. Installs runtime dependencies with pacman (Xorg, the terminal,
-#      the session compositor, the theme fonts, the Wayland stack the
-#      compositor builds and runs against) and a Rust toolchain if the
-#      system has none.
+#      picom, the theme fonts, and the graphics, input, and seat
+#      libraries the Wayland compositor builds and runs against) and a
+#      Rust toolchain if the system has none.
 #   2. Builds the release binaries - chonkstep and chonkstep-wayland.
-#   3. Installs /usr/share/xsessions/chonkstep.desktop pointing at this
-#      checkout's scripts/xsession.sh, so chonkstep appears in the
-#      login manager's session picker. No wayland-sessions entry: the
-#      compositor has no DRM/KMS backend yet, so a login entry for it
-#      would fail the moment it was chosen.
+#   3. Installs both session entries pointing at this checkout's
+#      launcher scripts - /usr/share/xsessions/chonkstep.desktop
+#      (scripts/xsession.sh) and
+#      /usr/share/wayland-sessions/chonkstep.desktop
+#      (scripts/wayland-session.sh) - so a login manager offers
+#      chonkstep in either flavour, and a machine with no login manager
+#      can start either one from a TTY.
 #
 # Usage: scripts/install.sh
 set -euo pipefail
@@ -33,8 +34,10 @@ fi
 echo "Installing dependencies (sudo)..."
 # xorg-server/xinit/xauth: the X session itself (xauth is what startx
 # needs on a machine with no display manager - stock Omarchy). rxvt-
-# unicode: the terminal the root menu launches. picom: the session
-# compositor behind the themes' translucent terminals. wireplumber:
+# unicode: the terminal the root menu launches. picom: the X11
+# compositing manager behind the themes' translucent terminals - the
+# Wayland session needs no equivalent, because a compositor composites
+# itself. wireplumber:
 # wpctl, which the dock's sound instrument reads and controls (already
 # present on any PipeWire desktop; harmless elsewhere - without a sink
 # the instrument shows its dead-screen face). Fonts: DejaVu
@@ -44,19 +47,37 @@ echo "Installing dependencies (sudo)..."
 # system has NetworkManager and falls back to /sys/class/net on
 # anything else (Omarchy's iwd setup included).
 #
-# The last line is the Wayland half's build and runtime needs, and it
-# is not optional even for an X11-only user: the workspace build below
-# compiles wm-wayland on any Linux host, and that links against
-# libxkbcommon and EGL. libxkbcommon (keyboard layouts), libglvnd/mesa
-# (EGL/GLES for the compositor's renderer), xorg-xwayland (the
-# Xwayland binary the compositor spawns so X11 apps run in a Wayland
-# session). All four are already present on essentially any graphical
-# Arch system; --needed makes listing them free.
+# The last two lines are the Wayland half's build and runtime needs,
+# and they are not optional even for an X11-only user: the workspace
+# build below compiles wm-wayland on any Linux host, and that links
+# against every one of them.
+#
+# Nested and session backends alike: libxkbcommon (keyboard layouts),
+# libglvnd/mesa (EGL/GLES for the compositor's renderer, and libgbm for
+# the session backend's buffer allocation), xorg-xwayland (the Xwayland
+# binary the compositor spawns so X11 apps run in a Wayland session).
+#
+# The session backend on top of that - what turns the compositor from a
+# window on someone else's desktop into a login session that owns the
+# machine: libdrm (mode setting on the graphics device), libinput (real
+# keyboards, mice, and touchpads), systemd-libs (libudev, which is how
+# those devices are discovered and hot-plugged), and seatd (libseat,
+# which is how the compositor opens the DRM and input devices without
+# being root and hands them back across VT switches). Package names
+# checked with `pacman -Qo /usr/lib/libseat.so` and friends rather than
+# guessed - libseat lives in seatd, and libudev in systemd-libs, on
+# Arch. The seatd *daemon* is not needed on a logind system, which is
+# every systemd machine including stock Omarchy; the closing notes
+# below say so only when logind is actually absent.
+#
+# All of these are already present on essentially any graphical Arch
+# system; --needed makes listing them free.
 sudo pacman -S --needed --noconfirm \
     xorg-server xorg-xinit xorg-xauth \
     rxvt-unicode picom wireplumber \
     ttf-dejavu gsfonts ttf-jetbrains-mono-nerd noto-fonts \
-    libxkbcommon libglvnd mesa xorg-xwayland
+    libxkbcommon libglvnd mesa xorg-xwayland \
+    libdrm libinput systemd-libs seatd
 
 if ! command -v cargo >/dev/null 2>&1; then
     echo "Installing Rust toolchain..."
@@ -69,13 +90,28 @@ fi
 echo "Building chonkstep (release)..."
 cargo build --release --workspace
 
-echo "Installing session entry (sudo)..."
+echo "Installing session entries (sudo)..."
 sudo install -d /usr/share/xsessions
 sudo tee /usr/share/xsessions/chonkstep.desktop >/dev/null <<DESKTOP
 [Desktop Entry]
 Name=chonkstep
 Comment=A window manager with WindowMaker parity
 Exec=${repo}/scripts/xsession.sh
+Type=Application
+DESKTOP
+
+# The Wayland twin. Display managers read this directory for sessions
+# they must start on a bare VT (no Xorg first), which is exactly what
+# the compositor's session backend wants: it opens the DRM device and
+# the input devices itself through libseat. The name carries the
+# "(Wayland)" suffix because both entries land in the same picker and
+# "chonkstep" twice would be a coin flip for the user.
+sudo install -d /usr/share/wayland-sessions
+sudo tee /usr/share/wayland-sessions/chonkstep.desktop >/dev/null <<DESKTOP
+[Desktop Entry]
+Name=chonkstep (Wayland)
+Comment=The chonkstep desktop as a native Wayland compositor
+Exec=${repo}/scripts/wayland-session.sh
 Type=Application
 DESKTOP
 
@@ -90,9 +126,10 @@ if [ ! -e "$config" ]; then
 fi
 
 # Stock Omarchy boots straight into Hyprland via autologin - there is
-# no login-manager session picker for the xsessions entry to appear in,
-# so point those users at startx; on a machine that does run a display
-# manager, the session-list path is the smoother one.
+# no login-manager session picker for either session entry to appear
+# in, so point those users at the TTY routes; on a machine that does
+# run a display manager, the session-list path is the smoother one for
+# both.
 has_dm=""
 for dm in sddm gdm lightdm greetd lemurs ly; do
     if systemctl is-enabled "$dm" >/dev/null 2>&1; then
@@ -101,52 +138,67 @@ for dm in sddm gdm lightdm greetd lemurs ly; do
     fi
 done
 
-# Which display stack the user is on right now, so the advice below
-# names the path they can actually take today. Deliberately NOT used to
-# pick "the Wayland version" as their session: see the note printed
-# below - the compositor has no DRM/KMS backend yet, so it cannot own
-# a TTY the way Xorg does, and installing a wayland-sessions entry
-# would put a session in the login picker that fails the moment it is
-# chosen. That entry lands with the session feature, not before.
-session_type="${XDG_SESSION_TYPE:-}"
-if [ -z "$session_type" ] && [ -n "${WAYLAND_DISPLAY:-}" ]; then
-    session_type="wayland"
+# Whether this machine has logind, which decides whether the Wayland
+# session needs any seat setup at all. libseat prefers logind and falls
+# back to the seatd daemon; on a systemd machine (every Omarchy, and
+# nearly every Arch desktop) logind is already granting device access
+# to whoever owns the active VT, so nothing else is required and
+# telling the user to enable seatd would be noise that invites them to
+# break a working setup. /run/systemd/seats is the direct evidence -
+# logind creates it - and an answering loginctl is the fallback for a
+# layout that differs.
+has_logind=""
+if [ -d /run/systemd/seats ] ||
+    { command -v loginctl >/dev/null 2>&1 && loginctl show-seat seat0 >/dev/null 2>&1; }; then
+    has_logind="yes"
 fi
 
 cat <<DONE
 
 chonkstep is installed - both binaries: chonkstep (X11) and
-chonkstep-wayland (the Smithay compositor).
+chonkstep-wayland (the Smithay compositor) - and both are real login
+sessions, running the same desktop.
 
 DONE
 if [ -n "$has_dm" ]; then
     cat <<DONE
-  - X11 session (the full desktop): log out and pick "chonkstep" in
-    ${has_dm}'s session list.
+  - X11 session: log out and pick "chonkstep" in ${has_dm}'s session list.
+  - Wayland session: log out and pick "chonkstep (Wayland)" in the same
+    list. It takes the graphics device, the input devices, and the VT
+    for itself - a session in its own right, not a window inside one.
 DONE
 else
     cat <<DONE
-  - X11 session (the full desktop): no display manager is enabled
-    (stock Omarchy boots straight into Hyprland), so switch to a TTY
-    (Ctrl+Alt+F3), log in, and run:
+  - X11 session: no display manager is enabled (stock Omarchy boots
+    straight into Hyprland), so switch to a TTY (Ctrl+Alt+F3), log in,
+    and run:
       startx ${repo}/scripts/xsession.sh
-    To get a graphical session picker instead, install and enable a
-    display manager (e.g. sddm) - the session entry is already in place.
+  - Wayland session: from that same TTY, instead run:
+      exec ${repo}/scripts/wayland-session.sh
+    (exec, so the compositor replaces the login shell and the session
+    ends when it does. No startx: it is the display server.)
+    To get a graphical session picker offering both instead, install
+    and enable a display manager (e.g. sddm) - both session entries are
+    already in place.
 DONE
 fi
 cat <<DONE
-  - Wayland: run the compositor nested inside your current desktop -
+  - Wayland, nested: for development or a look before you log in, run
       ${repo}/target/release/chonkstep-wayland
-    It opens a window that is its screen: same chrome, dock, menus, and
-    themes as the X11 session, with X11 apps running through XWayland.
-    Nested is the whole story today - the DRM/KMS session that would
-    make it a login option of its own is not built yet, which is why
-    this installer deliberately does not add a wayland-sessions entry.
+    from a terminal inside your current desktop. The compositor sees a
+    desktop already running and opens a window that is its screen -
+    same chrome, dock, menus, and themes, with X11 apps through
+    XWayland.
 DONE
-if [ "$session_type" = "wayland" ]; then
+if [ -z "$has_logind" ]; then
     cat <<DONE
-    (You are on a Wayland session right now, so the nested compositor
-    will run here as-is; the X11 session above needs the TTY route.)
+  - Seat access: this machine has no logind, so the Wayland session
+    needs the seatd daemon (installed above) to hand it the graphics
+    and input devices. Enable it -
+      sudo systemctl enable --now seatd
+    or your init system's equivalent - and join the seat group:
+      sudo usermod -aG seat \$USER
+    Log out and back in afterwards for the group to take effect.
 DONE
 fi
 cat <<DONE
@@ -154,7 +206,7 @@ cat <<DONE
     (the whole file is optional and every line is documented; both
     backends read it).
   - Update later with: scripts/update.sh
-  - The session entry points at this checkout (${repo});
+  - Both session entries point at this checkout (${repo});
     moving the checkout means re-running scripts/install.sh.
 
 DONE

--- a/scripts/wayland-session.sh
+++ b/scripts/wayland-session.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Entry point for the "chonkstep (Wayland)" session listed in a login
+# manager's session picker (see
+# /usr/share/wayland-sessions/chonkstep.desktop, which points Exec at
+# this script), and the thing to `exec` from a bare TTY for a login
+# session with no display manager at all:
+#
+#     exec /path/to/chonkstep/scripts/wayland-session.sh
+#
+# The Wayland twin of scripts/xsession.sh, and the differences are the
+# interesting part. There is no Xorg here for the session to become the
+# window manager of: chonkstep-wayland *is* the display server, and it
+# takes the DRM device, the input devices, and the VT for itself
+# through libseat. That also means no nesting wrapper — the
+# development equivalent of scripts/dev-nested.sh's Xephyr is just
+# running the binary directly inside an existing desktop, where it
+# picks the winit backend on its own.
+#
+# `exec`d directly by the display manager or by the user's login
+# shell — PATH/env here is whatever that launcher provides, not this
+# user's usual interactive environment. Keep this self-contained;
+# don't assume dotfiles ran.
+set -u
+
+# Resolve the repo root from this script's own location so the session
+# works wherever the checkout lives (real hardware, VM, any username).
+BIN="$(cd "$(dirname "$0")/.." && pwd)/target/release/chonkstep-wayland"
+LOG_DIR="$HOME/.local/state/chonkstep"
+mkdir -p "$LOG_DIR"
+
+# Its own log, not the X11 session's: both sessions write into the
+# same state directory, and a Wayland login that clobbered
+# session.log would destroy the evidence from the X11 session the user
+# is about to fall back to when something goes wrong.
+LOG="$LOG_DIR/wayland-session.log"
+
+export RUST_LOG="${RUST_LOG:-info}"
+
+# What every well-behaved toolkit checks to decide whether it is
+# allowed to prefer its Wayland path. Nothing in chonkstep reads it —
+# this is for the clients.
+export XDG_SESSION_TYPE=wayland
+
+# Deliberately NO CHONKSTEP_BACKEND export. The compositor decides for
+# itself which half of its dual backend to run: an existing
+# WAYLAND_DISPLAY or DISPLAY means there is already a desktop here to
+# nest a window inside, and their absence means it owns the hardware.
+# Pinning it here would be a lie the moment someone copied this script
+# somewhere else — and it would also disable the one useful diagnostic,
+# which is that the compositor logs which backend it chose and why.
+#
+# The corollary is that a stale DISPLAY or WAYLAND_DISPLAY leaking in
+# from a launcher (or from a dotfile that exports DISPLAY=:0
+# unconditionally) would make the compositor try to open a window on a
+# desktop that is not there and fail on a black screen. This is a
+# login session; by definition neither variable is meaningful yet, so
+# clear both and let the decision be made from the truth. The
+# compositor exports its own values — the socket it allocates, and
+# DISPLAY from the XWayland server it starts — to everything it
+# spawns.
+unset DISPLAY WAYLAND_DISPLAY
+
+# Keyboard layout. libxkbcommon's XKB_DEFAULT_* convention is what the
+# compositor reads to build the seat's keymap (see state.rs), because a
+# session started from a TTY has no settings daemon to ask and a
+# hardcoded US layout is unusable for most of the world. These are
+# re-exported rather than assigned: whatever the environment already
+# carries wins, and a user who has none sets them either in their own
+# environment or by editing the block below —
+#
+#     XKB_DEFAULT_LAYOUT=de
+#     XKB_DEFAULT_VARIANT=nodeadkeys
+#     XKB_DEFAULT_OPTIONS=ctrl:nocaps
+#
+# — before the loop. The unset ones are left alone rather than exported
+# empty: the compositor already discards empty values (state.rs), but
+# XWayland and the toolkits read these variables too, and handing them
+# an empty string where the user simply has no preference is a worse-
+# formed environment than an absent variable.
+for _xkb in XKB_DEFAULT_RULES XKB_DEFAULT_MODEL XKB_DEFAULT_LAYOUT \
+            XKB_DEFAULT_VARIANT XKB_DEFAULT_OPTIONS; do
+    if [ -n "${!_xkb:-}" ]; then
+        export "${_xkb?}"
+    fi
+done
+unset _xkb
+
+# Deliberately NO picom, and this is not an oversight to be corrected
+# by copying the block over from scripts/xsession.sh. picom is an X11
+# compositing manager; under Wayland the compositor *is* the
+# compositor, and the translucent terminals the themes ask for are
+# composited by chonkstep-wayland itself in the same GLES scene that
+# draws the chrome. Starting picom here would at best do nothing (no
+# X11 root window to own) and at worst fight XWayland for redirection.
+
+# Rotate a runaway log at login rather than letting it grow without
+# bound: a session that once got stuck in an error loop (a dead X
+# connection being polled, before ShutdownRequested existed) left a
+# multi-gigabyte session.log behind. One .old generation is plenty for
+# postmortems; the append redirect below starts the fresh file.
+if [ -f "$LOG" ] && [ "$(wc -c < "$LOG")" -gt 52428800 ]; then
+    mv -f "$LOG" "$LOG.old"
+fi
+
+# Pre-flight, because the failure modes here are silent ones. A display
+# manager that starts this and gets an immediate exit drops the user
+# back at the greeter with no explanation, and the session log would
+# hold nothing at all: the redirect that creates it is on the exec
+# below. So the two things that can be wrong before the compositor
+# even runs are said out loud, into both the log and the launcher's
+# stderr.
+fail() {
+    printf 'chonkstep-wayland session: %s\n' "$1" | tee -a "$LOG" >&2
+    exit 1
+}
+
+# Not built, or the checkout moved out from under the session entry
+# installed by scripts/install.sh.
+[ -x "$BIN" ] || fail "$BIN is missing or not executable; build it with \
+'cargo build --release --workspace' in the checkout, or re-run scripts/install.sh if the checkout moved"
+
+# The compositor cannot create its Wayland socket without this; on a
+# systemd machine pam_systemd sets it at login, so its absence means
+# either a non-systemd login path or a launcher that stripped the
+# environment.
+[ -n "${XDG_RUNTIME_DIR:-}" ] || fail "XDG_RUNTIME_DIR is not set - a Wayland compositor has nowhere to put its socket"
+
+# A session bus is not optional plumbing for a modern desktop —
+# chonkstep itself never touches D-Bus, but the applications its menus
+# launch expect $DBUS_SESSION_BUS_ADDRESS to exist. Unlike the X11
+# script this wraps conditionally: a display manager that starts
+# sessions through the systemd user instance has already given us a
+# bus, and starting a second one inside it would split the session in
+# half — an app launched from the dock would not be able to talk to
+# the same app started from anywhere else. A TTY login usually has no
+# bus, and that is the case dbus-run-session exists for.
+if [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || ! command -v dbus-run-session >/dev/null 2>&1; then
+    exec "$BIN" >> "$LOG" 2>&1
+fi
+
+exec dbus-run-session -- "$BIN" >> "$LOG" 2>&1


### PR DESCRIPTION
Part 4 of 4. REVIEW ONLY, DO NOT MERGE - already on `main`.

libseat, udev, GBM/EGL, mode setting, page flips, libinput, VT
switching, window/output capture, and linux-dmabuf - what makes
chonkstep-wayland a session you log into from a TTY.

Verified live on an Omarchy VM (mode set at 1920x1200, native Wayland
and XWayland clients under WindowMaker chrome, VT switch pause/resume,
input injected through uinput). NOT verified on multi-GPU or real GPU
hardware - only virtio-gpu with llvmpipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPsrCnhqdDRnMz1Z7iDUd4