### PR TITLE
Name keys in hyprctl binds instead of printing keysyms (#59)

### DIFF
--- a/crates/chonk-testkit/tests/hyprland_ipc.rs
+++ b/crates/chonk-testkit/tests/hyprland_ipc.rs
@@ -222,6 +222,60 @@ fn answers_the_queries_quickshell_makes_on_connect() {
     assert!(!request(&dir, "binds").trim().is_empty(), "the keybinding menu receives the live keymap");
 }
 
+/// `hyprctl binds` must name keys, because the thing reading it prints
+/// the name to a human.
+///
+/// `omarchy-menu-keybindings` — the script behind `SUPER + K` — parses
+/// the PLAIN bind block (deliberately, not `-j`: its own comment says
+/// Hyprland 0.56.0 emits invalid JSON for binds), awk-splits out the
+/// `key` field and puts it straight into a menu row. So the field is
+/// read by a person, and a `key` of `0x1008ff13` is a cheat sheet that
+/// has failed at the one thing it exists for.
+///
+/// The four chords bound here are the four shapes that were broken:
+/// the whole `XF86` block, the function keys, the editing keys, and
+/// `space` — which is not merely wrong but blank, and which on a real
+/// Omarchy desktop is `SUPER + SPACE`, the chord that opens the menu.
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn binds_names_every_key_rather_than_reporting_its_keysym_in_hex() {
+    let mut options = SessionOptions::default();
+    options.env.push(("CHONKSTEP_HYPRLAND_IPC".to_string(), "1".to_string()));
+    options.config_extra = "\n[keybindings]\n\
+        \"super+space\" = \"overview\"\n\
+        \"volumeup\" = \"toggle-dock\"\n\
+        \"super+f9\" = \"miniaturize\"\n\
+        \"super+shift+backspace\" = \"close\"\n"
+        .to_string();
+    let session = Session::boot("hypr-ipc-bind-names", options).expect("nested session");
+    let dir = socket_dir(&session);
+
+    let plain = request(&dir, "binds");
+    let keys: Vec<&str> = plain
+        .lines()
+        .filter_map(|line| line.trim().strip_prefix("key: "))
+        .map(str::trim_end)
+        .collect();
+    assert!(!keys.is_empty(), "no key fields in the bind block:\n{plain}");
+
+    // Not one row may be a hex number or blank — the two failures.
+    for key in &keys {
+        assert!(!key.starts_with("0x"), "a bind is reported as hex: {key:?}\n{plain}");
+        assert!(!key.is_empty(), "a bind is reported as blank\n{plain}");
+    }
+    // And the specific keys that used to be, by name.
+    for expected in ["space", "F9", "BackSpace", "XF86AudioRaiseVolume"] {
+        assert!(keys.contains(&expected), "no bind reported as {expected:?}, saw {keys:?}");
+    }
+
+    // The JSON encoding carries the same field and had the same bug.
+    let binds = json(&dir, "j/binds");
+    for bind in binds.as_array().expect("binds is an array") {
+        let key = bind["key"].as_str().expect("every bind has a string key");
+        assert!(!key.starts_with("0x") && !key.is_empty(), "j/binds key {key:?}");
+    }
+}
+
 /// A real window reaches both halves of the protocol, with one address.
 ///
 /// Quickshell correlates event payloads with `j/clients` entries by

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -35,6 +35,8 @@
 //! the pattern `docs/control-socket.md` established and the one
 //! `clippy.toml`'s incident report exists to protect.
 
+use smithay::input::keyboard::{xkb, Keysym};
+
 use chonk_hyprland_ipc::dispatch::{Action, Fullscreen};
 use chonk_hyprland_ipc::state::{Binding, Devices, Keyboard, Monitor, PointerDevice, Snapshot, Window, Workspace};
 use chonk_hyprland_ipc::Server;
@@ -315,12 +317,49 @@ fn hypr_modmask(modifiers: wm_core::Modifiers) -> u32 {
         | (u32::from(modifiers.contains(wm_core::Modifiers::SUPER)) << 6)
 }
 
+/// The name `hyprctl binds` reports for a bound key, in both the plain
+/// and the JSON encoding.
+///
+/// The consumer prints this string verbatim — `omarchy-menu-keybindings`,
+/// the script behind `SUPER + K`, awk-splits the plain bind block and
+/// puts the `key` field straight into a menu row — so a name that is
+/// not a key name is a cheat sheet that has failed at the one thing it
+/// exists for.
+///
+/// This used to be a seven-entry table with a `format!("0x{keysym:x}")`
+/// catch-all, which took the entire `XF86` block, `F1`-`F12`,
+/// `BackSpace`, `Delete`, `Insert`, `Home`, `End`, `Page_Up`,
+/// `Page_Down` and `Print` — about a quarter of Omarchy's shipped
+/// keymap, rendered as hexadecimal. `space` was worse: it fell inside
+/// the printable-ASCII arm at `0x20` and came out as a literal space,
+/// so `SUPER + SPACE`, the chord that opens Omarchy's own menu, listed
+/// itself as blank.
+///
+/// libxkbcommon's registry is the authority instead. It has a name for
+/// every keysym this compositor can bind, and the name it gives is the
+/// spelling Hyprland's config syntax uses for that key — so the round
+/// trip out through here and back through `wm_config`'s `keysym_for`
+/// lands on the same key.
 fn keysym_name(keysym: u32) -> String {
-    match keysym {
-        0xff0d => "RETURN".into(), 0xff09 => "TAB".into(), 0xff1b => "ESCAPE".into(),
-        0xff51 => "LEFT".into(), 0xff52 => "UP".into(), 0xff53 => "RIGHT".into(), 0xff54 => "DOWN".into(),
-        0x20..=0x7e => char::from_u32(keysym).unwrap_or('?').to_ascii_uppercase().to_string(),
-        _ => format!("0x{keysym:x}"),
+    // Printable ASCII above space keeps the existing behaviour: its own
+    // character, uppercased. That half already agreed with Hyprland,
+    // which prints `W` rather than the registry's `w`, and a working
+    // case is not worth moving. `0x20` is deliberately NOT in this
+    // range any more — it is `space`, and it has a name.
+    if (0x21..=0x7e).contains(&keysym) {
+        return char::from_u32(keysym).unwrap_or('?').to_ascii_uppercase().to_string();
+    }
+    // `keysym_get_name` has its own zero-padded hex fallback for a
+    // keysym it does not know (`0x0ffffffe`), so this rarely fires —
+    // but its documented failure answer is an empty string, and a
+    // blank `key` field reads as "no key", which is exactly the
+    // failure `space` used to have. The hex is ugly on purpose: an
+    // unmappable value should stay visibly unmappable.
+    let name = xkb::keysym_get_name(Keysym::new(keysym));
+    if name.is_empty() {
+        format!("0x{keysym:x}")
+    } else {
+        name
     }
 }
 
@@ -493,4 +532,115 @@ fn window_of(wm: &WindowManager<WaylandBackend>, id: u64) -> Option<<WaylandBack
     wm.iter_clients()
         .find(|(candidate, _): &(wm_core::ClientId, _)| candidate.as_u64() == id)
         .map(|(_, client)| client.window)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keysym_name;
+
+    /// Key names the config format documents whose keysym is above
+    /// printable ASCII — precisely the set the old `format!("0x{:x}")`
+    /// catch-all swallowed, plus `space`, which the printable-ASCII arm
+    /// rendered as a literal space. Listed rather than derived so that
+    /// a key added to `wm-config` without a thought for the cheat sheet
+    /// is caught here rather than shipped as hex.
+    const NAMED_KEYS: &[&str] = &[
+        // Navigation and editing: the old table had seven of these and
+        // the catch-all took the rest.
+        "space", "return", "tab", "escape", "left", "up", "right", "down", "home", "end",
+        "pageup", "pagedown", "backspace", "delete", "insert", "print",
+        // The function keys.
+        "f1", "f9", "f12", "f23",
+        // The XF86 block, which the catch-all took whole.
+        "volumeup", "volumedown", "volumemute", "micmute", "playpause", "audiopause",
+        "audiostop", "audionext", "audioprev", "brightnessup", "brightnessdown",
+        "kbdbrightnessup", "kbdbrightnessdown", "kbdlightonoff", "poweroff", "search",
+        "touchpadtoggle", "touchpadon", "touchpadoff", "calculator", "eject",
+    ];
+
+    #[test]
+    fn no_named_key_is_reported_as_a_hex_number() {
+        // The defect: everything above 0x7e came out as hexadecimal,
+        // which is about a quarter of Omarchy's shipped keymap — every
+        // XF86 chord, both F9 chords and SUPER+SHIFT+BACKSPACE.
+        for spec in NAMED_KEYS {
+            let combo = wm_config::parse_key(spec).unwrap_or_else(|| panic!("{spec} must parse"));
+            let name = keysym_name(combo.keysym);
+            assert!(
+                !name.starts_with("0x"),
+                "{spec} (keysym {:#x}) is reported to hyprctl as {name:?}",
+                combo.keysym
+            );
+            assert!(!name.trim().is_empty(), "{spec} is reported as blank");
+        }
+    }
+
+    #[test]
+    fn space_is_named_rather_than_printed_as_a_space() {
+        // `space` is keysym 0x20, inside the old printable-ASCII arm,
+        // so it was rendered as a literal space character. `SUPER +
+        // SPACE` opens Omarchy's menu and is the most-pressed chord on
+        // the desktop; the cheat sheet listed it as blank.
+        let space = wm_config::parse_key("space").expect("space parses");
+        assert_eq!(space.keysym, 0x20);
+        assert_eq!(keysym_name(space.keysym), "space");
+    }
+
+    #[test]
+    fn every_named_key_is_reported_as_a_name_the_config_reader_can_read_back() {
+        // What makes these names right rather than merely non-hex:
+        // libxkbcommon's registry spelling is the one Hyprland's config
+        // syntax uses, so a chord this compositor prints into a cheat
+        // sheet can be pasted back into a Hyprland config and bind the
+        // same key. That closes the loop, and it is the property that
+        // would break first if the lookup were swapped for a hand table
+        // again.
+        for spec in NAMED_KEYS {
+            let combo = wm_config::parse_key(spec).expect("documented key parses");
+            let reported = keysym_name(combo.keysym);
+            let round_trip = wm_config::hyprland::keys::spec_for(&format!("SUPER, {reported}"))
+                .unwrap_or_else(|trouble| {
+                    panic!("hyprctl reports {spec} as {reported:?}, which reads back as {trouble:?}")
+                });
+            let parsed = wm_config::parse_key(&round_trip)
+                .unwrap_or_else(|| panic!("{round_trip:?} must parse"));
+            assert_eq!(
+                parsed.keysym, combo.keysym,
+                "{spec} is reported as {reported:?}, which reads back as a different key"
+            );
+        }
+    }
+
+    #[test]
+    fn printable_ascii_keeps_hyprlands_own_spelling() {
+        // The half that already worked and is deliberately left alone:
+        // Hyprland's `binds` prints `W`, not the registry's `w`.
+        //
+        // The punctuation here is the documented exception to the round
+        // trip above. `keysym_for` insists on the word `minus` in a
+        // spec — a literal `-` beside the `+` separator reads like a
+        // typo — so `-` does not read back, and that is the right
+        // trade: a cheat sheet row saying `SUPER + -` tells a user
+        // which key to press, and `SUPER + minus` makes them think.
+        for (spec, reported) in
+            [("w", "W"), ("7", "7"), ("slash", "/"), ("minus", "-"), ("period", ".")]
+        {
+            let combo = wm_config::parse_key(spec).expect("parses");
+            assert_eq!(keysym_name(combo.keysym), reported, "{spec}");
+        }
+    }
+
+    #[test]
+    fn a_keysym_with_no_name_stays_visibly_unmappable() {
+        // libxkbcommon answers an unknown keysym with its own
+        // zero-padded hex rather than the empty string its docs allow,
+        // so this is what actually reaches the field. Either way the
+        // requirement is the same and is what is asserted: never blank,
+        // and obviously not a key name.
+        for unknown in [0x0fff_fffe_u32, 0xdead_beef, 0xffff_ffff] {
+            let name = keysym_name(unknown);
+            assert!(name.starts_with("0x"), "{unknown:#x} -> {name:?}");
+            assert!(!name.trim().is_empty(), "{unknown:#x} -> blank");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #59

## Root cause

`keysym_name` (`crates/wm-wayland/src/hyprland_ipc.rs`) was a seven-entry table with a hex catch-all:

```rust
0xff0d => "RETURN".into(), 0xff09 => "TAB".into(), 0xff1b => "ESCAPE".into(),
0xff51 => "LEFT".into(), 0xff52 => "UP".into(), 0xff53 => "RIGHT".into(), 0xff54 => "DOWN".into(),
0x20..=0x7e => char::from_u32(keysym).unwrap_or('?').to_ascii_uppercase().to_string(),
_ => format!("0x{keysym:x}"),
```

The catch-all takes every keysym above `0x7e` — the whole `XF86` block, `F1`–`F12`, `BackSpace`, `Delete`, `Insert`, `Home`, `End`, `Page_Up`, `Page_Down`, `Print`. And `0x20` falls inside the printable-ASCII arm, so `space` came out as a literal space character.

That string is written verbatim into both encodings (`chonk-hyprland-ipc/src/server.rs`, `plain_bindings` and `json_bindings`), and `omarchy-menu-keybindings` — the script behind `SUPER + K` — awk-splits the plain bind block and puts the `key` field straight into a menu row.

## Measured, before and after

A nested session with four bindings covering the four broken shapes. The `key:` rows the IPC actually served, on this branch's own e2e:

**Before**

```
key:            <- super+space, the chord that opens Omarchy's menu
key: 0xff08     <- super+shift+backspace
key: 0xffc6     <- super+f9
key: ESCAPE
key: F
key: LEFT
key: RETURN
key: RIGHT
key: UP
...
```

**After**

```
["Return", "Q", "X", "S", "M", "F", "Right", "Left", "Right", "Left",
 "Up", "Escape", "space", "F9", "BackSpace", "XF86AudioRaiseVolume"]
```

## Behavioral change

`keysym_name` asks libxkbcommon's registry (`xkb::keysym_get_name`) for everything except printable ASCII **above** `0x20`, which keeps its existing character-uppercased form. Reachable through `smithay::input::keyboard::{xkb, Keysym}` — smithay re-exports the module (`pub use xkbcommon::xkb::{self, keysyms, Keycode, Keysym}`), so **no new dependency**, matching the note in `wm-wayland/Cargo.toml` that keysyms come through smithay's re-exports.

Two deliberate decisions:

- **`0x20` leaves the ASCII arm.** It is `space` and it has a name; that arm is now `0x21..=0x7e`. This is the single most visible row on the desktop.
- **Printable ASCII keeps `to_ascii_uppercase`.** Hyprland's own `binds` prints `W`, not the registry's `w`. That half already agreed and is not worth moving, per the issue.

**Visible change to seven rows that already worked:** the old table's uppercase spellings become the registry's canonical ones — `RETURN` → `Return`, `ESCAPE` → `Escape`, `LEFT` → `Left`, and so on. This follows from replacing the table rather than extending it, and it is the spelling Hyprland's config syntax uses, which is what makes the round-trip test below possible. Flagging it because it is a user-visible string change beyond the broken rows. Say the word if you would rather keep those seven uppercased and I will special-case them.

## Invariants and edge cases

- **`keysym_get_name` never yields a blank.** Its documented failure answer is an empty string, but in practice it has its own zero-padded hex fallback — measured: `0x0ffffffe → "0x0ffffffe"`, `0xdeadbeef → "0xdeadbeef"`, `0x0 → "NoSymbol"`. The `is_empty()` guard is kept anyway, because a blank `key` field reads as "no key" and is precisely the failure `space` had. Either path keeps an unmappable value visibly unmappable.
- **Punctuation is deliberately not round-trippable.** `minus` is reported as `-`, and `keysym_for` requires the word `minus` in a spec (a literal `-` beside the `+` separator reads like a typo). A cheat sheet row saying `SUPER + -` tells a user which key to press; `SUPER + minus` makes them think. Asserted explicitly so the trade is on the record rather than discovered later.
- `keycode` stays hardcoded `0`, as the issue scopes it — reporting a real one needs `wm_core::KeyCombo` to carry a keycode, which is a larger change than this.

## Tests added

Five unit tests in `crates/wm-wayland/src/hyprland_ipc.rs`, one wire-level e2e in `crates/chonk-testkit/tests/hyprland_ipc.rs`:

- `no_named_key_is_reported_as_a_hex_number` — every documented key whose keysym is above printable ASCII, which is exactly the set the catch-all swallowed.
- `space_is_named_rather_than_printed_as_a_space`
- `every_named_key_is_reported_as_a_name_the_config_reader_can_read_back` — the property that makes these names *right* rather than merely non-hex: each reported name is fed back through `wm_config::hyprland::keys::spec_for` and must parse to the same keysym. A chord printed into a cheat sheet can be pasted into a Hyprland config and bind the same key.
- `printable_ascii_keeps_hyprlands_own_spelling` — the guard on the half that already worked, plus the punctuation exception.
- `a_keysym_with_no_name_stays_visibly_unmappable`
- `binds_names_every_key_rather_than_reporting_its_keysym_in_hex` (e2e) — boots a nested session binding `super+space`, `volumeup`, `super+f9` and `super+shift+backspace`, then asserts over **both** encodings that no `key` field is hex or blank, and that `space`, `F9`, `BackSpace` and `XF86AudioRaiseVolume` each appear by name.

**Verified failing without the fix.** Source reverted, tests kept:

```
test result: FAILED. 2 passed; 3 failed
    every_named_key_is_reported_as_a_name_the_config_reader_can_read_back
    no_named_key_is_reported_as_a_hex_number
    space_is_named_rather_than_printed_as_a_space
      hyprctl reports space as " ", which reads back as UnknownKey("SUPER")
      space is reported as blank
```

The two that pass on the old code are the guards on behaviour deliberately preserved. The e2e likewise fails on the old binary, reporting `key: 0xff08`.

## Commands run

| Command | Result |
| --- | --- |
| `cargo test -p wm-wayland` | ok — 0 failed |
| `cargo test --workspace --all-targets` | ok — 0 failed |
| `cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks` | clean |
| `RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' cargo doc --workspace --no-deps --locked --document-private-items` | clean |
| `git diff --check` | clean |
| `cargo test -p chonk-testkit --test hyprland_ipc -- --ignored` | 7 passed, 7 failed — see below |

`scripts/e2e.sh --headless` **could not be run on this machine: `weston` is not installed**; the non-headless path additionally exits on a missing `zenity`.

The 7 `hyprland_ipc` e2e failures are **pre-existing and environmental**, not from this change. `zenity` is the harness's long-lived window and is not installed here, so every test needing a real window fails. Baseline measured on unmodified `e0c1692` with the same command: **the identical 7 tests fail** (`a_real_window_appears_in_the_stream_and_the_client_list`, `focused_click_is_snapshot_free_and_drag_syncs_only_its_toplevel`, `foreign_toplevel_mapping_returns_the_same_live_ipc_address`, `native_control_mutations_reach_the_hyprland_event_stream`, `silently_moves_a_real_window_without_following_it`, `switches_the_workspace_for_real`, `window_geometry_plain_fields_and_monitor_eval_are_applied_before_ok`). Main scores 5 passed / 7 failed; this branch scores 7 passed / 7 failed — the 2 gained are the new test and nothing regressed. CI's `wayland` job runs the full suite with all clients present.

## Performance

Not applicable. `keysym_get_name` is a registry lookup into a 64-byte stack buffer, run once per binding per `binds` request — a request a bar makes when a user opens the cheat sheet.
