### PR TITLE
Release hidden Dock, Clip, strip and panel buffers (#95)

### DIFF
--- a/crates/chonk-shell/src/desktop.rs
+++ b/crates/chonk-shell/src/desktop.rs
@@ -1887,7 +1887,9 @@ impl<B: Backend> Desktop<B> {
             // would keep whatever hover state it drew.
             self.clear_dock_hover(backend, theme);
             backend.unmap_shell_surface(self.dock_window);
+            backend.release_shell_buffer(self.dock_window);
             backend.unmap_shell_surface(self.clip_window);
+            backend.release_shell_buffer(self.clip_window);
         } else {
             // Configured and painted before it is mapped, so the column
             // never appears for a frame at the geometry or the palette
@@ -4152,6 +4154,65 @@ mod tests {
         assert!(desktop.set_reservation(&mut backend, &theme, EdgeReservation::default()));
         assert_eq!(backend.shell_geometries[&desktop.dock_window()], before);
         assert_eq!(desktop.primary_workarea().size.w, screen.w - tile);
+    }
+
+    #[test]
+    fn hiding_the_dock_releases_the_columns_and_the_clips_pixels() {
+        use wm_core::fake_backend::FakeBackend;
+
+        // The Dock and the Clip keep their surfaces across a hide —
+        // destroy/recreate churn is what the stable identity avoids —
+        // but nothing can draw them while hidden, so the column's
+        // raster (one tile wide by the summed height of every widget
+        // slot) and the Clip's tile are dead weight until the show path
+        // repaints them, which it does before mapping.
+        let primary = Rect { pos: Point::new(0, 0), size: TEST_SCREEN };
+        let mut backend = FakeBackend::new();
+        let mut desktop: Desktop<FakeBackend> = Desktop::new(
+            &mut backend,
+            TEST_SCREEN,
+            primary,
+            1.0,
+            &test_theme(),
+            wm_theme::Appearance::Dark,
+            Vec::new(),
+            wm_theme::FontState::new(),
+        );
+        let theme = wm_theme::default_theme::theme_by_id("nextstep-classic").unwrap();
+        let (dock, clip) = (desktop.dock_window(), desktop.clip_window());
+
+        // Both are painted while shown — otherwise the assertions below
+        // would pass on a Dock that never had pixels to release.
+        desktop.redraw_dock(&mut backend, &theme);
+        desktop.reposition_clip(&mut backend, &theme);
+        assert!(
+            backend.shell_buffer_bytes.get(&dock).is_some_and(|bytes| *bytes > 0),
+            "the column must hold pixels before the hide under test"
+        );
+        assert!(
+            backend.shell_buffer_bytes.get(&clip).is_some_and(|bytes| *bytes > 0),
+            "the Clip must hold pixels before the hide under test"
+        );
+
+        assert!(desktop.set_dock_visibility(&mut backend, &theme, DockVisibility::Hidden));
+        assert_eq!(backend.shell_buffer_bytes.get(&dock), None, "the hidden column kept its raster");
+        assert_eq!(backend.shell_buffer_bytes.get(&clip), None, "the hidden Clip kept its raster");
+        // Released, not destroyed: the surfaces are what the next show
+        // reuses.
+        assert!(backend.shell_geometries.contains_key(&dock), "the column's surface must survive the hide");
+        assert!(backend.shell_geometries.contains_key(&clip), "the Clip's surface must survive the hide");
+
+        // And showing paints again before mapping, so the column never
+        // appears as its background fill for a frame.
+        assert!(desktop.set_dock_visibility(&mut backend, &theme, DockVisibility::Shown));
+        assert!(
+            backend.shell_buffer_bytes.get(&dock).is_some_and(|bytes| *bytes > 0),
+            "showing the Dock must repaint the column"
+        );
+        assert!(
+            backend.shell_buffer_bytes.get(&clip).is_some_and(|bytes| *bytes > 0),
+            "showing the Dock must repaint the Clip"
+        );
     }
 
     #[test]

--- a/crates/chonk-shell/src/dockapp/panel.rs
+++ b/crates/chonk-shell/src/dockapp/panel.rs
@@ -219,10 +219,15 @@ impl<B: Backend> InstrumentPanel<B> {
     }
 
     /// Takes the panel off screen and forgets its owner. The surface is
-    /// kept for the next open.
+    /// kept for the next open; its pixels are not. A granted panel is
+    /// bounded at `MAX_PANEL_BYTES` (4 MB) rather than by anything the
+    /// shell chooses, and nothing can draw it while it is hidden, so
+    /// the raster is dead weight until [`Self::show`] repaints it —
+    /// which it does before mapping.
     pub(crate) fn hide(&mut self, backend: &mut B) {
         if let Some(window) = self.window {
             backend.unmap_shell_surface(window);
+            backend.release_shell_buffer(window);
         }
         self.visible = false;
         self.owner = None;
@@ -266,6 +271,50 @@ mod tests {
         assert_eq!(rect.pos.x + rect.size.w as i32, dock.pos.x, "flush against the dock strip");
         assert_eq!(rect.pos.y, 112, "level with the owning tile's slot");
         assert_eq!(rect.size, Size::new(300 + inset * 2, 200 + inset * 2));
+    }
+
+    #[test]
+    fn closing_a_panel_releases_its_raster_and_reopening_reuses_the_surface() {
+        use wm_core::fake_backend::FakeBackend;
+
+        // The biggest of the four: a dockapp may be granted up to
+        // `MAX_PANEL_BYTES` (4 MB), and `hide` fires on every Dock hide
+        // too, by way of `dismiss_instrument_panel`. The surface is kept
+        // for the next open — that policy is what the doc comment on
+        // `hide` states and is not being changed — but nothing can draw
+        // the panel while it is off screen, and `show` repaints before
+        // it maps.
+        let theme = theme();
+        let mut backend = FakeBackend::new();
+        let mut panel: InstrumentPanel<FakeBackend> = InstrumentPanel::default();
+
+        panel.show(&mut backend, &theme, "probe", (300, 200), area((100, 100), (312, 212)), None);
+        let window = panel.window.expect("showing creates the surface");
+        assert!(panel.visible);
+        assert!(
+            backend.shell_buffer_bytes.get(&window).is_some_and(|bytes| *bytes > 0),
+            "an open panel must hold pixels before the close under test"
+        );
+
+        panel.hide(&mut backend);
+        assert!(!panel.visible);
+        assert_eq!(panel.owner, None, "hiding forgets the owner");
+        assert_eq!(panel.window, Some(window), "the surface is kept for the next open");
+        assert!(backend.shell_geometries.contains_key(&window), "released, not destroyed");
+        assert_eq!(
+            backend.shell_buffer_bytes.get(&window),
+            None,
+            "the closed panel kept its raster"
+        );
+
+        // Reopening neither recreates the surface nor shows an unpainted
+        // one.
+        panel.show(&mut backend, &theme, "probe", (300, 200), area((100, 100), (312, 212)), None);
+        assert_eq!(panel.window, Some(window), "reopening must reuse the surface");
+        assert!(
+            backend.shell_buffer_bytes.get(&window).is_some_and(|bytes| *bytes > 0),
+            "reopening must repaint before mapping"
+        );
     }
 
     #[test]

--- a/crates/chonk-shell/src/launchdock.rs
+++ b/crates/chonk-shell/src/launchdock.rs
@@ -358,6 +358,12 @@ impl<B: Backend> LaunchDock<B> {
             if self.mapped {
                 if let Some(window) = self.window {
                     backend.unmap_shell_surface(window);
+                    // The surface survives the last pin being removed —
+                    // re-pinning should not churn the display server —
+                    // but the strip's raster grows with the pin count
+                    // and is rebuilt in full below the moment one comes
+                    // back, so nothing is kept by keeping it.
+                    backend.release_shell_buffer(window);
                 }
                 self.mapped = false;
             }
@@ -658,6 +664,59 @@ mod tests {
             "org.mozilla.firefox\norg.gnome.Calculator\n"
         );
         cleanup(&path);
+    }
+
+    #[test]
+    fn unpinning_the_last_pin_releases_the_strips_pixels_but_keeps_its_surface() {
+        use wm_core::fake_backend::FakeBackend;
+
+        // The strip's surface outlives an empty spell on purpose (see
+        // the field doc on `window`), but its raster grows with the pin
+        // count — up to the screen height minus one tile — and nothing
+        // can draw it while it is unmapped. The re-pin path repaints in
+        // full, so releasing costs the next pin nothing.
+        let theme = wm_theme::default_theme::theme_by_id("nextstep-classic").unwrap();
+        let primary = Rect { pos: Point::new(0, 0), size: Size::new(1920, 1200) };
+        let mut backend = FakeBackend::new();
+        let mut dock: LaunchDock<FakeBackend> =
+            LaunchDock::new(&mut backend, &theme, primary, 56, &[], wm_theme::FontState::new());
+
+        // Pin two, so the strip has a surface and pixels to release.
+        // Written straight into the fields rather than through a drag:
+        // this test is about `sync_window`, and a synthesized drag would
+        // also be testing the pointer path.
+        dock.pins = vec![entry("app.a"), entry("app.b")];
+        dock.lit = vec![false; dock.pins.len()];
+        dock.sync_window(&mut backend, &theme);
+        let window = dock.window.expect("pinning creates the strip's surface");
+        assert!(dock.mapped, "a strip with pins is mapped");
+        assert!(
+            backend.shell_buffer_bytes.get(&window).is_some_and(|bytes| *bytes > 0),
+            "the strip must hold pixels before the unpin under test"
+        );
+
+        // Unpin both — the empty-strip arm of `sync_window`.
+        dock.pins.clear();
+        dock.lit.clear();
+        dock.sync_window(&mut backend, &theme);
+        assert!(!dock.mapped, "an empty strip is unmapped");
+        assert_eq!(dock.window, Some(window), "the surface must survive the empty spell");
+        assert!(backend.shell_geometries.contains_key(&window), "released, not destroyed");
+        assert_eq!(
+            backend.shell_buffer_bytes.get(&window),
+            None,
+            "the unmapped strip kept its raster"
+        );
+
+        // Re-pinning repaints, so nothing was lost by releasing.
+        dock.pins = vec![entry("app.c")];
+        dock.lit = vec![false];
+        dock.sync_window(&mut backend, &theme);
+        assert_eq!(dock.window, Some(window), "re-pinning reuses the surface");
+        assert!(
+            backend.shell_buffer_bytes.get(&window).is_some_and(|bytes| *bytes > 0),
+            "re-pinning must repaint the strip"
+        );
     }
 
     #[test]

--- a/crates/chonk-shell/src/overview.rs
+++ b/crates/chonk-shell/src/overview.rs
@@ -227,6 +227,7 @@ impl<B: Backend> OverviewPanel<B> {
             // No cards on this desk: nothing to select, nothing shown.
             if let Some(selection) = self.selection {
                 backend.unmap_shell_surface(selection);
+                backend.release_shell_buffer(selection);
             }
             return;
         };

--- a/crates/chonk-testkit/tests/dock_toggle.rs
+++ b/crates/chonk-testkit/tests/dock_toggle.rs
@@ -145,6 +145,39 @@ fn hiding_the_dock_from_the_root_menu_gives_a_maximized_window_its_strip() {
     })
     .expect("hiding the Dock takes the Clip with it");
 
+    // -- and both give their pixels back ------------------------------
+    // The column and the Clip keep their surfaces across a hide — the
+    // stable identity is what avoids display-server churn — but nothing
+    // can draw them while they are unmapped, so the column's raster
+    // (one tile wide by the summed height of every widget slot) and the
+    // Clip's tile are dead weight until the show path repaints them.
+    // `buffer_bytes` is the compositor's own account of the CPU-side
+    // pixels it is holding for a surface; a released one reads zero
+    // while the surface itself stays in the ledger.
+    let released = poll_until(Duration::from_secs(10), "the hidden Dock and Clip to release their pixels", || {
+        let world = session.world().ok()?;
+        let dock = world.shells.iter().find(|s| s.id == home.id)?;
+        (!dock.mapped && dock.buffer_bytes == 0).then_some(())
+    })
+    .map(|()| session.world().unwrap());
+    let world = released.unwrap_or_else(|e| {
+        let world = session.world().unwrap();
+        panic!("{e}; shells now: {:?}", world.shells)
+    });
+    assert!(
+        world.shells.iter().any(|s| s.id == home.id),
+        "the column's surface must survive the hide, not be destroyed"
+    );
+    // The Clip by the same shape test the visibility check above uses —
+    // a square tile in the far corner — since it has no id in hand here.
+    let clip = world
+        .shells
+        .iter()
+        .find(|s| s.w == s.h && s.x + s.w as i32 == output_w as i32 && s.y + s.h as i32 == output_h as i32)
+        .expect("the Clip's surface must survive the hide too");
+    assert!(!clip.mapped, "the Clip is unmapped");
+    assert_eq!(clip.buffer_bytes, 0, "the hidden Clip is still holding its tile: {clip:?}");
+
     // -- and the equivalent binding shows it again --------------------
     // With the window now covering the entire output there is still no
     // bare desktop on which to summon a root menu. The public action is
@@ -167,6 +200,15 @@ fn hiding_the_dock_from_the_root_menu_gives_a_maximized_window_its_strip() {
             .then_some(())
     })
     .expect("showing the Dock brings the Clip back");
+    // Painted before mapped, so the column never appears for a frame as
+    // the bare background fill its released state draws.
+    let world = session.world().unwrap();
+    let column = world.shells.iter().find(|s| s.id == home.id).expect("the column is back");
+    assert!(column.mapped, "the column is mapped again");
+    assert!(
+        column.buffer_bytes > 0,
+        "showing the Dock must repaint the column it released, saw {column:?}"
+    );
     assert_eq!(std::fs::read_to_string(session.state_file("dock-visibility")).unwrap().trim(), "shown");
 }
 


