### PR TITLE
Fail loudly when a test client is missing (#75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
           sudo apt-get install -y \
             libxkbcommon-dev libegl-dev libgles-dev libwayland-dev \
             libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
-            weston xwayland foot alacritty zenity grim wayland-utils
+            weston xwayland foot alacritty zenity grim wayland-utils wlr-randr
 
       # --locked: the compositor pins Smithay 0.7.0, and a silent
       # re-resolution here would test a different dependency tree than
@@ -391,8 +391,17 @@ jobs:
 
       # Weston provides the host display a nested compositor needs,
       # with Mesa's software renderer on runners that expose no GPU.
-      # The Chromium-specific regression skips when Chromium is absent;
-      # all protocol probes and the Foot/Alacritty/Zenity paths run.
+      #
+      # Every client the suite drives is installed above, and a missing
+      # one is now a failure rather than a skip: `require_client`
+      # panics under `CI` for anything not on its documented
+      # `CI_CANNOT_INSTALL` list. `wlr-randr` is in the list above
+      # because it was NOT, and the only test exercising
+      # wlr-output-management against a real client had therefore been
+      # reporting `1 passed` in 0.00s without booting a compositor.
+      # Chromium comes with the runner image; the same guard is what
+      # turns the day it stops coming into a red build instead of a
+      # quietly smaller suite.
       - name: Run the nested compositor end-to-end suite
         run: scripts/e2e.sh --headless
 

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -181,6 +181,110 @@ pub mod keys {
 /// this, so the fixture and the assertions on it cannot drift apart.
 pub const FAKE_BAR_RGB: [u8; 3] = [0xE0, 0x70, 0x10];
 
+/// Clients this suite needs that CI genuinely cannot install, with the
+/// reason — the allow-list [`require_client`] consults before turning a
+/// missing client into a red build.
+///
+/// Being on this list is not permission to skip quietly. A skip is
+/// still recorded and still printed by `scripts/e2e.sh`; the list only
+/// says "we already know, and it is not a regression". Deleting an
+/// entry the day the client becomes installable is the point: the
+/// build goes red until someone adds it to the workflow.
+const CI_CANNOT_INSTALL: &[(&str, &str)] = &[
+    // Hyprland's night-light daemon. Not packaged for Ubuntu, and
+    // building it on a runner would pull the whole Hyprland toolchain
+    // for one gamma assertion. `gamma.rs`'s other tests drive the
+    // protocol directly and do run.
+    ("hyprsunset", "not packaged for Ubuntu; the rest of gamma.rs drives the protocol directly"),
+];
+
+/// Where [`require_client`] records a client it did not find, so a run
+/// can say plainly which tests did not run. `scripts/e2e.sh` prints
+/// this file next to its closing line.
+pub fn skip_log_path() -> PathBuf {
+    std::env::temp_dir().join("chonk-testkit").join("skipped.log")
+}
+
+/// Whether `program` is on `PATH`, and the only sanctioned way for a
+/// test to decide it cannot run.
+///
+/// # Why this is not an `eprintln!` and a `return`
+///
+/// That was the idiom, in three tests, and it is invisible: `cargo
+/// test` captures a *passing* test's output, so the skip line is never
+/// printed and the test reports `ok`. On CI the
+/// `wlr-output-management` conformance test was in that state
+/// permanently — the only test in the tree that exercises that
+/// protocol against a real client, reporting `1 passed` in 0.00s while
+/// never booting a compositor. A skip that is indistinguishable from a
+/// pass is the same silent-failure class this project labels
+/// everywhere else, turned on its own suite.
+///
+/// So: under `CI`, a missing client is a **panic** naming it, unless it
+/// is in [`CI_CANNOT_INSTALL`]. Off CI it returns `false` — a developer
+/// without every client should still be able to run most of the suite —
+/// but the skip is recorded to [`skip_log_path`] either way, and
+/// `scripts/e2e.sh` prints the file, so a local run says which tests did
+/// not run rather than implying they all did.
+///
+/// A `PATH` scan rather than running the program: the workspace bans
+/// the blocking wait (`clippy::disallowed_methods`), and existence is
+/// all that is being asked.
+pub fn require_client(program: &str) -> bool {
+    let found = std::env::var_os("PATH").is_some_and(|path| {
+        std::env::split_paths(&path).any(|dir| dir.join(program).is_file())
+    });
+    if found {
+        return true;
+    }
+    let known = CI_CANNOT_INSTALL.iter().find(|(name, _)| *name == program);
+    let note = match known {
+        Some((_, reason)) => format!("{program} is not installed ({reason})"),
+        None => format!("{program} is not installed"),
+    };
+    let verdict = client_verdict(std::env::var_os("CI").is_some(), known.is_some());
+    // Recorded before the panic, so even the red build leaves the same
+    // artifact a green one would.
+    let path = skip_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new().create(true).append(true).open(&path) {
+        use std::io::Write as _;
+        let _ = writeln!(file, "{note}");
+    }
+    if verdict == MissingClient::Fatal {
+        panic!(
+            "{note}. On CI a missing client is a failure, not a skip: install it in \
+             .github/workflows/ci.yml's wayland job, or add it to \
+             chonk_testkit::CI_CANNOT_INSTALL with the reason it cannot be installed."
+        );
+    }
+    false
+}
+
+/// What a missing client costs, kept pure so the rule is testable
+/// without mutating the process environment — `CI` is global, and a
+/// test that set it would race every other test in the binary.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum MissingClient {
+    /// Off CI, or a client CI cannot install: the test returns early
+    /// and the skip is recorded and printed.
+    Skip,
+    /// On CI, and a client CI could have installed: a red build.
+    Fatal,
+}
+
+/// The rule: a missing client is fatal on CI unless it is one CI
+/// genuinely cannot install. Everything else is a recorded skip.
+pub fn client_verdict(on_ci: bool, ci_cannot_install: bool) -> MissingClient {
+    if on_ci && !ci_cannot_install {
+        MissingClient::Fatal
+    } else {
+        MissingClient::Skip
+    }
+}
+
 /// Where the session called `name` keeps its scratch — config, state,
 /// logs, screenshots, the door socket. Public so a test can name a
 /// path inside the directory (a marker file for a command to write)
@@ -1568,6 +1672,37 @@ mod tests {
     #[test]
     fn a_mangled_line_is_rejected_not_misparsed() {
         assert!(parse_window_line("window id=oops x=1 y=1 w=1 h=1 mapped=true").is_none());
+    }
+
+    #[test]
+    fn a_missing_client_is_fatal_on_ci_and_a_skip_off_it() {
+        // The whole point of the helper. Off CI a developer without
+        // every client still gets most of the suite; on CI a missing
+        // client is a red build, because a skip there is
+        // indistinguishable from a pass and that is how the only
+        // wlr-output-management test spent its life reporting `ok` in
+        // 0.00s without booting anything.
+        assert_eq!(client_verdict(true, false), MissingClient::Fatal, "CI, installable");
+        assert_eq!(client_verdict(false, false), MissingClient::Skip, "developer machine");
+        // The escape hatch, and it only opens on CI's side of the
+        // decision: a client CI genuinely cannot install is still a
+        // recorded, printed skip rather than a failure.
+        assert_eq!(client_verdict(true, true), MissingClient::Skip, "CI, not installable");
+        assert_eq!(client_verdict(false, true), MissingClient::Skip, "developer machine, not installable");
+    }
+
+    #[test]
+    fn every_declared_unavailable_client_carries_a_reason() {
+        // `CI_CANNOT_INSTALL` is an escape hatch, and an escape hatch
+        // with no argument written next to it is how a temporary
+        // exemption becomes permanent. An entry must say why.
+        for (client, reason) in CI_CANNOT_INSTALL {
+            assert!(!client.is_empty(), "a nameless entry");
+            assert!(
+                reason.len() > 20,
+                "{client} is exempted from the CI check with no real reason given: {reason:?}"
+            );
+        }
     }
 
     /// The exact bytes libwayland 1.26 writes under `FORCE_COLOR`,

--- a/crates/chonk-testkit/tests/e2e.rs
+++ b/crates/chonk-testkit/tests/e2e.rs
@@ -825,13 +825,11 @@ fn appearance_request_flips_the_desktop_live() {
 #[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit -- --ignored --test-threads=1"]
 fn chromium_resize_at_scale_2_keeps_its_scale() {
     // Chromium is the one client that exhibits the over-allocate+crop
-    // commit pattern; without it there is nothing to test against. A
-    // PATH scan rather than `Command::status` — the workspace bans the
-    // blocking wait, and existence is all that is being asked.
-    let chromium_on_path = std::env::var_os("PATH")
-        .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join("chromium").is_file()));
-    if !chromium_on_path {
-        eprintln!("chromium not installed; skipping");
+    // commit pattern; without it there is nothing to test against.
+    // `require_client` is what stops that from becoming a silent pass
+    // the day the runner image drops the binary — the risk this
+    // comment used to only reason about.
+    if !chonk_testkit::require_client("chromium") {
         return;
     }
     // Frameless on purpose, like the zenity tests: the desktop now

--- a/crates/chonk-testkit/tests/gamma.rs
+++ b/crates/chonk-testkit/tests/gamma.rs
@@ -308,15 +308,11 @@ fn a_non_diagonal_ctm_is_a_named_protocol_error_not_an_approximation() {
 #[ignore = "needs a live Wayland session and the packaged hyprsunset client"]
 // This is an ignored integration test running on Cargo's test thread,
 // never the compositor repaint thread. It must synchronously inspect
-// the two real command-line clients' exit status and output.
+// `hyprctl`'s exit status and output. (The availability check that
+// used to need this too is now `require_client`, a PATH scan.)
 #[allow(clippy::disallowed_methods)]
 fn real_hyprsunset_stays_running_serves_its_ipc_and_restores_on_exit() {
-    if Command::new("hyprsunset")
-        .arg("--version")
-        .output()
-        .is_err()
-    {
-        eprintln!("SKIP: hyprsunset is not installed");
+    if !chonk_testkit::require_client("hyprsunset") {
         return;
     }
     let mut session = Session::boot("hyprsunset-real", with_gamma()).unwrap();

--- a/crates/chonk-testkit/tests/output_management.rs
+++ b/crates/chonk-testkit/tests/output_management.rs
@@ -6,6 +6,22 @@
 //! manager, and checks that an unsupported disable is rejected without
 //! costing the desktop. Those are the three distinct server paths:
 //! announce, apply/update, and fail.
+//!
+//! # Why the plain listing rather than `--json`
+//!
+//! This test asked for `--json` and had never once run: `wlr-randr`
+//! was not installed on CI, and the skip guard reported `ok` in 0.00s
+//! (see #75). The first run with the package installed found that
+//! Ubuntu ships a `wlr-randr` predating that flag — `unrecognized
+//! option '--json'` — so the JSON shape was never a property of the
+//! client this suite can actually get.
+//!
+//! The default listing is the interface every version has had, and it
+//! is what a user sees, so it is what is parsed here. The two readers
+//! below take only the two facts the assertions need and are
+//! deliberately tolerant of the surrounding format: the head name is
+//! the first token of an unindented line, and the scale is whatever
+//! follows `Scale:`.
 
 use std::time::Duration;
 
@@ -27,6 +43,27 @@ fn run(session: &mut Session, args: &[&str]) -> Result<String, String> {
     }
 }
 
+/// The head names in a listing: `wlr-randr` prints each head flush
+/// left and indents every property under it, so an unindented,
+/// non-empty line begins a head and its first token is the name.
+fn head_names(report: &str) -> Vec<&str> {
+    report
+        .lines()
+        .filter(|line| !line.is_empty() && !line.starts_with(char::is_whitespace))
+        .filter_map(|line| line.split_whitespace().next())
+        .collect()
+}
+
+/// The scale a listing reports, from the `Scale: 1.500000` property.
+/// Parsed as a float rather than string-matched because the number of
+/// decimal places is the client's business, not this test's.
+fn reported_scale(report: &str) -> Option<f64> {
+    report
+        .lines()
+        .find_map(|line| line.trim().strip_prefix("Scale:"))
+        .and_then(|value| value.trim().parse().ok())
+}
+
 #[test]
 #[ignore = "needs a live Wayland session and wlr-randr"]
 fn wlr_randr_lists_applies_and_observes_output_state() {
@@ -35,18 +72,29 @@ fn wlr_randr_lists_applies_and_observes_output_state() {
     }
 
     let mut session = Session::boot("output-management", SessionOptions::default()).unwrap();
-    let initial = run(&mut session, &["--json"]).expect("initial output listing succeeds");
-    let initial: serde_json::Value =
-        serde_json::from_str(&initial).unwrap_or_else(|error| panic!("wlr-randr did not return JSON: {error}"));
-    assert_eq!(initial[0]["name"], "chonkstep");
+    // Announce: a complete head publication the client can consume.
+    let initial = run(&mut session, &[]).expect("initial output listing succeeds");
+    assert!(
+        head_names(&initial).contains(&"chonkstep"),
+        "the compositor must announce its head by name: {initial:?}"
+    );
+    assert_eq!(reported_scale(&initial), Some(1.0), "a fresh session is at scale 1: {initial:?}");
 
+    // Apply, then read it back through a second manager — the point of
+    // re-running the client rather than trusting the first one's exit
+    // code.
     run(&mut session, &["--output", "chonkstep", "--scale", "1.5"])
         .expect("fractional output scale applies");
-    let updated = run(&mut session, &["--json"]).expect("updated output listing succeeds");
-    let updated: serde_json::Value =
-        serde_json::from_str(&updated).unwrap_or_else(|error| panic!("wlr-randr did not return JSON: {error}"));
-    assert_eq!(updated[0]["name"], "chonkstep");
-    assert_eq!(updated[0]["scale"], 1.5);
+    let updated = run(&mut session, &[]).expect("updated output listing succeeds");
+    assert!(
+        head_names(&updated).contains(&"chonkstep"),
+        "the head must still be announced after a change: {updated:?}"
+    );
+    assert_eq!(
+        reported_scale(&updated),
+        Some(1.5),
+        "the applied fractional scale must come back through a fresh manager: {updated:?}"
+    );
 
     session.launch(CLIENT, &["--output", "chonkstep", "--off"]).unwrap();
     let status = poll_until(WAIT, "unsupported output disable to be answered", || {
@@ -59,4 +107,46 @@ fn wlr_randr_lists_applies_and_observes_output_state() {
         "the client should explain that the configuration failed"
     );
     assert!(session.compositor_alive(), "a refused configuration keeps the desktop alive");
+}
+
+/// A listing in the shape `wlr-randr` prints, so the two readers above
+/// are pinned without needing the client installed. Taken from the
+/// format `wlr-randr` has emitted since it grew scale reporting: each
+/// head flush left with its description quoted, every property
+/// indented beneath it, and the modes indented one level further.
+const SAMPLE_LISTING: &str = "\
+chonkstep \"chonkstep chonkstep Unknown\"
+  Make: chonkstep
+  Model: chonkstep
+  Serial: Unknown
+  Physical size: 0x0 mm
+  Enabled: yes
+  Modes:
+    2560x1600 px, 60.000000 Hz (preferred, current)
+  Position: 0,0
+  Transform: normal
+  Scale: 1.500000
+";
+
+#[test]
+fn a_listing_yields_its_head_names_and_not_its_properties() {
+    // The indentation is the whole distinction: `Make:` and the mode
+    // line must not be mistaken for heads, or the name assertion
+    // passes on anything.
+    assert_eq!(head_names(SAMPLE_LISTING), vec!["chonkstep"]);
+    assert_eq!(head_names(""), Vec::<&str>::new());
+    // A second head is a second unindented line.
+    let two = format!("{SAMPLE_LISTING}HDMI-A-1 \"Other\"\n  Scale: 1.000000\n");
+    assert_eq!(head_names(&two), vec!["chonkstep", "HDMI-A-1"]);
+}
+
+#[test]
+fn a_listing_yields_its_scale_as_a_number() {
+    // Parsed, not string-matched: how many decimal places the client
+    // prints is its business, and an assertion on the text would break
+    // on a version that printed `1.5`.
+    assert_eq!(reported_scale(SAMPLE_LISTING), Some(1.5));
+    assert_eq!(reported_scale("  Scale: 1\n"), Some(1.0));
+    assert_eq!(reported_scale("  Position: 0,0\n"), None);
+    assert_eq!(reported_scale(""), None);
 }

--- a/crates/chonk-testkit/tests/output_management.rs
+++ b/crates/chonk-testkit/tests/output_management.rs
@@ -7,7 +7,6 @@
 //! costing the desktop. Those are the three distinct server paths:
 //! announce, apply/update, and fail.
 
-use std::process::Command;
 use std::time::Duration;
 
 use chonk_testkit::{poll_until, Session, SessionOptions};
@@ -30,13 +29,8 @@ fn run(session: &mut Session, args: &[&str]) -> Result<String, String> {
 
 #[test]
 #[ignore = "needs a live Wayland session and wlr-randr"]
-// This ignored integration test runs on Cargo's test thread, never the
-// compositor repaint thread. The synchronous probe is only an
-// availability check before the real client is supervised by Session.
-#[allow(clippy::disallowed_methods)]
 fn wlr_randr_lists_applies_and_observes_output_state() {
-    if Command::new(CLIENT).arg("--help").output().is_err() {
-        eprintln!("SKIP: wlr-randr is not installed");
+    if !chonk_testkit::require_client(CLIENT) {
         return;
     }
 

--- a/crates/chonk-testkit/tests/popup_anchor.rs
+++ b/crates/chonk-testkit/tests/popup_anchor.rs
@@ -89,10 +89,7 @@ fn popup_configure(log: &str, popup_id: &str) -> Option<(i32, i32, u32, u32)> {
 #[test]
 #[ignore = "needs a Wayland session and Chromium"]
 fn chromium_popup_without_a_new_anchor_is_dismissed_on_parent_resize() {
-    let chromium_on_path = std::env::var_os("PATH")
-        .is_some_and(|path| std::env::split_paths(&path).any(|dir| dir.join("chromium").is_file()));
-    if !chromium_on_path {
-        eprintln!("chromium not installed; skipping");
+    if !chonk_testkit::require_client("chromium") {
         return;
     }
     let mut session = Session::boot(

--- a/crates/chonk-testkit/tests/wayland_globals.rs
+++ b/crates/chonk-testkit/tests/wayland_globals.rs
@@ -11,17 +11,8 @@ use chonk_testkit::{poll_until, Session, SessionOptions};
 
 #[test]
 #[ignore = "needs a live Wayland session and wayland-info"]
-// This ignored integration test runs on Cargo's test thread, never the
-// compositor repaint thread. The synchronous probe is only an
-// availability check before the real client is supervised by Session.
-#[allow(clippy::disallowed_methods)]
 fn ordinary_desktop_globals_bind_successfully() {
-    if std::process::Command::new("wayland-info")
-        .arg("--help")
-        .output()
-        .is_err()
-    {
-        eprintln!("SKIP: wayland-info is not installed");
+    if !chonk_testkit::require_client("wayland-info") {
         return;
     }
     let mut session = Session::boot("wayland-globals", SessionOptions::default()).unwrap();

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -27,8 +27,17 @@
 #   alacritty  Omarchy's terminal, for the decoration tests
 #   zenity     GTK dialogs, for the drag/resize/miniaturize regressions
 #   grim       every screenshot, via the compositor's own screencopy
+#   wlr-randr  the only client exercising wlr-output-management
 # Missing ones are reported together up front rather than one at a
 # time as each test in turn fails to map a window.
+#
+# Clients deliberately NOT pre-flighted, because the suite is still
+# worth running without them — each is guarded by
+# `chonk_testkit::require_client`, which records the skip and prints it
+# at the end of this script, and which fails outright under CI:
+#   chromium   the real-browser resize and popup-anchor regressions
+#   wayland-info  the registry enumeration probe
+#   hyprsunset the night-light integration (see CI_CANNOT_INSTALL)
 #
 # `--headless` starts an isolated Weston host first.  It is useful on a
 # CI runner, over SSH, or while the real desktop is locked: a hidden
@@ -111,7 +120,7 @@ if [ -z "${WAYLAND_DISPLAY:-}" ] && [ -z "${DISPLAY:-}" ]; then
 fi
 
 missing=()
-for client in foot alacritty zenity grim; do
+for client in foot alacritty zenity grim wlr-randr; do
     command -v "$client" >/dev/null 2>&1 || missing+=("$client")
 done
 if [ "${#missing[@]}" -gt 0 ]; then
@@ -132,6 +141,13 @@ cargo build -p chonkstep-wayland -p chonk-testkit --quiet
 # --test-threads=1: each test opens a compositor window on your
 # desktop; serial keeps them from fighting for focus and keeps the
 # host from tiling five of them into shapes nobody asserted on.
+# A skip is only honest if it is visible. `require_client` appends a
+# line here for every client it did not find; the run is not green
+# until the reader has been told which tests that silenced.
+skip_log="${TMPDIR:-/tmp}/chonk-testkit/skipped.log"
+mkdir -p "$(dirname "$skip_log")"
+rm -f "$skip_log"
+
 echo "Running the end-to-end suite (one nested compositor at a time)..."
 if "$headless"; then
     # GitHub's runner exports a nonfunctional D-Bus address. Chromium
@@ -149,8 +165,30 @@ fi
 # (`#[ignore]`d for the same no-such-thing-in-CI reason; they skip
 # themselves when Omarchy is absent). No "$@": that filter is the
 # harness's.
+#
+# These report `N passed` in 0.00s whether they read a real Omarchy or
+# returned immediately, which looks identical to a real pass. Saying
+# up front whether there is an Omarchy to read is the difference.
 echo "Running the unit tests that read the installed Omarchy..."
+# The same root `chonk_shell::omarchy_menu::omarchy_root` resolves —
+# $OMARCHY_PATH when set (what Omarchy's own scripts read, and
+# /usr/share/omarchy on an Omarchy 4 machine), else the pre-package
+# location under $HOME — and the same file `MenuPaths::discover` tests
+# for, so this line cannot say "reading" about a tree those tests would
+# walk away from.
+omarchy_root="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
+omarchy_menu="$omarchy_root/default/omarchy/omarchy-menu.jsonc"
+if [ -f "$omarchy_menu" ]; then
+    echo "  (reading $omarchy_root)"
+else
+    echo "  (no Omarchy menu at $omarchy_menu — these tests return early, so their 'passed' counts mean nothing here)"
+fi
 cargo test -p chonk-shell -p wm-theme --lib -- --ignored installed
 
 echo
+if [ -s "$skip_log" ]; then
+    echo "Tests that did NOT run, and why:"
+    sed 's/^/  - /' "$skip_log" | sort -u
+    echo
+fi
 echo "e2e suite passed. Artifacts (logs + screenshots) are under ${TMPDIR:-/tmp}/chonk-testkit/"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -161,27 +161,43 @@ else
     cargo test -p chonk-testkit --tests -- --ignored --test-threads=1 "$@"
 fi
 
-# The unit tests that read the Omarchy installed on this machine
-# (`#[ignore]`d for the same no-such-thing-in-CI reason; they skip
-# themselves when Omarchy is absent). No "$@": that filter is the
-# harness's.
-#
-# These report `N passed` in 0.00s whether they read a real Omarchy or
-# returned immediately, which looks identical to a real pass. Saying
-# up front whether there is an Omarchy to read is the difference.
+# The unit tests that read the Omarchy installed on this machine are
+# `#[ignore]`d for the same no-such-thing-in-CI reason. No "$@": that
+# filter is the harness's. Each suite has its own prerequisite, so
+# report them separately: a partial/custom install may contain either
+# the menu or the themes without the other.
 echo "Running the unit tests that read the installed Omarchy..."
-# The same root `chonk_shell::omarchy_menu::omarchy_root` resolves —
-# $OMARCHY_PATH when set (what Omarchy's own scripts read, and
-# /usr/share/omarchy on an Omarchy 4 machine), else the pre-package
-# location under $HOME — and the same file `MenuPaths::discover` tests
-# for, so this line cannot say "reading" about a tree those tests would
-# walk away from.
-omarchy_root="${OMARCHY_PATH:-$HOME/.local/share/omarchy}"
-omarchy_menu="$omarchy_root/default/omarchy/omarchy-menu.jsonc"
-if [ -f "$omarchy_menu" ]; then
-    echo "  (reading $omarchy_root)"
+# Match `chonk_shell::omarchy_menu::omarchy_root`: an empty
+# $OMARCHY_PATH falls back to $HOME, and a missing $HOME falls back to
+# the current directory.
+if [ -n "${OMARCHY_PATH:-}" ]; then
+    omarchy_menu_root="$OMARCHY_PATH"
 else
-    echo "  (no Omarchy menu at $omarchy_menu — these tests return early, so their 'passed' counts mean nothing here)"
+    omarchy_menu_root="${HOME:-.}/.local/share/omarchy"
+fi
+omarchy_menu="$omarchy_menu_root/default/omarchy/omarchy-menu.jsonc"
+if [ -f "$omarchy_menu" ]; then
+    echo "  chonk-shell menu fixture: reading $omarchy_menu"
+else
+    echo "  chonk-shell menu fixture: absent at $omarchy_menu — its installed tests return early"
+fi
+
+# Match `wm_theme::omarchy`'s installed-theme test exactly: unlike the
+# menu helper it treats a set-but-empty $OMARCHY_PATH as the current
+# directory, and it has no path at all when both environment variables
+# are unset.
+omarchy_themes=""
+if [ "${OMARCHY_PATH+x}" = x ]; then
+    omarchy_themes="${OMARCHY_PATH:+$OMARCHY_PATH/}themes"
+elif [ "${HOME+x}" = x ]; then
+    omarchy_themes="${HOME:+$HOME/}.local/share/omarchy/themes"
+fi
+if [ -n "$omarchy_themes" ] && [ -d "$omarchy_themes" ] && [ -r "$omarchy_themes" ]; then
+    echo "  wm-theme theme fixture: reading $omarchy_themes"
+elif [ -n "$omarchy_themes" ]; then
+    echo "  wm-theme theme fixture: absent or unreadable at $omarchy_themes — its installed test returns early"
+else
+    echo "  wm-theme theme fixture: unresolved because OMARCHY_PATH and HOME are unset — its installed test returns early"
 fi
 cargo test -p chonk-shell -p wm-theme --lib -- --ignored installed
 


### PR DESCRIPTION
Fixes #75

## Outcome

Tests that require external clients can no longer turn a missing CI dependency into an invisible green pass.

- `chonk_testkit::require_client` records every missing-client skip and makes it fatal under CI unless the client has a documented, tested exception.
- CI installs `wlr-randr`, and `scripts/e2e.sh` preflights it with the other mandatory clients.
- Chromium and the other guarded clients use the shared rule, so their disappearance from a runner becomes visible.
- `hyprsunset` remains an explicit documented CI exception because Ubuntu does not package it; its skip is still printed.
- `wlr-randr` output is parsed from the version-compatible plain listing. This was necessary because enabling the previously skipped test proved Ubuntu's packaged client does not support `--json`.
- The script prints the accumulated skip log at the end of the run.
- Installed Omarchy reporting treats the menu and theme fixtures independently, matching the exact environment/fallback rules used by each Rust suite. Partial/custom installs therefore cannot be misreported as wholly exercised or wholly skipped.

## Repair applied during review

The original script used only the menu file to characterize both installed-Omarchy suites. The repaired head reports `chonk-shell`'s exact menu prerequisite and `wm-theme`'s independently resolved themes directory separately, including menu-only, themes-only, both, and neither states.

The branch is rebased onto current `main` and includes the post-#108 Go test-race fix.

## Validation

Exact repaired head `4726bb4032361d40651ffe0abfec248a17ef439c` passed locally:

- `cargo test -p chonk-testkit`
- `cargo test --workspace --all-targets`
- strict workspace Clippy
- warning-denied private-item docs
- `cargo test -p wm-wayland`
- `scripts/e2e.sh --headless`, including the live `wlr-randr` conformance test and both installed Omarchy suites
- `bash -n scripts/e2e.sh`
- `shellcheck scripts/e2e.sh`
- fixture-reporting matrix for menu-only, themes-only, both, and neither
- `git diff --check`

Merge remains contingent on fresh CI for that exact head.
