### PR TITLE
Make the numeric keypad bindable (#90)

### DIFF
--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -165,6 +165,10 @@ pub mod keys {
     pub const X: u32 = 45;
     pub const LEFTALT: u32 = 56;
     pub const SPACE: u32 = 57;
+    /// The lock key and keypad digit used together to prove keypad
+    /// bindings are independent of the active Num Lock level.
+    pub const NUMLOCK: u32 = 69;
+    pub const KP1: u32 = 79;
     pub const UP: u32 = 103;
     pub const LEFT: u32 = 105;
     pub const RIGHT: u32 = 106;

--- a/crates/chonk-testkit/tests/commands.rs
+++ b/crates/chonk-testkit/tests/commands.rs
@@ -42,6 +42,16 @@ fn marker(dir: &Path, name: &str) -> Option<()> {
     dir.join(name).exists().then_some(())
 }
 
+/// The number of completed command writes, once at least `wanted`
+/// have landed. A bound key can run a process asynchronously, so the
+/// filesystem is the observable completion boundary rather than a
+/// sleep after input injection.
+fn marker_lines(dir: &Path, name: &str, wanted: usize) -> Option<usize> {
+    let text = std::fs::read_to_string(dir.join(name)).ok()?;
+    let lines = text.lines().count();
+    (lines >= wanted).then_some(lines)
+}
+
 /// The whole point of the seam: a bound key runs the command it names.
 ///
 /// Before this existed there was no way to bind a key to anything the
@@ -89,6 +99,47 @@ fn a_bare_media_key_runs_a_command() {
     session.door().tap_key(keys::VOLUMEUP).expect("key injects");
     poll_until(SPAWNED, "the marker written by the command `louder`", || marker(&dir, "louder"))
         .expect("a bare volumeup press should have run the command named `louder`");
+}
+
+/// A named keypad binding reaches the compositor's real keyboard path
+/// at both levels of the keypad keymap.
+///
+/// The config parser intentionally resolves `kp1` to the physical
+/// key's level-0 cursor symbol. This test is the integration proof for
+/// that policy: unlike table assertions, these evdev events update the
+/// seat's real xkb state and pass through production binding matching.
+#[test]
+#[ignore = "needs a live Wayland session to nest inside"]
+fn a_keypad_binding_fires_with_num_lock_off_and_on() {
+    let dir = session_dir("commands-keypad-numlock");
+    let presses = dir.join("presses");
+    let config = format!(
+        "[commands]\nmark = [\"sh\", \"-c\", \"echo ran >> {}\"]\n\n[keybindings]\n\"kp1\" = \"run mark\"\n",
+        presses.display()
+    );
+    let mut session = Session::boot(
+        "commands-keypad-numlock",
+        SessionOptions { config_extra: config, ..Default::default() },
+    )
+    .expect("session boots with a named keypad binding");
+
+    // A fresh default keymap starts with Num Lock off. KEY_KP1 must
+    // match its level-0 KP_End symbol through the real input path.
+    session.door().tap_key(keys::KP1).expect("keypad 1 injects with Num Lock off");
+    poll_until(SPAWNED, "the first keypad command write", || marker_lines(&dir, "presses", 1))
+        .expect("kp1 should run its command with Num Lock off");
+
+    // Toggle the seat's real xkb modifier state, then inject the same
+    // physical key. Binding lookup must remain on the stable raw symbol
+    // even though client delivery would now see the Num Lock level.
+    session.door().tap_key(keys::NUMLOCK).expect("Num Lock toggles on");
+    session.door().tap_key(keys::KP1).expect("keypad 1 injects with Num Lock on");
+    let writes = poll_until(SPAWNED, "the second keypad command write", || {
+        marker_lines(&dir, "presses", 2)
+    })
+    .expect("kp1 should run its command with Num Lock on");
+
+    assert_eq!(writes, 2, "one physical press in each Num Lock state must run exactly once");
 }
 
 /// Autostart runs on a genuinely new session, in file order.

--- a/crates/wm-config/src/hyprland/keys.rs
+++ b/crates/wm-config/src/hyprland/keys.rs
@@ -26,8 +26,8 @@
 //! available at config-read time is the standard US mapping the
 //! numbers were chosen against. [`KEYCODES`] is that mapping, and it
 //! covers exactly the range Omarchy actually uses plus the rest of the
-//! main block; a keycode outside it is refused by name rather than
-//! guessed at.
+//! main block and the numeric keypad; a keycode outside it is refused
+//! by name rather than guessed at.
 //!
 //! This is a real limitation and it is written down rather than
 //! papered over: on a non-US layout `code:20` is whatever key sits
@@ -105,15 +105,29 @@ pub fn spec_for(keys: &str) -> Result<String, KeyTrouble> {
         if chunk.is_empty() {
             continue;
         }
-        // `SUPER_SHIFT` is one chunk holding two modifiers; a key name
-        // never contains `_`, so splitting here is unambiguous.
+        // `SUPER_SHIFT` is one chunk holding two modifiers, so `_`
+        // has to be split on — but only as far as the modifiers go.
+        // This used to split the whole chunk on the premise that "a
+        // key name never contains `_`", which is false for every key
+        // on the numeric keypad: `KP_Enter` became the two tokens
+        // `KP` and `Enter`, and the line was refused with
+        // `UnknownModifier("KP")` — the real reason a numpad binding
+        // from a Hyprland config never worked, and a reason that
+        // named the wrong thing.
+        //
+        // So the leading run of modifiers is peeled off and whatever
+        // follows is one key token, underscores intact. The first
+        // part that is not a modifier begins the key, which keeps
+        // `SUPER_SHIFT` and `SUPER_KP_Enter` both reading correctly
+        // and needs no list of which key names contain `_`.
         if chunk.contains('_') && !chunk.to_ascii_lowercase().starts_with("code:") {
-            tokens.extend(
-                chunk
-                    .split('_')
-                    .filter(|p| !p.is_empty())
-                    .map(str::to_string),
-            );
+            let parts: Vec<&str> = chunk.split('_').filter(|part| !part.is_empty()).collect();
+            let leading_modifiers =
+                parts.iter().take_while(|part| modifier_name(part).is_some()).count();
+            tokens.extend(parts[..leading_modifiers].iter().map(|part| (*part).to_string()));
+            if leading_modifiers < parts.len() {
+                tokens.push(parts[leading_modifiers..].join("_"));
+            }
         } else {
             tokens.push(chunk.to_string());
         }
@@ -265,6 +279,30 @@ pub fn keycode_name(code: u32) -> Option<&'static str> {
         117 => "pagedown",
         118 => "insert",
         119 => "delete",
+        // The numeric keypad, in the evdev map's own order — note 63
+        // and 125 sit well outside the 79..=91 run the other keypad
+        // keys form, which is why this is a list and not a range.
+        // Names are `parse_key`'s, so a `code:` binding and a named
+        // one resolve to the same keysym; see `crate::keysym_for`'s
+        // keypad block for why the digits are named by the key rather
+        // than by their NumLock-on keysym.
+        63 => "kpmultiply",
+        79 => "kp7",
+        80 => "kp8",
+        81 => "kp9",
+        82 => "kpsubtract",
+        83 => "kp4",
+        84 => "kp5",
+        85 => "kp6",
+        86 => "kpadd",
+        87 => "kp1",
+        88 => "kp2",
+        89 => "kp3",
+        90 => "kp0",
+        91 => "kpdecimal",
+        104 => "kpenter",
+        106 => "kpdivide",
+        125 => "kpequal",
         // Omarchy binds this Apple-keyboard position as its menu key;
         // the evdev map aliases X keycode 201 to F23.
         201 => "f23",
@@ -312,5 +350,51 @@ const XKEYSYM_ALIASES: &[(&str, &str)] = &[
     // short ones.
     ("prior", "pageup"),
     ("next", "pagedown"),
-    ("kp_enter", "return"),
+    // The keypad, in X's underscored spelling — Hyprland's configs use
+    // these names verbatim.
+    //
+    // `kp_enter` used to map to `return`, which is not a normalisation
+    // but a substitution of one key for another. It never fired: the
+    // chunk splitter above tore `KP_Enter` into `KP` + `Enter` before
+    // `key_name` — and therefore this table — was ever consulted, so
+    // the entry was dead and the line was refused as
+    // `UnknownModifier("KP")` instead. That makes it a trap rather
+    // than a live bug, and one that fixing the splitter alone would
+    // have sprung: `bind()` de-duplicates by combo, so a config
+    // binding both `SUPER, Return` and `SUPER, KP_Enter` would have
+    // kept only the second action, on the MAIN Enter key, silently.
+    // The two had to be fixed together.
+    ("kp_enter", "kpenter"),
+    ("kp_add", "kpadd"),
+    ("kp_subtract", "kpsubtract"),
+    ("kp_multiply", "kpmultiply"),
+    ("kp_divide", "kpdivide"),
+    ("kp_decimal", "kpdecimal"),
+    ("kp_separator", "kpseparator"),
+    ("kp_equal", "kpequal"),
+    ("kp_0", "kp0"),
+    ("kp_1", "kp1"),
+    ("kp_2", "kp2"),
+    ("kp_3", "kp3"),
+    ("kp_4", "kp4"),
+    ("kp_5", "kp5"),
+    ("kp_6", "kp6"),
+    ("kp_7", "kp7"),
+    ("kp_8", "kp8"),
+    ("kp_9", "kp9"),
+    // The same keys under their NumLock-off names, which is what a
+    // config written against the cursor-mode symbols spells.
+    ("kp_home", "kphome"),
+    ("kp_end", "kpend"),
+    ("kp_up", "kpup"),
+    ("kp_down", "kpdown"),
+    ("kp_left", "kpleft"),
+    ("kp_right", "kpright"),
+    ("kp_prior", "kpprior"),
+    ("kp_page_up", "kppageup"),
+    ("kp_next", "kpnext"),
+    ("kp_page_down", "kppagedown"),
+    ("kp_begin", "kpbegin"),
+    ("kp_insert", "kpinsert"),
+    ("kp_delete", "kpdelete"),
 ];

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -1289,6 +1289,199 @@ fn a_keycode_resolves_through_the_layout_the_numbers_were_chosen_against() {
 }
 
 #[test]
+fn underscore_separates_modifiers_without_splitting_a_key_name() {
+    // `_` is one of the three separators Hyprland puts between
+    // modifiers, and it is also inside the name of every key on the
+    // numeric keypad. The splitter used to assume the first and take
+    // the whole chunk apart, so `KP_Enter` arrived as `KP` + `Enter`
+    // and the line was refused for a modifier nobody wrote.
+    assert_eq!(keys::spec_for("SUPER_SHIFT RETURN").as_deref(), Ok("super+shift+return"));
+    assert_eq!(keys::spec_for("SUPER, KP_Enter").as_deref(), Ok("super+kpenter"));
+    // Modifiers and an underscored key name in one chunk: the leading
+    // run of modifiers comes off and the rest stays whole.
+    assert_eq!(keys::spec_for("SUPER_KP_Enter").as_deref(), Ok("super+kpenter"));
+    assert_eq!(keys::spec_for("SUPER_SHIFT_KP_Add").as_deref(), Ok("super+shift+kpadd"));
+    // A genuinely unknown key still reports itself, and reports the
+    // whole name rather than the fragment after the last underscore.
+    assert_eq!(
+        keys::spec_for("SUPER, KP_Nonsense"),
+        Err(keys::KeyTrouble::UnknownKey("KP_Nonsense".into()))
+    );
+    // The pointer bindings that also contain `_` are still refused as
+    // pointer bindings, ahead of any of this.
+    assert!(matches!(keys::spec_for("SUPER, mouse_up"), Err(keys::KeyTrouble::NotAKey(_))));
+}
+
+#[test]
+fn kp_enter_is_its_own_key_and_does_not_steal_the_main_enter_binding() {
+    // Two failures at once, which is why this asserts both halves.
+    // On main `KP_Enter` did not resolve at all — the chunk splitter
+    // tore it into `KP` + `Enter` and the line was refused as
+    // `UnknownModifier("KP")`. Behind that stood a dead
+    // `("kp_enter", "return")` alias, so fixing only the splitter
+    // would have turned a refused binding into a silent collision:
+    // `bind()` de-duplicates by combo, and a config binding both
+    // `SUPER, Return` and `SUPER, KP_Enter` would have kept just the
+    // second action, on the main Enter key. On an Omarchy machine the
+    // binding that would have removed is the terminal's.
+    assert_eq!(keys::spec_for("SUPER, Return").as_deref(), Ok("super+return"));
+    assert_eq!(keys::spec_for("SUPER, KP_Enter").as_deref(), Ok("super+kpenter"));
+    assert_ne!(
+        keys::spec_for("SUPER, KP_Enter"),
+        keys::spec_for("SUPER, Return"),
+        "the numpad's Enter and the main Enter are different keys"
+    );
+    // And they really are two distinct keysyms downstream, not two
+    // spellings the parser folds back together.
+    let numpad = crate::parse_key("super+kpenter").expect("kpenter parses");
+    let main = crate::parse_key("super+return").expect("return parses");
+    assert_eq!(numpad.keysym, 0xff8d, "XK_KP_Enter");
+    assert_eq!(main.keysym, 0xff0d, "XK_Return");
+    assert_ne!(numpad, main);
+}
+
+#[test]
+fn binding_both_enters_leaves_two_bindings_rather_than_one() {
+    // The collision end-to-end, through the reader that de-duplicates
+    // by combo: the shape of an Omarchy config that also binds the
+    // numpad. On main the second line was refused outright, so the
+    // numpad did nothing; with the splitter fixed but the `kp_enter`
+    // alias left pointing at `return` both lines would collide on
+    // `super+return` and the terminal binding would vanish. Only both
+    // fixes together give the two bindings this asserts.
+    let root = scratch("kp-enter-collision");
+    write(
+        &root.join(".config/hypr/hyprland.conf"),
+        "bind = SUPER, Return, exec, my-terminal\nbind = SUPER, KP_Enter, exec, my-calculator\n",
+    );
+    let reading = read(&Roots::under(&root));
+    assert_eq!(
+        argv_for(&reading, "super+return"),
+        Some(vec!["my-terminal".into()]),
+        "the main Enter must keep its own action"
+    );
+    assert_eq!(
+        argv_for(&reading, "super+kpenter"),
+        Some(vec!["my-calculator".into()]),
+        "the numpad Enter must get its own binding"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_keypad_is_bindable_by_name_in_both_spellings() {
+    // Every keypad key Hyprland can name, resolved. The digits and the
+    // cursor-mode names are two spellings of one key, so they must
+    // produce the same keysym — see `keysym_for`'s keypad block.
+    for (hypr, spec) in [
+        ("KP_1", "kp1"),
+        ("KP_5", "kp5"),
+        ("KP_0", "kp0"),
+        ("KP_Add", "kpadd"),
+        ("KP_Subtract", "kpsubtract"),
+        ("KP_Multiply", "kpmultiply"),
+        ("KP_Divide", "kpdivide"),
+        ("KP_Decimal", "kpdecimal"),
+        ("KP_End", "kpend"),
+        ("KP_Begin", "kpbegin"),
+        ("KP_Insert", "kpinsert"),
+    ] {
+        assert_eq!(
+            keys::spec_for(&format!("SUPER, {hypr}")).as_deref(),
+            Ok(format!("super+{spec}").as_str()),
+            "{hypr}"
+        );
+    }
+    for (digit, cursor) in
+        [("kp1", "kpend"), ("kp5", "kpbegin"), ("kp0", "kpinsert"), ("kpdecimal", "kpdelete")]
+    {
+        assert_eq!(
+            crate::parse_key(digit).map(|combo| combo.keysym),
+            crate::parse_key(cursor).map(|combo| combo.keysym),
+            "{digit} and {cursor} are the same key"
+        );
+    }
+}
+
+#[test]
+fn a_keypad_binding_names_the_keysym_the_compositor_will_actually_see() {
+    // The correction that makes this fix work rather than merely
+    // parse. Bindings are matched against the keycode's LEVEL-0
+    // keysym (`wm-wayland`'s `input.rs`), and on the stock US map the
+    // keypad's digits are all at level 2, behind NumLock:
+    //
+    //   $ xkbcli how-to-type --keysym KP_1
+    //   KEYCODE 87  KP1  LEVEL# 2  MODIFIERS [ Mod2 NumLock ]
+    //   $ xkbcli how-to-type --keysym KP_End
+    //   KEYCODE 87  KP1  LEVEL# 1  MODIFIERS [ ]
+    //
+    // So XK_KP_1 (0xffb1) is a keysym this compositor can never be
+    // handed for a binding. Naming `kp1` after it would produce a
+    // binding that parses, warns about nothing and never fires. Each
+    // digit therefore resolves to its key's level-0 keysym, which also
+    // makes the binding independent of how NumLock happens to be set.
+    for (spec, keysym) in [
+        ("kp7", 0xff95),
+        ("kp4", 0xff96),
+        ("kp8", 0xff97),
+        ("kp6", 0xff98),
+        ("kp2", 0xff99),
+        ("kp9", 0xff9a),
+        ("kp3", 0xff9b),
+        ("kp1", 0xff9c),
+        ("kp5", 0xff9d),
+        ("kp0", 0xff9e),
+        ("kpdecimal", 0xff9f),
+    ] {
+        let combo = crate::parse_key(spec).unwrap_or_else(|| panic!("{spec} parses"));
+        assert_eq!(combo.keysym, keysym, "{spec}");
+        assert!(
+            !(0xffb0..=0xffb9).contains(&combo.keysym),
+            "{spec} resolved to a NumLock-only keysym, which can never match"
+        );
+    }
+    // The operators have no second level to hide behind and keep their
+    // own keysyms.
+    for (spec, keysym) in [
+        ("kpenter", 0xff8d),
+        ("kpmultiply", 0xffaa),
+        ("kpadd", 0xffab),
+        ("kpsubtract", 0xffad),
+        ("kpdivide", 0xffaf),
+        ("kpequal", 0xffbd),
+    ] {
+        assert_eq!(crate::parse_key(spec).map(|combo| combo.keysym), Some(keysym), "{spec}");
+    }
+}
+
+#[test]
+fn the_keypads_keycodes_resolve_too() {
+    // `code:N` and the name must land on the same key, or a config
+    // that mixes the two spellings gets two bindings where it meant
+    // one. Note 63 and 125 sit outside the 79..=91 run the rest of the
+    // keypad forms.
+    for (code, spec) in [
+        (63, "kpmultiply"),
+        (79, "kp7"),
+        (82, "kpsubtract"),
+        (84, "kp5"),
+        (86, "kpadd"),
+        (87, "kp1"),
+        (90, "kp0"),
+        (91, "kpdecimal"),
+        (104, "kpenter"),
+        (106, "kpdivide"),
+        (125, "kpequal"),
+    ] {
+        assert_eq!(
+            keys::spec_for(&format!("SUPER + code:{code}")).as_deref(),
+            Ok(format!("super+{spec}").as_str()),
+            "code:{code}"
+        );
+    }
+}
+
+#[test]
 fn a_chord_of_nothing_but_modifiers_is_not_a_binding() {
     assert_eq!(
         keys::spec_for("SUPER + SHIFT"),

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -748,6 +748,70 @@ fn keysym_for(token: &str) -> Option<u32> {
         "kbdlightonoff" => 0x1008ff04,
         "calculator" => 0x1008ff1d,
         "eject" => 0x1008ff2c,
+        // The numeric keypad. Every name here is a name for a *key*,
+        // and the keysym each one resolves to is the one the
+        // compositor will actually be handed when that key is pressed
+        // — which for half the pad is NOT the keysym its X11 name
+        // suggests, so this block needs its reasoning stated.
+        //
+        // A binding is matched against the LEVEL-0 keysym of the
+        // keycode (`wm-wayland`'s `input.rs`: the unshifted sym, so
+        // that Alt+Shift+T matches T with SHIFT in the mask rather
+        // than the shifted sym). The keypad's digits do not live at
+        // level 0. On the stock US map every one of them is at level
+        // 2, behind NumLock — `xkbcli how-to-type --keysym KP_1` says
+        // `keycode 87, level 2, [ Mod2 NumLock ]`, while level 1 of
+        // that same keycode is `KP_End`. So `KP_1` (0xffb1) is a
+        // keysym this compositor can never see for a binding, and a
+        // table that mapped `kp1` to it would hand back a spec that
+        // parses, warns about nothing, and never fires — the exact
+        // silent failure this block exists to end.
+        //
+        // Each digit therefore names its key by the keysym that key
+        // actually delivers, which is the NumLock-off (cursor-mode)
+        // one. The upshot is the behaviour a user wants and would
+        // assume: `kp1` means the numpad's 1 key, and it fires
+        // whichever way NumLock happens to be set, because level-0
+        // lookup does not consult NumLock at all. Both spellings are
+        // accepted for the same key — the digit a user reads off the
+        // keycap, and the X11 cursor-mode name someone who knows the
+        // keysym table would reach for — in the same way "return" and
+        // "enter" are one key above.
+        "kp0" | "kpinsert" => 0xff9e,
+        "kp1" | "kpend" => 0xff9c,
+        "kp2" | "kpdown" => 0xff99,
+        "kp3" | "kpnext" | "kppagedown" => 0xff9b,
+        "kp4" | "kpleft" => 0xff96,
+        "kp5" | "kpbegin" => 0xff9d,
+        "kp6" | "kpright" => 0xff98,
+        "kp7" | "kphome" => 0xff95,
+        "kp8" | "kpup" => 0xff97,
+        "kp9" | "kpprior" | "kppageup" => 0xff9a,
+        "kpdecimal" | "kpdelete" => 0xff9f,
+        // The operators and Enter have no second level to hide behind:
+        // each is a single-level key whose own keysym is at level 0
+        // (`xkbcli` puts KP_Add, KP_Subtract, KP_Multiply, KP_Divide,
+        // KP_Enter and KP_Equal all at level 1, no modifiers), so
+        // these names mean exactly what they say.
+        //
+        // `kpenter` is the numpad's own Enter, and a different key
+        // from `return` — 0xff8d against 0xff0d. The Hyprland reader
+        // used to alias `kp_enter` to `return`, which would have made
+        // a numpad-Enter binding quietly replace the main Enter key's
+        // (see `hyprland::keys`'s alias table for why that never
+        // actually fired, and why it had to be fixed anyway).
+        "kpenter" => 0xff8d,
+        "kpadd" => 0xffab,
+        "kpsubtract" => 0xffad,
+        "kpmultiply" => 0xffaa,
+        "kpdivide" => 0xffaf,
+        "kpequal" => 0xffbd,
+        // Not on the US map at all, where <KPDL> is KP_Delete/
+        // KP_Decimal; layouts that use a comma as the decimal mark put
+        // it at level 0 of that key. Named for the same reason as the
+        // rest: a key this format cannot name is unbindable, and a
+        // user on such a layout cannot take it back by hand either.
+        "kpseparator" => 0xffac,
         _ => return None,
     };
     Some(keysym)

--- a/crates/wm-config/tests/example_doc.rs
+++ b/crates/wm-config/tests/example_doc.rs
@@ -106,3 +106,44 @@ fn every_documented_media_key_name_parses() {
         assert!(wm_config::parse_key(&format!("super+{name}")).is_some(), "super+{name}");
     }
 }
+
+/// The keypad names the reference documents, in both spellings, and
+/// the promise it makes about them: the two spellings of a digit are
+/// the same key, and the numpad's Enter is not the main one.
+#[test]
+fn every_documented_keypad_key_name_parses() {
+    for name in [
+        "kp0", "kp1", "kp2", "kp3", "kp4", "kp5", "kp6", "kp7", "kp8", "kp9", "kpenter",
+        "kpadd", "kpsubtract", "kpmultiply", "kpdivide", "kpdecimal", "kpequal", "kpinsert",
+        "kpend", "kpdown", "kpnext", "kpleft", "kpbegin", "kpright", "kphome", "kpup",
+        "kpprior", "kpdelete", "kppageup", "kppagedown", "kpseparator",
+    ] {
+        assert!(
+            wm_config::parse_key(name).is_some(),
+            "the docs list {name} as a key token, but the parser does not know it"
+        );
+        assert!(wm_config::parse_key(&format!("super+{name}")).is_some(), "super+{name}");
+    }
+    // "kp1 is also kpend", as the reference puts it.
+    for (digit, cursor) in [
+        ("kp0", "kpinsert"),
+        ("kp1", "kpend"),
+        ("kp2", "kpdown"),
+        ("kp3", "kpnext"),
+        ("kp4", "kpleft"),
+        ("kp5", "kpbegin"),
+        ("kp6", "kpright"),
+        ("kp7", "kphome"),
+        ("kp8", "kpup"),
+        ("kp9", "kpprior"),
+        ("kpdecimal", "kpdelete"),
+    ] {
+        assert_eq!(
+            wm_config::parse_key(digit),
+            wm_config::parse_key(cursor),
+            "the docs say {digit} and {cursor} are the same key"
+        );
+    }
+    // "a different key from return", which is the whole point.
+    assert_ne!(wm_config::parse_key("kpenter"), wm_config::parse_key("return"));
+}

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -448,7 +448,7 @@
 #         bound bare: "volumeup" = "run volume-up"
 #   Numeric keypad:
 #         kp0 through kp9, kpenter, kpadd, kpsubtract, kpmultiply,
-#         kpdivide, kpdecimal, kpequal
+#         kpdivide, kpdecimal, kpseparator, kpequal
 #         kpenter is the keypad's own Enter, a different key from
 #         return. Each digit is also spellable by its NumLock-off
 #         name -- kp1/kpend, kp2/kpdown, kp3/kpnext, kp4/kpleft,

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -446,6 +446,15 @@
 #         eject, search
 #         These take modifiers like any other key, and are usually
 #         bound bare: "volumeup" = "run volume-up"
+#   Numeric keypad:
+#         kp0 through kp9, kpenter, kpadd, kpsubtract, kpmultiply,
+#         kpdivide, kpdecimal, kpequal
+#         kpenter is the keypad's own Enter, a different key from
+#         return. Each digit is also spellable by its NumLock-off
+#         name -- kp1/kpend, kp2/kpdown, kp3/kpnext, kp4/kpleft,
+#         kp5/kpbegin, kp6/kpright, kp7/kphome, kp8/kpup,
+#         kp9/kpprior, kp0/kpinsert, kpdecimal/kpdelete -- and the
+#         two spellings name the same key either way NumLock is set.
 #
 # Actions (kebab-case, a closed set):
 #   spawn-terminal, close, toggle-maximize, toggle-shade, miniaturize,

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -364,6 +364,15 @@ are usually bound bare: `volumeup`, `volumedown`, `volumemute` (or
 `brightnessdown`, `kbdbrightnessup`, `kbdbrightnessdown`, `poweroff`,
 `search`.
 
+The numeric keypad: `kp0`–`kp9`, `kpenter`, `kpadd`, `kpsubtract`,
+`kpmultiply`, `kpdivide`, `kpdecimal`, `kpequal`. `kpenter` is the
+numpad's own Enter and is a different key from `return` — binding one
+does not touch the other. Each digit can also be spelled by the name
+X gives it with NumLock off (`kp1` is also `kpend`, `kp5` is also
+`kpbegin`, `kp0` is also `kpinsert`, `kpdecimal` is also `kpdelete`,
+and so on); the two spellings are the same key, and a keypad binding
+fires whichever way NumLock is set.
+
 A typo'd combo or unknown action is warned about and skipped; every
 other line still applies.
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -365,11 +365,11 @@ are usually bound bare: `volumeup`, `volumedown`, `volumemute` (or
 `search`.
 
 The numeric keypad: `kp0`–`kp9`, `kpenter`, `kpadd`, `kpsubtract`,
-`kpmultiply`, `kpdivide`, `kpdecimal`, `kpequal`. `kpenter` is the
-numpad's own Enter and is a different key from `return` — binding one
-does not touch the other. Each digit can also be spelled by the name
-X gives it with NumLock off (`kp1` is also `kpend`, `kp5` is also
-`kpbegin`, `kp0` is also `kpinsert`, `kpdecimal` is also `kpdelete`,
+`kpmultiply`, `kpdivide`, `kpdecimal`, `kpseparator`, `kpequal`.
+`kpenter` is the numpad's own Enter and is a different key from
+`return` — binding one does not touch the other. Each digit can also be
+spelled by the name X gives it with NumLock off (`kp1` is also `kpend`,
+`kp5` is also `kpbegin`, `kp0` is also `kpinsert`, `kpdecimal` is also `kpdelete`,
 and so on); the two spellings are the same key, and a keypad binding
 fires whichever way NumLock is set.
 


### PR DESCRIPTION
Fixes #90

## Root cause

Keypad bindings failed at three layers:

1. the Hyprland reader split every underscore, so `KP_Enter` became `KP` plus `Enter` and was rejected before alias resolution;
2. `keysym_for` had no keypad entries;
3. `keycode_name` stopped before the keypad.

The old `KP_Enter -> Return` alias was dead because of the splitter, but fixing only the splitter would have activated that alias and silently collided with the main Return binding.

## Fix

- The Hyprland splitter peels off only a leading run of modifiers and preserves the remaining underscored key name.
- `KP_Enter` resolves to its distinct keypad keysym.
- Keypad operators, digits, cursor-mode aliases, and standard keypad keycodes are supported.
- Digits resolve to the stable level-0 cursor symbol used by compositor binding matching, so one named binding works with Num Lock off and on.
- Both reference documents now publish the complete list, including `kpseparator`.

## Regression coverage

Parser tests cover underscore handling, distinct Return/KP_Enter bindings, both keypad spellings, level-0 keysyms, and keypad keycodes. Documentation tests ensure every published keypad name parses.

A new real-compositor test boots a headless nested session, binds `kp1` to an observable command, injects evdev `KEY_KP1`, toggles evdev `KEY_NUMLOCK`, injects `KEY_KP1` again, and proves the command ran exactly once in each state. This exercises the real seat xkb state and production keyboard binding path rather than only constants.

## Review repairs

The branch was rebased onto current `main`. The missing `kpseparator` documentation was added to both published lists, and the requested live Num Lock off/on integration proof was added.

## Validation at `c2a669f89c86793b1bc873395d201f8a6869f2e9`

- `cargo test -p wm-config` — 146 unit tests passed, 1 diagnostic ignored; all 10 doc/preset integration tests passed
- `cargo test -p chonk-testkit` — passed
- `cargo test --workspace --all-targets` — passed
- strict workspace/all-targets Clippy with all repository deny flags — passed
- strict locked workspace docs with private items — passed
- `cargo test -p wm-wayland` — 198 passed, 1 benchmark ignored
- focused headless keypad/NumLock E2E — passed
- full `scripts/e2e.sh --headless` — every runnable suite passed, including the new six-test commands suite and real installed Omarchy checks
- `git diff --check` — passed