### PR DESCRIPTION
Fixes #95

Completeness item, exactly as the issue frames it: `166d1dd` added `Backend::release_shell_buffer` and wired it into the Overview and the switcher; five other keep-the-surface, drop-the-session sites were not converted. This converts them.

## Root cause

`release_shell_buffer` drops the `MemoryRenderBuffer` and the GLES texture smithay caches inside it while leaving the surface and its geometry alone, and `None` is a first-class rendering state that draws the record's `background` fill. Five `unmap_shell_surface` calls did not pair with it, so each surface kept a raster nothing could draw until its next repaint:

| Site | Surface | Retained |
| --- | --- | --- |
| `desktop.rs` `set_dock_visibility` | Dock column | one tile wide by the summed height of every widget slot |
| `desktop.rs` `set_dock_visibility` | Clip | one tile |
| `dockapp/panel.rs` `InstrumentPanel::hide` | instrument panel | granted panel + chrome, up to `MAX_PANEL_BYTES` (4 MB) |
| `launchdock.rs` `sync_window` | launcher strip | tile x pins, clamped to the screen height |
| `overview.rs` `place_selection` | selection plate | card-sized |

The panel is the one that fires most often: `set_dock_visibility` calls `dismiss_instrument_panel`, which calls `hide`, so every Dock hide goes through it too.

