### PR TITLE
Fix session-lock unlock accepting any client (#43)

### DIFF
--- a/crates/chonk-testkit/src/bin/chonk-lock-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-lock-probe.rs
@@ -66,6 +66,11 @@
 //!    arrive. **`relocked on a reused surface WxH`**,
 //!    **`survived the third unlock teardown`**
 //!
+//! Run with `--hold` the script stops after step 2 and keeps the lock
+//! (**`holding the lock`**) instead of ever unlocking: that is the
+//! standing lock `chonk-lock-thief` is pointed at, and a bypass can
+//! only be attempted against a lock that is actually in force.
+//!
 //! Then it sits in its dispatch loop like any shell process would. A
 //! broken connection at any step prints `connection broke: ...` (with
 //! the protocol error, if one was posted) and exits 2.
@@ -462,6 +467,11 @@ fn unlock_and_teardown(
 }
 
 fn main() {
+    // `--hold` stops the script after the first lock and keeps it, for
+    // the bypass e2e; without it the full seven-step teardown script
+    // below runs. `Session::launch` passes argv but not environment, so
+    // the switch is a flag.
+    let hold = std::env::args().any(|arg| arg == "--hold");
     let conn = Connection::connect_to_env().unwrap_or_else(|e| fatal(&format!("no compositor: {e}")));
     let mut queue = conn.new_event_queue();
     let qh = queue.handle();
@@ -520,6 +530,22 @@ fn main() {
     let kept_wl_surface = compositor.create_surface(&qh, ());
     let (held, (w, h)) = lock_and_draw(&conn, &mut queue, &mut probe, &qh, &kept_wl_surface);
     println!("locked {w}x{h}");
+
+    // -- `--hold`: stop here, still locked ------------------------------
+    // The holder half of the bypass e2e. Everything below this point
+    // unlocks, and the bypass can only be attempted against a lock that
+    // is actually in force, so that test needs a locker that takes the
+    // lock and then does nothing but stay alive — the state a real
+    // locker sits in for as long as the user is away.
+    if hold {
+        println!("holding the lock");
+        let _ = std::io::stdout().flush();
+        loop {
+            if let Err(error) = queue.blocking_dispatch(&mut probe) {
+                broken(&conn, "the hold loop", &error);
+            }
+        }
+    }
 
     // -- 3: the teardown that killed omarchy-shell ----------------------
     unlock_and_teardown(

--- a/crates/chonk-testkit/src/bin/chonk-lock-thief.rs
+++ b/crates/chonk-testkit/src/bin/chonk-lock-thief.rs
@@ -1,0 +1,191 @@
+//! The lock-screen bypass, spelled as a client — the attacker half of
+//! the session-lock e2e, pointed at a `chonk-lock-probe --hold` that is
+//! holding a confirmed lock on the same session.
+//!
+//! This is not a synthetic sequence. It is every request a process
+//! needs to make, from no privilege beyond having opened the Wayland
+//! socket, to put the user's desktop back on an unattended screen:
+//!
+//! ```text
+//!  -> wl_registry#2.bind(ext_session_lock_manager_v1)
+//!  -> ext_session_lock_manager_v1#3.lock(new id 4)
+//!  <- ext_session_lock_v1#4.finished()     <- the compositor's refusal
+//!  -> ext_session_lock_v1#4.unlock_and_destroy()
+//! ```
+//!
+//! The third line is the compositor doing the right thing: a live
+//! locker already holds the session, so `lock::LockRequest::Deny` drops
+//! the confirmation, which sends `finished`. What it cannot do is
+//! destroy that object — only the client may — so the refusal hands the
+//! caller a live `ext_session_lock_v1` whose per-object `lock_status`
+//! is false, and smithay 0.7.0's `unlock_and_destroy` arm posts
+//! `invalid_unlock` on it *without returning* and then calls
+//! `state.unlock()` regardless. The error kills this process's
+//! connection, which an attacker does not care about, because by then
+//! the screen is already the user's desktop.
+//!
+//! What the fixed compositor does instead is refuse at the door:
+//! `lock::request_unlock` sees an object that is not the recorded
+//! holder, logs the attempt, and posts `invalid_unlock` *in place of*
+//! unlocking. From out here the two are told apart by exactly one
+//! thing — whether the session is still locked afterwards — which is
+//! why the checkpoints below are only half the test and
+//! `tests/session_lock.rs` takes the screenshot.
+//!
+//! The script, each step reported on stdout in the shape the e2e polls
+//! for:
+//!
+//! 1. Bind the manager. **`bound the lock manager`**
+//! 2. `lock`, and expect `finished` rather than `locked` — a session
+//!    already locked by someone else must refuse a second locker, and
+//!    if it does not, the bypass is not even needed.
+//!    **`lock refused`**
+//! 3. `unlock_and_destroy` on the refused object, then roundtrip.
+//!    **`unlock_and_destroy sent`**, then either
+//!    **`refused: <protocol error>`** (the connection died, no unlock)
+//!    or **`accepted without error`** (the compositor answered a
+//!    non-holder's unlock silently).
+//!
+//! Neither outcome is failure on its own: a compositor is entitled to
+//! answer an impostor with an error or with silence, and the assertion
+//! that matters is made by the harness against the session, not here.
+//! Exiting 0 either way is deliberate — this probe reports, the test
+//! judges.
+
+use std::io::Write;
+
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
+use wayland_client::protocol::wl_registry;
+use wayland_protocols::ext::session_lock::v1::client::{
+    ext_session_lock_manager_v1::ExtSessionLockManagerV1,
+    ext_session_lock_v1::{self, ExtSessionLockV1},
+};
+
+fn fatal(message: &str) -> ! {
+    eprintln!("chonk-lock-thief: {message}");
+    let _ = std::io::stdout().flush();
+    std::process::exit(1);
+}
+
+#[derive(Default)]
+struct Thief {
+    lock_manager: Option<ExtSessionLockManagerV1>,
+    /// `locked` arrived — the compositor handed the session to a client
+    /// that did not have it. A failure all by itself.
+    locked: bool,
+    /// `finished` arrived — the refusal this probe expects, and the
+    /// event that leaves the live object the bypass is sent on.
+    finished: bool,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for Thief {
+    fn event(
+        thief: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, .. } = event {
+            if interface == "ext_session_lock_manager_v1" {
+                thief.lock_manager = Some(registry.bind(name, 1, qh, ()));
+            }
+        }
+    }
+}
+
+impl Dispatch<ExtSessionLockV1, ()> for Thief {
+    fn event(
+        thief: &mut Self,
+        _: &ExtSessionLockV1,
+        event: ext_session_lock_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        match event {
+            ext_session_lock_v1::Event::Locked => thief.locked = true,
+            ext_session_lock_v1::Event::Finished => thief.finished = true,
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtSessionLockManagerV1, ()> for Thief {
+    fn event(
+        _: &mut Self,
+        _: &ExtSessionLockManagerV1,
+        _: <ExtSessionLockManagerV1 as Proxy>::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+/// The protocol error the compositor posted, if it killed us — the
+/// interesting half of a broken connection here, since being killed is
+/// the *expected* answer to this request.
+fn protocol_error(conn: &Connection) -> Option<String> {
+    let error = conn.protocol_error()?;
+    Some(format!(
+        "{}@{} code {}: {}",
+        error.object_interface, error.object_id, error.code, error.message
+    ))
+}
+
+fn main() {
+    let conn = Connection::connect_to_env().unwrap_or_else(|e| fatal(&format!("no compositor: {e}")));
+    let mut queue = conn.new_event_queue();
+    let qh = queue.handle();
+    let mut thief = Thief::default();
+    conn.display().get_registry(&qh, ());
+    queue.roundtrip(&mut thief).unwrap_or_else(|e| fatal(&format!("registry roundtrip failed: {e}")));
+
+    // -- 1: the manager, advertised to every client on the socket ------
+    // The filter on this global is deliberately `|_| true`
+    // (`state.rs`'s session-lock comment): locking is harmless, and a
+    // filter would need a sandboxing story this desktop does not have.
+    // That is the premise of this whole probe — it is not privileged,
+    // and nothing about it had to be.
+    let Some(manager) = thief.lock_manager.clone() else {
+        fatal("the compositor does not advertise ext_session_lock_manager_v1");
+    };
+    println!("bound the lock manager");
+
+    // -- 2: ask for the lock, and be refused ---------------------------
+    let lock = manager.lock(&qh, ());
+    if let Err(error) = queue.roundtrip(&mut thief) {
+        fatal(&format!("the connection broke while asking for the lock: {error}"));
+    }
+    if thief.locked {
+        // The compositor handed a second client the lock outright,
+        // which is a worse bug than the one under test and needs no
+        // bypass at all.
+        println!("lock granted to a second client");
+        let _ = std::io::stdout().flush();
+        std::process::exit(0);
+    }
+    if !thief.finished {
+        fatal("the lock request was neither granted nor refused");
+    }
+    println!("lock refused");
+
+    // -- 3: the bypass ------------------------------------------------
+    // `finished` did not destroy the object — it cannot; only the
+    // client may — so this request is legal to *send*, and on smithay
+    // 0.7.0's unguarded path it reaches `SessionLockHandler::unlock`
+    // and the desktop comes back.
+    lock.unlock_and_destroy();
+    println!("unlock_and_destroy sent");
+    let _ = std::io::stdout().flush();
+    match queue.roundtrip(&mut thief) {
+        Err(error) => {
+            let reported = protocol_error(&conn).unwrap_or_else(|| error.to_string());
+            println!("refused: {reported}");
+        }
+        Ok(_) => println!("accepted without error"),
+    }
+    let _ = std::io::stdout().flush();
+}

--- a/crates/chonk-testkit/tests/session_lock.rs
+++ b/crates/chonk-testkit/tests/session_lock.rs
@@ -39,6 +39,14 @@
 //!    mandatory first configure and so can never draw
 //!    (`lock::prime_reused_lock_surface`).
 //!
+//! The second test in this file is about the way out rather than the
+//! teardown: `ext-session-lock-v1` is the session's one security
+//! boundary, and `unlock_and_destroy` has to be answered on the
+//! strength of WHO sent it. Two clients — the locker holding a
+//! confirmed lock, and `chonk-lock-thief` making the three requests a
+//! bypass needs — against the assertion that the screen is still a
+//! wall afterwards. See its own comments for the mechanism.
+//!
 //! Same run rules as `e2e.rs`: needs a live Wayland session to nest
 //! in, so `#[ignore]`d; run with `scripts/e2e.sh` or
 //! `cargo test -p chonk-testkit -- --ignored --test-threads=1`.
@@ -49,7 +57,7 @@ use std::time::Duration;
 /// The probe's captured stdout/stderr — checkpoint lines, and on a
 /// kill, the connection post-mortem it prints before exiting.
 fn probe_log(session: &Session) -> String {
-    std::fs::read_to_string(session.dir.join("client-0-chonk-lock-probe.log")).unwrap_or_default()
+    session.client_log("chonk-lock-probe")
 }
 
 /// Waits for the probe to print `checkpoint`, failing with the whole
@@ -57,10 +65,17 @@ fn probe_log(session: &Session) -> String {
 /// "connection broke" post-mortem, the most useful thing a failure
 /// here can say.
 fn checkpoint(session: &Session, checkpoint: &str) {
-    poll_until(Duration::from_secs(15), &format!("the probe to report {checkpoint:?}"), || {
-        probe_log(session).contains(checkpoint).then_some(())
+    client_checkpoint(session, "chonk-lock-probe", checkpoint);
+}
+
+/// [`checkpoint`] for any of this test file's probes, named by binary.
+fn client_checkpoint(session: &Session, client: &str, checkpoint: &str) {
+    poll_until(Duration::from_secs(15), &format!("{client} to report {checkpoint:?}"), || {
+        session.client_log(client).contains(checkpoint).then_some(())
     })
-    .unwrap_or_else(|timeout| panic!("{timeout}\n-- probe log --\n{}", probe_log(session)));
+    .unwrap_or_else(|timeout| {
+        panic!("{timeout}\n-- {client} log --\n{}", session.client_log(client))
+    });
 }
 
 #[test]
@@ -125,5 +140,117 @@ fn a_lockers_other_surfaces_survive_the_unlock_teardown() {
     let log = probe_log(&session);
     assert!(!log.contains("connection broke"), "the probe reported a broken connection:\n{log}");
     assert!(session.compositor_alive(), "the compositor must outlive all three cycles");
+    session.kill_client("chonk-lock-probe");
+}
+
+/// The lock screen's fill, as `chonk-lock-probe` paints it —
+/// `LOCK_NAVY` in the probe is premultiplied ARGB8888 little-endian
+/// (B, G, R, A), so the RGB a screenshot reads back is its middle
+/// three bytes reversed.
+const LOCK_NAVY_RGB: [u8; 3] = [0x08, 0x18, 0x40];
+
+#[test]
+#[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit -- --ignored --test-threads=1"]
+fn a_client_that_does_not_hold_the_lock_cannot_unlock_the_session() {
+    // The lock-screen bypass, driven over the real wire by two real
+    // clients. `chonk-lock-probe --hold` is the user's locker: it takes
+    // the lock, draws, is confirmed, and then does nothing — the state
+    // a locker sits in while its owner is away from the machine.
+    // `chonk-lock-thief` is any other process on the socket, and makes
+    // the only three requests the bypass needs.
+    //
+    // The regression this pins is not the thief's fate — a compositor
+    // may answer an impostor with a protocol error or with silence, and
+    // either is defensible. It is whether the SESSION is still locked
+    // afterwards, which is why the assertions below are a screenshot of
+    // the desk and the compositor's own log, not the attacker's report.
+    let mut session =
+        Session::boot("session-lock-bypass", SessionOptions { scale: Some(1.0), ..Default::default() })
+            .unwrap();
+    let probe = profile_binary("chonk-lock-probe").expect("cargo build -p chonk-testkit builds the probe");
+    let thief = profile_binary("chonk-lock-thief").expect("cargo build -p chonk-testkit builds the thief");
+
+    // -- the locker takes the session and keeps it ------------------------
+    session.launch(probe.to_str().unwrap(), &["--hold"]).expect("the locker launches");
+    checkpoint(&session, "locked ");
+    checkpoint(&session, "holding the lock");
+
+    // What a locked session looks like from outside: the locker's navy
+    // fills the output, because `renderer::build_scene` returns before
+    // it can reach a single non-lock surface — including for `grim`,
+    // which is the client taking this picture.
+    session.door().barrier().expect("the compositor answers a barrier while locked");
+    let locked = session.screenshot("locked").expect("grim captures the locked session");
+    assert!(
+        chonk_testkit::near(locked.centre_rgb(), LOCK_NAVY_RGB),
+        "the session should be showing the lock screen before the attack, saw {:?} in {}",
+        locked.centre_rgb(),
+        locked.path.display()
+    );
+
+    // -- the attack --------------------------------------------------------
+    session.launch(thief.to_str().unwrap(), &[]).expect("the thief launches");
+    client_checkpoint(&session, "chonk-lock-thief", "bound the lock manager");
+    // The compositor must refuse a second lock while a live locker
+    // holds one — the denial is what leaves the thief a live
+    // `ext_session_lock_v1` to send the bypass on, so a session that
+    // GRANTED the lock here would be broken in a worse way.
+    client_checkpoint(&session, "chonk-lock-thief", "lock refused");
+    assert!(
+        session.log().contains("refusing a session lock"),
+        "the compositor should have logged refusing the second lock"
+    );
+    client_checkpoint(&session, "chonk-lock-thief", "unlock_and_destroy sent");
+    // Whichever way it was answered, the answer has been dispatched by
+    // the time the thief prints this.
+    poll_until(Duration::from_secs(15), "the thief to report how the unlock was answered", || {
+        let log = session.client_log("chonk-lock-thief");
+        (log.contains("refused: ") || log.contains("accepted without error")).then_some(())
+    })
+    .unwrap_or_else(|timeout| {
+        panic!("{timeout}\n-- thief log --\n{}", session.client_log("chonk-lock-thief"))
+    });
+
+    // -- the session is still a wall ---------------------------------------
+    // `unlock()` is the only writer of "session unlocked" and the only
+    // path that clears `backend.locked`, so its absence is a direct
+    // assertion on the flag every render and input gate reads.
+    let log = session.log();
+    assert!(
+        !log.contains("session unlocked"),
+        "a client that does not hold the lock unlocked the session:\n{}",
+        chonk_testkit::strip_ansi(&log)
+    );
+    // And the refusal is on the record as a security event, at `error`,
+    // with the offending process named.
+    assert!(
+        log.contains("refusing unlock_and_destroy"),
+        "the refused unlock should have been logged:\n{}",
+        chonk_testkit::strip_ansi(&log)
+    );
+
+    // The picture is the proof: still the locker's navy, and the same
+    // frame as before the attack rather than the desktop behind it.
+    session.door().barrier().expect("the compositor still answers a barrier");
+    let after = session.screenshot("after-bypass-attempt").expect("grim captures the session again");
+    assert!(
+        chonk_testkit::near(after.centre_rgb(), LOCK_NAVY_RGB),
+        "the session came out of the lock: centre {:?} in {}",
+        after.centre_rgb(),
+        after.path.display()
+    );
+    assert!(
+        locked.diff_fraction(&after, 8) < 0.01,
+        "the screen changed across the bypass attempt: {} in {}",
+        locked.diff_fraction(&after, 8),
+        after.path.display()
+    );
+
+    // The locker itself was never collateral: refusing the impostor
+    // must cost the client that legitimately holds the lock nothing.
+    let held = probe_log(&session);
+    assert!(!held.contains("connection broke"), "the locker's connection was broken:\n{held}");
+    assert!(session.compositor_alive(), "the compositor must outlive the bypass attempt");
+    session.kill_client("chonk-lock-thief");
     session.kill_client("chonk-lock-probe");
 }

--- a/crates/wm-wayland/src/lock.rs
+++ b/crates/wm-wayland/src/lock.rs
@@ -18,13 +18,19 @@
 //!   delivery against the lock surface, plus VT switching, which the
 //!   spec explicitly leaves to the compositor and which is the user's
 //!   only escape hatch on real hardware.
-//! - **Only `unlock_and_destroy` unlocks.** The lock *state* lives in
-//!   this compositor ([`LockMachine`]), not in the locker process: a
-//!   locker that crashes takes its surfaces with it and leaves the
-//!   state `Locked`, so the session blanks and stays blanked until a
-//!   new locker binds the manager and takes over — the spec's
-//!   recovery path, and the difference between a lock screen and a
-//!   screensaver.
+//! - **Only the holder's `unlock_and_destroy` unlocks.** The lock
+//!   *state* lives in this compositor ([`LockMachine`]), not in the
+//!   locker process: a locker that crashes takes its surfaces with it
+//!   and leaves the state `Locked`, so the session blanks and stays
+//!   blanked until a new locker binds the manager and takes over —
+//!   the spec's recovery path, and the difference between a lock
+//!   screen and a screensaver. And the request is authenticated
+//!   against the recorded holder before it is honoured: the manager
+//!   global is advertised to every client, so "a client asked to
+//!   unlock" and "the client holding the lock asked to unlock" are
+//!   different sentences, and only the second one is an unlock.
+//!   smithay 0.7.0 conflates them, which is a complete lock-screen
+//!   bypass; see the `ext_session_lock_v1` dispatch guard below.
 //!
 //! The `locked` event is only sent after a locked frame has actually
 //! been *presented* (`confirm_after_frame`, called from the dispatch
@@ -59,16 +65,20 @@
 //! `layers::keyboard_target` is where both this module and the layer
 //! shell ask who it belongs to.
 
-use smithay::delegate_session_lock;
 use smithay::output::Output;
-use smithay::reexports::wayland_protocols::ext::session_lock::v1::server::ext_session_lock_v1::ExtSessionLockV1;
+use smithay::reexports::wayland_protocols::ext::session_lock::v1::server::{
+    ext_session_lock_manager_v1::ExtSessionLockManagerV1,
+    ext_session_lock_surface_v1::ExtSessionLockSurfaceV1,
+    ext_session_lock_v1::{self, ExtSessionLockV1},
+};
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
-use smithay::reexports::wayland_server::Resource;
+use smithay::reexports::wayland_server::{Client, DataInit, DisplayHandle, Resource};
 use smithay::utils::SERIAL_COUNTER;
 use smithay::wayland::compositor::{add_pre_commit_hook, with_states, BufferAssignment, SurfaceAttributes};
 use smithay::wayland::session_lock::{
-    LockSurface, SessionLockHandler, SessionLockManagerState, SessionLocker,
+    ExtLockSurfaceUserData, LockSurface, SessionLockHandler, SessionLockManagerGlobalData,
+    SessionLockManagerState, SessionLockState, SessionLocker,
 };
 
 use wm_core::BackendEvent;
@@ -195,6 +205,69 @@ impl LockMachine {
     /// The protocol's `unlock_and_destroy` — the one and only way out.
     pub(crate) fn unlocked(&mut self) {
         *self = LockMachine::Unlocked;
+    }
+
+    /// Answers a client's `unlock_and_destroy`. `caller_is_holder` is
+    /// whether the `ext_session_lock_v1` the request arrived on is the
+    /// very object this compositor recorded as the holder — object
+    /// identity, not client identity, because a client may hold more
+    /// than one and only one of them took the lock.
+    ///
+    /// The lock is the compositor's single security boundary, so this
+    /// is a whitelist: everything that is not provably the holder
+    /// finishing a confirmed lock is refused, and refusals are named
+    /// so the caller can log which one happened.
+    pub(crate) fn request_unlock(&self, caller_is_holder: bool) -> UnlockRequest {
+        match self {
+            // The whole point. `Locked` is the state in which the
+            // `locked` event has gone out, which is the state the spec
+            // makes `unlock_and_destroy` legal in.
+            LockMachine::Locked if caller_is_holder => UnlockRequest::Accept,
+            LockMachine::Locked | LockMachine::Locking => {
+                if caller_is_holder {
+                    // The holder, but too early: `locked` has not been
+                    // sent, so the spec's own name for this request is
+                    // `invalid_unlock`. Upstream posts that error and
+                    // then unlocks anyway; refusing keeps the blank up,
+                    // and since the error kills the locker's connection
+                    // the holder goes dead and the recovery path admits
+                    // a replacement. Fail-secure, and recoverable.
+                    UnlockRequest::DenyUnconfirmed
+                } else {
+                    UnlockRequest::DenyNotHolder
+                }
+            }
+            // Nothing is locked; there is nothing to unlock. Harmless
+            // in itself, but it is still a caller asking for the one
+            // transition that matters, so it is refused by the same
+            // rule rather than by luck.
+            LockMachine::Unlocked => UnlockRequest::DenyNotHolder,
+        }
+    }
+}
+
+/// What an `unlock_and_destroy` request is answered with — the exit
+/// half of [`LockMachine::request_lock`]'s entry decision.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum UnlockRequest {
+    /// The holder is ending a confirmed lock: let it through.
+    Accept,
+    /// The caller is not the object holding the lock. This is the
+    /// lock-screen bypass, and a security event.
+    DenyNotHolder,
+    /// The holder asked before its `locked` event went out.
+    DenyUnconfirmed,
+}
+
+impl UnlockRequest {
+    /// The message that goes out with the protocol error, and into the
+    /// log beside it.
+    fn refusal(self) -> &'static str {
+        match self {
+            UnlockRequest::Accept => "",
+            UnlockRequest::DenyNotHolder => "This object does not hold the session lock.",
+            UnlockRequest::DenyUnconfirmed => "Session is not locked.",
+        }
     }
 }
 
@@ -331,7 +404,133 @@ impl SessionLockHandler for Compositor {
     }
 }
 
-delegate_session_lock!(Compositor);
+// ---------------------------------------------------------------------
+// Workaround: smithay's `unlock_and_destroy` unlocks for anyone.
+// ---------------------------------------------------------------------
+
+// `delegate_session_lock!(Compositor)` would emit all four of the
+// delegations below. Three of them are taken verbatim; the fourth —
+// `ext_session_lock_v1` itself — is written out by hand underneath so
+// that `unlock_and_destroy` can be authenticated before upstream sees
+// it. Keep this list in step with the macro
+// (`smithay-0.7.0/src/wayland/session_lock/mod.rs:227-244`) if smithay
+// ever adds an interface to it.
+smithay::reexports::wayland_server::delegate_global_dispatch!(Compositor: [
+    ExtSessionLockManagerV1: SessionLockManagerGlobalData
+] => SessionLockManagerState);
+smithay::reexports::wayland_server::delegate_dispatch!(Compositor: [
+    ExtSessionLockManagerV1: ()
+] => SessionLockManagerState);
+smithay::reexports::wayland_server::delegate_dispatch!(Compositor: [
+    ExtSessionLockSurfaceV1: ExtLockSurfaceUserData
+] => SessionLockManagerState);
+
+/// Authenticates `unlock_and_destroy` against the recorded holder, then
+/// hands every request on to smithay's implementation.
+///
+/// # The upstream bug
+///
+/// [`SessionLockHandler::unlock`] takes no argument, so the identity of
+/// the caller cannot reach a compositor through the handler at all —
+/// and smithay does not check it either.
+/// `smithay-0.7.0/src/wayland/session_lock/lock.rs:181-189`:
+///
+/// ```text
+/// Request::UnlockAndDestroy => {
+///     // Ensure session is locked.
+///     if !data.lock_status.load(Ordering::Relaxed) {
+///         lock.post_error(Error::InvalidUnlock, "Session is not locked.");
+///     }
+///
+///     state.lock_state().locked_outputs.clear();
+///     state.unlock();
+/// }
+/// ```
+///
+/// There is no `return` after the `post_error`, and `lock_status` is a
+/// **per-object** flag minted false for every `lock` request and set
+/// true only when the compositor confirms
+/// (`session_lock/mod.rs:143-152` and `:217-222`). So a client whose
+/// lock request this compositor *denied* holds a live
+/// `ext_session_lock_v1` with `lock_status == false` — the deny branch
+/// answers by dropping the confirmation, which sends `finished` but
+/// cannot destroy an object only the client may destroy — and sending
+/// `unlock_and_destroy` on it posts a protocol error that kills the
+/// *attacker's* connection and then falls through to `state.unlock()`,
+/// which is this module's. Three requests from any process that can
+/// open the Wayland socket — bind the manager, `lock`, then
+/// `unlock_and_destroy` on the object the denial left behind — and the
+/// screen in front of an unattended machine is the user's desktop
+/// again, keyboard and all.
+///
+/// # What this does instead
+///
+/// Every request is forwarded unchanged except `unlock_and_destroy`,
+/// which is put to [`LockMachine::request_unlock`] first. The identity
+/// compared is the protocol object: `session_lock.holder` is written
+/// only in `lock()`'s accept branch, from the confirmation's own
+/// `ext_session_lock_v1`, so equality here means "the object that took
+/// the lock now in force". `ObjectId` equality covers the client and
+/// the object's generation as well as its numeric id, so a destroyed
+/// object's id being handed out again cannot be mistaken for the
+/// holder.
+///
+/// A refused request is answered with the protocol's own
+/// `invalid_unlock`, which is accurate on both refusal paths — neither
+/// caller ever received `locked` on the object it is asking with — and
+/// which disconnects it. The compositor's lock state is not touched, so
+/// upstream's `unlock()` is never reached and the blank stays up.
+///
+/// # Removing this
+///
+/// When smithay returns after that `post_error` *and* passes the
+/// `&ExtSessionLockV1` to `SessionLockHandler::unlock`, this whole
+/// section collapses back to `delegate_session_lock!(Compositor)` plus
+/// a holder comparison at the top of [`Compositor::unlock`]. Until it
+/// does both, the delegation has to be split, because the handler
+/// signature is where the caller's identity is lost.
+impl smithay::reexports::wayland_server::Dispatch<ExtSessionLockV1, SessionLockState> for Compositor {
+    fn request(
+        state: &mut Self,
+        client: &Client,
+        lock: &ExtSessionLockV1,
+        request: ext_session_lock_v1::Request,
+        data: &SessionLockState,
+        dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        // Matching binds nothing, so the request is not moved and is
+        // still available to forward below.
+        if matches!(request, ext_session_lock_v1::Request::UnlockAndDestroy) {
+            let caller_is_holder =
+                state.session_lock.holder.as_ref().is_some_and(|holder| holder == lock);
+            let verdict = state.session_lock.machine.request_unlock(caller_is_holder);
+            if verdict != UnlockRequest::Accept {
+                // A refused unlock is an attempt on the session's one
+                // security boundary, not a routine protocol denial, so
+                // it is logged at `error` with enough to identify the
+                // process behind it. The pid is the only durable
+                // handle a user has on "which program did this"; a
+                // client that has already gone is not worth a failure
+                // here, hence the `ok()`.
+                let pid = client.get_credentials(dhandle).ok().map(|credentials| credentials.pid);
+                tracing::error!(
+                    ?verdict,
+                    pid,
+                    object = lock.id().protocol_id(),
+                    "refusing unlock_and_destroy: the session stays locked"
+                );
+                lock.post_error(ext_session_lock_v1::Error::InvalidUnlock, verdict.refusal());
+                return;
+            }
+        }
+        <SessionLockManagerState as smithay::reexports::wayland_server::Dispatch<
+            ExtSessionLockV1,
+            SessionLockState,
+            Compositor,
+        >>::request(state, client, lock, request, data, dhandle, data_init);
+    }
+}
 
 /// Sends the owed `locked` confirmation once a locked frame has been
 /// presented. Called from `dispatch_pending` after the render: a
@@ -700,6 +899,64 @@ mod tests {
         machine.frame_presented();
         machine.unlocked();
         assert!(!machine.locked());
+    }
+
+    #[test]
+    fn a_client_that_does_not_hold_the_lock_cannot_unlock() {
+        // The bypass, in the state machine: the real locker holds a
+        // confirmed lock, and a second client asks to unlock with an
+        // object that is not the holder's. smithay's dispatch would
+        // reach `unlock()` here; the guard is what stops it.
+        let mut machine = LockMachine::default();
+        machine.request_lock(false);
+        machine.frame_presented();
+        assert_eq!(machine.request_unlock(false), UnlockRequest::DenyNotHolder);
+        assert!(machine.locked(), "a refused unlock must not disturb the lock");
+    }
+
+    #[test]
+    fn the_holder_may_unlock_a_confirmed_lock() {
+        let mut machine = LockMachine::default();
+        machine.request_lock(false);
+        machine.frame_presented();
+        assert_eq!(machine.request_unlock(true), UnlockRequest::Accept);
+    }
+
+    #[test]
+    fn even_the_holder_may_not_unlock_before_its_locked_event() {
+        // `Locking` is the window between accepting the lock and
+        // presenting the first blanked frame. The spec's own name for
+        // an unlock here is `invalid_unlock` — "unlock requested but
+        // locked event was never sent" — so it is refused, and the
+        // blank holds rather than lifting on a client that is by
+        // definition not yet showing a lock screen.
+        let mut machine = LockMachine::default();
+        machine.request_lock(false);
+        assert_eq!(machine.request_unlock(true), UnlockRequest::DenyUnconfirmed);
+        assert_eq!(machine.request_unlock(false), UnlockRequest::DenyNotHolder);
+        assert!(machine.locked());
+    }
+
+    #[test]
+    fn an_unlock_on_an_unlocked_session_is_refused_rather_than_ignored() {
+        let machine = LockMachine::default();
+        assert_eq!(machine.request_unlock(true), UnlockRequest::DenyNotHolder);
+        assert_eq!(machine.request_unlock(false), UnlockRequest::DenyNotHolder);
+    }
+
+    #[test]
+    fn a_recovering_locker_may_unlock_the_session_it_took_over() {
+        // Refusing impostors must not cost the recovery path its exit:
+        // a locker that took over a dead one's session is the holder
+        // from the moment it is accepted, and unlocks like any other
+        // once its own frame is on screen.
+        let mut machine = LockMachine::default();
+        machine.request_lock(false);
+        machine.frame_presented();
+        // The holder dies; a replacement takes over and confirms.
+        assert_eq!(machine.request_lock(false), LockRequest::Accept);
+        assert!(machine.frame_presented());
+        assert_eq!(machine.request_unlock(true), UnlockRequest::Accept);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #43

## Root cause

Two defects compose into a complete lock-screen bypass.

**smithay 0.7.0 dispatches `unlock_and_destroy` without returning after its protocol error.** `smithay-0.7.0/src/wayland/session_lock/lock.rs:181-189`:

```rust
Request::UnlockAndDestroy => {
    // Ensure session is locked.
    if !data.lock_status.load(Ordering::Relaxed) {
        lock.post_error(Error::InvalidUnlock, "Session is not locked.");
    }

    state.lock_state().locked_outputs.clear();
    state.unlock();
}
```

`lock_status` is a **per-object** `Arc<AtomicBool>`, minted false for every `ext_session_lock_manager_v1.lock` (`session_lock/mod.rs:143-152`) and set true only when the compositor confirms (`:217-222`).

**`SessionLockHandler::unlock` takes no argument**, so the caller's identity never reaches chonkstep, and `lock.rs`'s `unlock()` was unconditional — it never consulted the `holder` it separately records at `lock.rs:222`.

chonkstep answers a second lock request correctly (`LockRequest::Deny`, `finished`), but `finished` cannot destroy an object only the client may destroy. The denial therefore hands the caller a live `ext_session_lock_v1` with `lock_status == false`, and `unlock_and_destroy` on it posts a protocol error that kills the *attacker's* connection and then falls through to `state.unlock()`.

Three requests from any process that can open the Wayland socket, with the real locker alive and holding:

1. bind `ext_session_lock_manager_v1` (the global's filter is `|_| true` by design);
2. `lock` — refused;
3. `unlock_and_destroy` on the object the refusal left behind.

Reproduced on the wire against the real compositor, not inferred. With the guard disabled, the compositor log reads:

```
INFO  wm_wayland::lock: refusing a session lock: a live locker already holds one
WARN  wm_wayland::state: client killed for a protocol error object=ext_session_lock_v1 object_id=4 code=1 Session is not locked.
INFO  wm_wayland::lock: session unlocked
```

The last line is the desktop coming back on an unattended screen.

## Behavioral change

`delegate_session_lock!(Compositor)` is expanded by hand: three of its four delegations are taken verbatim, and `ext_session_lock_v1` gets a `Dispatch` impl in `lock.rs` that authenticates `unlock_and_destroy` before upstream sees it. Every other request forwards unchanged.

The decision is pure and lives beside the existing lifecycle machine, mirroring `LockMachine::request_lock(holder_alive)`:

```rust
LockMachine::request_unlock(&self, caller_is_holder: bool) -> UnlockRequest
```

- **`Locked` + caller is the holder → `Accept`.** Forwarded to smithay, which finds `lock_status` true, posts nothing, and unlocks. The normal path is untouched.
- **caller is not the holder → `DenyNotHolder`.** The bypass. Logged at `error`, answered with `invalid_unlock`, and the lock state is not touched.
- **`Locking` + caller is the holder → `DenyUnconfirmed`.** The lesser bug in #43: the `locked` event has not been sent, so the spec's own name for this request is `invalid_unlock` ("unlock requested but locked event was never sent"). Upstream posts that error *and* unlocks; this refuses. The error kills the locker's connection either way, so the holder goes dead and the crashed-locker recovery path admits a replacement — fail-secure and still recoverable, rather than fail-open.
- **`Unlocked` → `DenyNotHolder`.** Refused by rule rather than by luck.

The identity compared is the protocol object, not the client: `session_lock.holder` is written only in `lock()`'s accept branch from the confirmation's own `ext_session_lock_v1`. `ObjectId` equality covers client id and object generation as well as the numeric id, so a re-used id cannot be mistaken for the holder.

## Invariants and edge cases

- **The crashed-locker recovery path is untouched.** `lock.rs:171-178` still admits a replacement when the holder is dead, and that replacement becomes the holder and can unlock normally — pinned by a new unit test. An attacker cannot reach this path: it cannot destroy another client's lock object.
- **Fail-secure.** Every refusal leaves `backend.locked`, `lock_surfaces` and the machine exactly as they were; upstream's `unlock()` is never reached.
- **A refused unlock is a security event, not a routine denial**, so it logs at `error` with the offending pid (via `Client::get_credentials`) and object id:
  ```
  ERROR wm_wayland::lock: refusing unlock_and_destroy: the session stays locked verdict=DenyNotHolder pid=389994 object=4
  ```
- **No new privilege model.** The manager global stays unfiltered — locking really is harmless, and `state.rs:2989-2992`'s reasoning about that is correct. It simply does not extend to unlocking, which is what this changes.
- **The legitimate locker is never collateral.** The existing unlock-teardown e2e (`a_lockers_other_surfaces_survive_the_unlock_teardown`) still passes unchanged, including all three of its lock/unlock cycles.
- The hand-expanded delegation list carries a comment to keep it in step with `delegate_session_lock!` if smithay adds an interface to it.

## Tests added

**Unit** (`crates/wm-wayland/src/lock.rs`, 5 new):

- `a_client_that_does_not_hold_the_lock_cannot_unlock`
- `the_holder_may_unlock_a_confirmed_lock`
- `even_the_holder_may_not_unlock_before_its_locked_event`
- `an_unlock_on_an_unlocked_session_is_refused_rather_than_ignored`
- `a_recovering_locker_may_unlock_the_session_it_took_over`

**Wire-level e2e** (`crates/chonk-testkit/tests/session_lock.rs::a_client_that_does_not_hold_the_lock_cannot_unlock_the_session`), two real clients against a real nested compositor:

- `chonk-lock-probe --hold` (new flag) takes the lock, draws, is confirmed, and then holds it — the state a locker sits in while its owner is away.
- `chonk-lock-thief` (new probe) makes exactly the three requests above and reports what it was answered.
- The assertions are on the *session*, not the attacker's fate: `grim` screenshots before and after must both be the locker's navy (`near(centre_rgb, [8,24,64])`) and must not differ (`diff_fraction < 0.01`), the compositor log must not contain `session unlocked`, and it must contain the `error`-level refusal. The locker's own connection must be intact.

**Verified the test fails without the fix.** With the guard short-circuited and everything else identical:

```
thread 'a_client_that_does_not_hold_the_lock_cannot_unlock_the_session' panicked at
crates/chonk-testkit/tests/session_lock.rs:211:5:
a client that does not hold the lock unlocked the session:
...
test result: FAILED. 0 passed; 1 failed
```

## Commands run

| Command | Result |
| --- | --- |
| `cargo test -p wm-wayland` | ok — 378 passed, 2 ignored |
| `cargo test --workspace --all-targets` | ok — 0 failed across all targets |
| `cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks` | clean |
| `RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' cargo doc --workspace --no-deps --locked --document-private-items` | clean |
| `git diff --check` | clean |
| `cargo test -p chonk-testkit --test session_lock -- --ignored --test-threads=1` | ok — 2 passed (nested, real compositor) |

`scripts/e2e.sh --headless` **could not be run on this machine: `weston` is not installed** (`--headless` exits with "e2e.sh: --headless needs weston on PATH"), and the non-headless path additionally exits on a missing `zenity`. Instead the nesting suite was run directly against a live session, target by target, for everything session-, lock- and protocol-adjacent that does not require `zenity`:

```
session_lock      ok — 2 passed      session_restore   ok — 4 passed
wayland_globals   ok — 1 passed      idle              ok — 1 passed
layer_bar         ok — 2 passed      focus_grab        ok — 1 passed
supervisor        ok — 1 passed      control_socket    ok — 2 passed
```

`tests/e2e.rs` and `tests/hyprland_ipc.rs` are the two targets that launch `zenity` and were not run; CI's Wayland job covers both.

## Performance

Not applicable. The guard adds one `Option<ExtSessionLockV1>` comparison on the `unlock_and_destroy` request only — once per lock cycle, off every hot path.

## Known limitations and follow-up

- **The upstream bug is unreported so far.** Acceptance criterion 5 asks for it, and it needs a decision I did not want to make unilaterally: filing on `Smithay/smithay` is a public post from the maintainer's account. The report is written and ready — the missing `return` at `session_lock/lock.rs:183`, plus the durable fix of passing `&ExtSessionLockV1` to `SessionLockHandler::unlock` so a compositor can compare it against its own holder. Say the word and I will file it, or it can go up under whichever account is preferred. Until *both* land upstream, the split delegation has to stay: the handler signature is where the caller's identity is lost, so returning after the `post_error` alone would not be enough.
- The `# Removing this` section on the new impl says exactly what to delete when upstream does land, matching the convention the two existing workarounds in this module already follow.
- `Request::Destroy` has the same missing-`return` shape upstream but nothing after the `post_error`, so it is inert and is left alone; it forwards unchanged.