## Behavioral change

One `backend.release_shell_buffer(...)` beside each unmap, matching the Overview's and switcher's shape. No policy changes — every surface is still kept, and every show path already repaints before mapping:

- `set_dock_visibility` — the show branch calls `redraw_dock` then `reposition_clip`, both before their `map_shell_surface`, and the existing comment already says the column is "configured and painted before it is mapped".
- `InstrumentPanel::show` — calls `self.repaint(...)` before `map_shell_surface`.
- `LaunchDock::sync_window` — the re-pin path falls through to `configure_shell_surface` plus a full strip repaint.
- `OverviewPanel::place_selection` — the empty-desk branch; the plate is rebuilt whenever a card exists to select.

Safe on both backends, per the issue: Wayland drops the buffer, X11 is a documented no-op (a server-side window has no client-side raster), `FakeBackend` records the release.

The doc comment on `InstrumentPanel::hide` is extended — it already said "The surface is kept for the next open", which stays true and is now qualified with "its pixels are not", plus why.

## Tests added

Three unit tests, all driven through `FakeBackend`, which already tracks `shell_buffer_bytes` — the issue's own suggestion that this is "expressible without a compositor":

- `chonk_shell::desktop::hiding_the_dock_releases_the_columns_and_the_clips_pixels` — paints both, hides, asserts both rasters are gone **and** both surfaces survive in the ledger, then shows and asserts both are repainted.
- `chonk_shell::launchdock::unpinning_the_last_pin_releases_the_strips_pixels_but_keeps_its_surface` — pins two, unpins to empty, asserts released-not-destroyed, re-pins and asserts repainted.
- `chonk_shell::dockapp::panel::closing_a_panel_releases_its_raster_and_reopening_reuses_the_surface` — the 4 MB case; also asserts reopening reuses the same surface, so the release does not cost the churn the retained surface exists to avoid.

Each asserts the surface **survives** as well as that the pixels go, because a fix that accidentally destroyed the surface would satisfy "bytes are zero" while undoing the churn-avoidance the whole pattern is for.

**Verified failing without the fix.** Production `release_shell_buffer` calls stripped, tests kept:

```
test result: FAILED. 378 passed; 3 failed
    desktop::tests::hiding_the_dock_releases_the_columns_and_the_clips_pixels
    dockapp::panel::tests::closing_a_panel_releases_its_raster_and_reopening_reuses_the_surface
    launchdock::tests::unpinning_the_last_pin_releases_the_strips_pixels_but_keeps_its_surface
```

Plus wire-level assertions added to the existing `crates/chonk-testkit/tests/dock_toggle.rs` e2e, using the `buffer_bytes` field `166d1dd` already plumbed through the test door: after the Dock is hidden, the column (by id) and the Clip (by the same corner-shape test that test already uses) must both be unmapped with `buffer_bytes == 0` and still present in the shell ledger; after it is shown again, the column must be mapped **and** repainted.

## Acceptance criteria

- [x] Hiding the Dock releases the column's and the Clip's pixels while keeping both surfaces
- [x] Closing an instrument panel releases its raster; reopening it still does not recreate the surface
- [x] Unpinning the last launcher pin releases the strip's raster
- [x] A test asserts retained shell-buffer bytes after each of those is zero

## Commands run

| Command | Result |
| --- | --- |
| `cargo test -p chonk-shell` | ok — 381 passed, 2 ignored |
| `cargo test --workspace --all-targets` | ok — 0 failed |
| `cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks` | clean |
| `RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' cargo doc --workspace --no-deps --locked --document-private-items` | clean |
| `git diff --check` | clean |

**The `dock_toggle` e2e additions were not run locally, and I want to be direct about that.** `scripts/e2e.sh --headless` cannot run here (`weston` is not installed), and the host session has degraded partway through this work in the way `e2e.sh`'s own comment predicts — "a hidden nested host window cannot complete presentation, which starves the barrier the harness intentionally waits on and produces misleading client-map timeouts". `dock_toggle`, `instrument_panel`, `overview` and `layer_bar` now all fail here at setup, before reaching anything this branch touches (`"door read timed out"` opening the root menu; `"timed out after 10s waiting for a mapped window matching \"foot\""`).

I measured the baseline rather than assuming: on unmodified `26e95e2` with the same commands, **the identical four targets fail identically** — 0 passed in each. Earlier in the same session, before the host degraded, `session_lock`, `hyprland_config`, `omarchy`, `omarchy_mode`, `commands`, `session_restore`, `idle`, `focus_grab`, `supervisor`, `control_socket` and `layer_bar` all passed against this machine, so the harness itself is sound.

The e2e additions compile and follow the exact `buffer_bytes` pattern the Overview e2e from `166d1dd` already uses, but CI's `wayland` job is what will actually exercise them. Flagging it rather than letting a green table imply otherwise. The three unit tests, which are what the acceptance criteria ask for, are fully verified locally both ways.

## Performance

Per the issue's own accounting, roughly **0.75-1.5 MB** of CPU-side buffer plus the same again in GPU texture on a stock desk, with a worst realistic case of 4 MB + 4 MB for a dockapp granted a maximum-size panel. No measurement beyond that is offered: this is a completeness change with no hot path in it, the numbers are small and stated as such, and inventing a benchmark for freed allocations that no workload can observe would be less honest than quoting the arithmetic.

## Known limitations

- **The `overview.rs` `place_selection` site has no dedicated test.** It is the fifth site, the issue calls it "genuinely negligible" (card-sized, and the session almost always ends through `hide`, which already released), and it is not among the acceptance criteria. Reaching that branch needs an `OverviewPanel` with a `FontSystem`, a `SwashCache` and a laid-out desk with zero cells; that setup would be several times the size of the one line it covers. Converting it anyway because, as the issue puts it, leaving half the pattern applied is how the next monitor-sized panel gets written the old way.
