### PR TITLE
Emit and ship release debug information (#50)

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -41,6 +41,7 @@ jobs:
           set -euo pipefail
           version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
           package_release=$(sed -n 's/^pkgrel=//p' packaging/arch/PKGBUILD-release | head -n1)
+          source_id=$(git describe --tags --always --dirty)
           if [[ $GITHUB_REF == refs/tags/preview-v* ]]; then
             tag_version=${GITHUB_REF_NAME#preview-v}
             if [[ $tag_version =~ ^(.+)-r([1-9][0-9]*)$ ]]; then
@@ -66,7 +67,7 @@ jobs:
           install -m644 packaging/arch/PKGBUILD-release "$build_dir/PKGBUILD"
 
           package_name="chonkstep-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
-          # `options=(!strip debug)` in the PKGBUILD makes makepkg emit
+          # `options=(strip debug)` in the PKGBUILD makes makepkg emit
           # this beside the main package: the symbols a coredump needs
           # to be more than a list of addresses. Shipped as its own
           # asset so the main package stays small and only someone
@@ -76,6 +77,7 @@ jobs:
           echo "package_release=$package_release" >> "$GITHUB_OUTPUT"
           echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
           echo "debug_package_name=$debug_package_name" >> "$GITHUB_OUTPUT"
+          echo "source_id=$source_id" >> "$GITHUB_OUTPUT"
 
       - name: Build the native Arch package environment
         run: |
@@ -93,6 +95,7 @@ jobs:
             --env CARGO_INCREMENTAL=0 \
             --env CARGO_PROFILE_DEV_DEBUG=0 \
             --env CARGO_PROFILE_TEST_DEBUG=0 \
+            --env "CHONKSTEP_GIT_DESCRIBE=${{ steps.metadata.outputs.source_id }}" \
             --volume "$RUNNER_TEMP/chonkstep-package:/build" \
             --volume "$GITHUB_WORKSPACE:/source:ro" \
             "chonkstep-arch-builder:${{ matrix.arch }}" \
@@ -103,7 +106,8 @@ jobs:
               /source/scripts/verify-release-package.sh \
                 "$package" \
                 "${{ matrix.arch }}" \
-                "${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.package_release }}"
+                "${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.package_release }}" \
+                "${{ steps.metadata.outputs.source_id }}"
               install -d /build/dist
               install -m644 "$package" /build/dist/
               # The verifier above already failed the build if this was

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -66,9 +66,16 @@ jobs:
           install -m644 packaging/arch/PKGBUILD-release "$build_dir/PKGBUILD"
 
           package_name="chonkstep-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
+          # `options=(!strip debug)` in the PKGBUILD makes makepkg emit
+          # this beside the main package: the symbols a coredump needs
+          # to be more than a list of addresses. Shipped as its own
+          # asset so the main package stays small and only someone
+          # reading a crash pays for it.
+          debug_package_name="chonkstep-debug-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "package_release=$package_release" >> "$GITHUB_OUTPUT"
           echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "debug_package_name=$debug_package_name" >> "$GITHUB_OUTPUT"
 
       - name: Build the native Arch package environment
         run: |
@@ -99,21 +106,32 @@ jobs:
                 "${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.package_release }}"
               install -d /build/dist
               install -m644 "$package" /build/dist/
+              # The verifier above already failed the build if this was
+              # missing; installing it here is what gets it attested and
+              # published rather than discarded with the container.
+              install -m644 "/build/${{ steps.metadata.outputs.debug_package_name }}" /build/dist/
             '
 
-      - name: Record package digest
-        run: sha256sum "$RUNNER_TEMP/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}"
+      - name: Record package digests
+        run: |
+          cd "$RUNNER_TEMP/chonkstep-package/dist"
+          sha256sum "${{ steps.metadata.outputs.package_name }}" \
+                    "${{ steps.metadata.outputs.debug_package_name }}"
 
+      # Both subjects, so the symbols a user symbolises a crash with
+      # carry the same provenance guarantee as the binary that crashed.
       - name: Attest package provenance
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
         with:
-          subject-path: ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}
+          subject-path: |
+            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}
+            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.debug_package_name }}
 
-      - name: Upload package for release assembly
+      - name: Upload packages for release assembly
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: chonkstep-package-${{ matrix.arch }}
-          path: ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}
+          path: ${{ runner.temp }}/chonkstep-package/dist/
           if-no-files-found: error
           retention-days: 14
 
@@ -143,6 +161,16 @@ jobs:
           cd dist
           test -f "chonkstep-$version-$package_release-x86_64.pkg.tar.zst"
           test -f "chonkstep-$version-$package_release-aarch64.pkg.tar.zst"
+          # The symbol packages are assets in their own right: without
+          # them a crash report from an installed package symbolises as
+          # `??`, and Arch's debuginfod serves only official packages.
+          # Asserted rather than globbed for, so losing one is a failed
+          # release rather than a quieter one.
+          test -f "chonkstep-debug-$version-$package_release-x86_64.pkg.tar.zst"
+          test -f "chonkstep-debug-$version-$package_release-aarch64.pkg.tar.zst"
+          # The glob takes all four; `chonkstep-debug-*` matches
+          # `chonkstep-*` too, so SHA256SUMS and the asset list below
+          # need no separate entry.
           LC_ALL=C sha256sum chonkstep-*.pkg.tar.zst | sort -k2 > SHA256SUMS
 
           cat > "$RUNNER_TEMP/release-notes.md" <<EOF
@@ -177,9 +205,25 @@ jobs:
           gh attestation verify "\$chonkstep_dir/\$chonkstep_pkg" --repo $GITHUB_REPOSITORY
           \`\`\`
 
-          \`SHA256SUMS\` covers both package files. This is a prerelease
-          distribution path; the eventual stable \`v$version\` tag will also
-          publish the source recipe to the AUR.
+          Each architecture also has a \`chonkstep-debug-\` package. It is not
+          needed to run the desktop, and installing it changes nothing about
+          how the desktop behaves. It carries the debug symbols, so install it
+          before reporting a crash — without it every ChonkStep frame in a
+          coredump reads as \`??\`, and Arch's debuginfod does not carry
+          symbols for packages installed this way:
+
+          \`\`\`sh
+          chonkstep_debug_pkg="chonkstep-debug-$version-$package_release-\$chonkstep_arch.pkg.tar.zst"
+          curl -fL -o "\$chonkstep_dir/\$chonkstep_debug_pkg" \
+            "https://github.com/$GITHUB_REPOSITORY/releases/download/$GITHUB_REF_NAME/\$chonkstep_debug_pkg"
+          sudo pacman -U "\$chonkstep_dir/\$chonkstep_debug_pkg"
+          coredumpctl gdb chonkstep-wayland   # now shows file:line, not ??
+          \`\`\`
+
+          \`SHA256SUMS\` covers all four package files, and every one of them
+          carries GitHub build provenance. This is a prerelease distribution
+          path; the eventual stable \`v$version\` tag will also publish the
+          source recipe to the AUR.
           EOF
 
           assets=(chonkstep-*.pkg.tar.zst SHA256SUMS)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "chonk-build-info"
+version = "0.2.0"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "chonk-dock-proto"
 version = "0.2.0"
 dependencies = [
@@ -416,6 +423,7 @@ dependencies = [
 name = "chonkstep"
 version = "0.2.0"
 dependencies = [
+ "chonk-build-info",
  "chonk-shell",
  "chonk-xsettings",
  "libc",
@@ -432,6 +440,7 @@ dependencies = [
 name = "chonkstep-wayland"
 version = "0.2.0"
 dependencies = [
+ "chonk-build-info",
  "tracing",
  "tracing-subscriber",
  "wm-config",
@@ -1503,6 +1512,15 @@ dependencies = [
  "objc2",
  "objc2-core-location",
  "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ license = "GPL-3.0-only"
 #
 # "shipped" is after the `objcopy --only-keep-debug` + `strip` that
 # `makepkg`'s own `debug` option performs, which is why the packaging
-# recipes now set `options=(!strip debug)`: the split belongs to the
+# recipes now set `options=(strip debug)`: the split belongs to the
 # packager, and the shipped binary comes out SMALLER than it was
 # before this section existed (34 MB against 44 MB, because a full
 # strip also drops the `.symtab` the old build kept).
@@ -73,14 +73,12 @@ license = "GPL-3.0-only"
 # option needs to extract — so it fights the packaging step rather
 # than helping it. Sidecar splitting here is the packager's job.
 #
-# `codegen-units = 1` and `lto = "thin"` are kept for two reasons that
-# can be demonstrated and one that cannot. They make the shipped
-# binary and the debug package smaller than any other row above
-# (33.5 MB and 100.8 MB), and one codegen unit makes the build
-# deterministic, which is what the release workflow's provenance
-# attestation is worth having. They cost +21s (+19%) on a full release
-# build. They are NOT claimed to make the desktop faster: nothing in
-# this tree times a frame yet, so no such claim could be honest.
+# `codegen-units = 1` and `lto = "thin"` make the shipped binary and
+# the debug package smaller than any other measured row above (33.5 MB
+# and 100.8 MB). They cost +21s (+19%) on a full release build. Neither
+# deterministic output nor a faster desktop is claimed: this profile
+# alone cannot guarantee reproducibility, and nothing in this tree
+# times a frame yet.
 [profile.release]
 debug = "line-tables-only"
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,58 @@ license = "GPL-3.0-only"
 # making a debug session behave like a desktop instead of a
 # slideshow. Release builds are untouched — this section exists only
 # for the dev/test loop.
+# The release profile exists so a crash can be read. The compositor's
+# panic hook deliberately turns every panic into a `SIGABRT` so the
+# session supervisor can recover, which makes a coredump the one
+# durable artifact a lost session leaves behind — and with cargo's
+# default `debug = 0` that coredump carried no `.debug_*` at all, so
+# every chonkstep frame symbolised as `??`. Arch's debuginfod serves
+# only official packages, so it cannot fill the gap for anything
+# installed from this project's releases or the AUR recipe.
+#
+# Measured on this workspace (aarch64, `chonkstep-wayland`), because
+# the settings below are not free and the numbers are the argument:
+#
+#   profile                              build   unstripped   shipped   debug pkg
+#   ------------------------------------------------------------------------------
+#   cargo default (debug = 0)             113s      44.0 MB    44.0 MB      none
+#   debug = "line-tables-only"            106s     151.2 MB    34.9 MB   150.1 MB
+#   debug = 1                             112s     197.0 MB    34.8 MB   196.0 MB
+#   line-tables + cgu = 1 + thin LTO      134s     101.6 MB    33.5 MB   100.8 MB
+#
+# "shipped" is after the `objcopy --only-keep-debug` + `strip` that
+# `makepkg`'s own `debug` option performs, which is why the packaging
+# recipes now set `options=(!strip debug)`: the split belongs to the
+# packager, and the shipped binary comes out SMALLER than it was
+# before this section existed (34 MB against 44 MB, because a full
+# strip also drops the `.symtab` the old build kept).
+#
+# `debug = "line-tables-only"` over `debug = 1`: both cost the same
+# build time and the same shipped bytes, and line tables are what turn
+# `??` into `file:line` for every frame. Full DWARF buys locals and
+# types for an interactive gdb session at +95 MB in the debug package,
+# which is not the case this profile is for. Revisit if someone is
+# routinely stepping through a release build.
+#
+# NOT `split-debuginfo = "packed"`. Measured: it *grew* the executable
+# to 96.7 MB while also emitting a 51.6 MB `.dwp`, and it takes the
+# debug information out of the object files that `makepkg`'s `debug`
+# option needs to extract — so it fights the packaging step rather
+# than helping it. Sidecar splitting here is the packager's job.
+#
+# `codegen-units = 1` and `lto = "thin"` are kept for two reasons that
+# can be demonstrated and one that cannot. They make the shipped
+# binary and the debug package smaller than any other row above
+# (33.5 MB and 100.8 MB), and one codegen unit makes the build
+# deterministic, which is what the release workflow's provenance
+# attestation is worth having. They cost +21s (+19%) on a full release
+# build. They are NOT claimed to make the desktop faster: nothing in
+# this tree times a frame yet, so no such claim could be honest.
+[profile.release]
+debug = "line-tables-only"
+codegen-units = 1
+lto = "thin"
+
 [profile.dev.package.tiny-skia]
 opt-level = 3
 [profile.dev.package.tiny-skia-path]

--- a/crates/chonk-build-info/Cargo.toml
+++ b/crates/chonk-build-info/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "chonk-build-info"
+description = "Build identity and ELF build-ID reporting for ChonkStep binaries"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+object = { version = "0.37.3", default-features = false, features = ["elf", "read_core", "std"] }

--- a/crates/chonk-build-info/build.rs
+++ b/crates/chonk-build-info/build.rs
@@ -1,0 +1,76 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=CHONKSTEP_GIT_DESCRIBE");
+
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    track_git_inputs(&workspace);
+
+    let source_id = std::env::var("CHONKSTEP_GIT_DESCRIBE")
+        .ok()
+        .and_then(one_line)
+        .or_else(|| {
+            git(&workspace, &["describe", "--tags", "--always", "--dirty"]).and_then(one_line)
+        })
+        .unwrap_or_else(|| format!("v{}+unknown-source", env!("CARGO_PKG_VERSION")));
+    println!("cargo:rustc-env=CHONKSTEP_SOURCE_ID={source_id}");
+}
+
+fn one_line(value: String) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty() && !value.chars().any(char::is_control)).then(|| value.to_owned())
+}
+
+// This is a Cargo build script, not the compositor's event/repaint thread;
+// source identity must be known before rustc compiles the binary.
+#[allow(clippy::disallowed_methods)]
+fn git(workspace: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Make a checkout build follow branch switches, new commits, staged
+/// changes, and tags. Source archives have none of these paths; their
+/// identity comes from `CHONKSTEP_GIT_DESCRIBE` instead.
+fn track_git_inputs(workspace: &Path) {
+    for name in ["HEAD", "index"] {
+        if let Some(path) = git_path(workspace, name) {
+            println!("cargo:rerun-if-changed={}", path.display());
+        }
+    }
+    if let Some(common) = git(workspace, &["rev-parse", "--git-common-dir"]).and_then(one_line) {
+        let common = absolute(workspace, PathBuf::from(common));
+        println!(
+            "cargo:rerun-if-changed={}",
+            common.join("packed-refs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            common.join("refs/tags").display()
+        );
+    }
+}
+
+fn git_path(workspace: &Path, name: &str) -> Option<PathBuf> {
+    git(workspace, &["rev-parse", "--git-path", name])
+        .and_then(one_line)
+        .map(PathBuf::from)
+        .map(|path| absolute(workspace, path))
+}
+
+fn absolute(workspace: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        workspace.join(path)
+    }
+}

--- a/crates/chonk-build-info/src/lib.rs
+++ b/crates/chonk-build-info/src/lib.rs
@@ -1,0 +1,76 @@
+//! The two session binaries' reportable build identity.
+//!
+//! A package version identifies a release family, not the exact source
+//! that produced one executable, and the GNU ELF build ID is what joins
+//! a coredump to its separate debug file. Keeping both answers here
+//! makes the X11 and Wayland entry points print the same contract.
+
+use std::path::Path;
+
+use object::Object;
+
+/// `git describe --tags --always --dirty` from build time.
+///
+/// A source-archive packager supplies the description through
+/// `CHONKSTEP_GIT_DESCRIBE`, because an archive has no `.git` directory.
+/// A direct non-git build says `v<version>+unknown-source` rather than
+/// pretending the package version identifies unknown source exactly.
+pub const SOURCE_ID: &str = env!("CHONKSTEP_SOURCE_ID");
+
+/// The GNU ELF build ID of the executable running this code, as lower
+/// case hexadecimal.
+pub fn current_elf_build_id() -> Result<String, String> {
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("cannot locate the running executable: {error}"))?;
+    elf_build_id(executable)
+}
+
+/// The GNU ELF build ID recorded in `path`, as lower-case hexadecimal.
+///
+/// This reads the linker's actual `NT_GNU_BUILD_ID` note rather than
+/// embedding a second value that could drift from it. It is public so
+/// binary integration tests can compare `--version` with the file that
+/// was executed.
+pub fn elf_build_id(path: impl AsRef<Path>) -> Result<String, String> {
+    let path = path.as_ref();
+    let bytes =
+        std::fs::read(path).map_err(|error| format!("cannot read {}: {error}", path.display()))?;
+    let file = object::File::parse(bytes.as_slice())
+        .map_err(|error| format!("{} is not a readable object: {error}", path.display()))?;
+    let id = file
+        .build_id()
+        .map_err(|error| format!("cannot read {} build ID: {error}", path.display()))?
+        .ok_or_else(|| format!("{} has no GNU ELF build ID", path.display()))?;
+    Ok(hex(id))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+
+    let mut text = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        write!(&mut text, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_source_identity_is_one_nonempty_line() {
+        assert!(!SOURCE_ID.is_empty());
+        assert!(!SOURCE_ID.chars().any(char::is_control));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_test_executable_has_a_hexadecimal_gnu_build_id() {
+        let id = current_elf_build_id().unwrap();
+        assert!(!id.is_empty());
+        assert!(id
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()));
+    }
+}

--- a/crates/chonkstep-wayland/Cargo.toml
+++ b/crates/chonkstep-wayland/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 # through `wm-wayland` rather than naming them itself; only the config
 # loader and the compositor crate appear here.
 [target.'cfg(target_os = "linux")'.dependencies]
+chonk-build-info = { path = "../chonk-build-info" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wm-config = { path = "../wm-config" }

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -11,7 +11,35 @@
 //! configuration loading, and the exit code.
 
 #[cfg(target_os = "linux")]
+/// Answers `--version` and `-V` before anything else starts, and
+/// nothing else — these binaries take no other arguments.
+///
+/// It exists so a bug report can name its build. The version was
+/// previously reachable only through `pacman -Qi`, which is one more
+/// thing a user has to know to produce a report the crash itself
+/// cannot produce for them.
+///
+/// The ELF build id, which is what actually matches a coredump to a
+/// symbol package, is deliberately NOT embedded here: `coredumpctl
+/// info` already prints it for the core, and `readelf -n` prints it
+/// for the binary, so embedding a copy would add a build script and a
+/// note parser to restate something both ends already know. The line
+/// below says where to get it instead.
+fn print_version_and_exit_if_asked() {
+    let asked = std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V");
+    if !asked {
+        return;
+    }
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!("build id: run `readelf -n \"$(command -v {})\"` (coredumpctl prints the core's own)", env!("CARGO_PKG_NAME"));
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "linux")]
 fn main() {
+    // Before the subscriber, so `--version` prints one clean line
+    // rather than a line preceded by whatever RUST_LOG asked for.
+    print_version_and_exit_if_asked();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
 
     // A panic anywhere in this process must become an abnormal *process

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -11,27 +11,26 @@
 //! configuration loading, and the exit code.
 
 #[cfg(target_os = "linux")]
-/// Answers `--version` and `-V` before anything else starts, and
-/// nothing else — these binaries take no other arguments.
+/// Answers `--version` and `-V` before anything else starts.
 ///
 /// It exists so a bug report can name its build. The version was
 /// previously reachable only through `pacman -Qi`, which is one more
 /// thing a user has to know to produce a report the crash itself
 /// cannot produce for them.
 ///
-/// The ELF build id, which is what actually matches a coredump to a
-/// symbol package, is deliberately NOT embedded here: `coredumpctl
-/// info` already prints it for the core, and `readelf -n` prints it
-/// for the binary, so embedding a copy would add a build script and a
-/// note parser to restate something both ends already know. The line
-/// below says where to get it instead.
 fn print_version_and_exit_if_asked() {
-    let asked = std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V");
+    let asked = std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--version" || arg == "-V");
     if !asked {
         return;
     }
     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("build id: run `readelf -n \"$(command -v {})\"` (coredumpctl prints the core's own)", env!("CARGO_PKG_NAME"));
+    println!("source: {}", chonk_build_info::SOURCE_ID);
+    match chonk_build_info::current_elf_build_id() {
+        Ok(build_id) => println!("build id: {build_id}"),
+        Err(error) => println!("build id: unavailable ({error})"),
+    }
     std::process::exit(0);
 }
 

--- a/crates/chonkstep-wayland/tests/version.rs
+++ b/crates/chonkstep-wayland/tests/version.rs
@@ -1,0 +1,41 @@
+#[cfg(target_os = "linux")]
+// This is a test process waiting for the CLI it deliberately spawned,
+// not the compositor's event/repaint thread.
+#[allow(clippy::disallowed_methods)]
+fn assert_version(flag: &str) {
+    let binary = env!("CARGO_BIN_EXE_chonkstep-wayland");
+    let output = std::process::Command::new(binary)
+        .arg(flag)
+        .output()
+        .expect("run chonkstep-wayland");
+    assert!(output.status.success(), "{flag}: {:?}", output.status);
+    assert!(
+        output.stderr.is_empty(),
+        "{flag}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let build_id = chonk_build_info::elf_build_id(binary).unwrap();
+    let expected = format!(
+        "chonkstep-wayland {}\nsource: {}\nbuild id: {build_id}\n",
+        env!("CARGO_PKG_VERSION"),
+        chonk_build_info::SOURCE_ID,
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        expected,
+        "{flag}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn long_version_names_the_source_and_executable_build_id() {
+    assert_version("--version");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn short_version_is_the_same_report() {
+    assert_version("-V");
+}

--- a/crates/chonkstep/Cargo.toml
+++ b/crates/chonkstep/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "A modern NeXTSTEP-style window manager for X11."
 
 [dependencies]
+chonk-build-info = { path = "../chonk-build-info" }
 # The backend-generic desktop shell — everything the desktop *is*; this
 # binary only wires it to the X11 backend and drives the event loop.
 chonk-shell = { path = "../chonk-shell" }

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -21,27 +21,26 @@ use chonk_shell::spawn;
 use chonk_shell::startup::{ensure_xcursor_size, SessionRequestPoller, SessionState};
 use chonk_xsettings::{DesktopAppearance, XSettingsManager};
 
-/// Answers `--version` and `-V` before anything else starts, and
-/// nothing else — these binaries take no other arguments.
+/// Answers `--version` and `-V` before anything else starts.
 ///
 /// It exists so a bug report can name its build. The version was
 /// previously reachable only through `pacman -Qi`, which is one more
 /// thing a user has to know to produce a report the crash itself
 /// cannot produce for them.
 ///
-/// The ELF build id, which is what actually matches a coredump to a
-/// symbol package, is deliberately NOT embedded here: `coredumpctl
-/// info` already prints it for the core, and `readelf -n` prints it
-/// for the binary, so embedding a copy would add a build script and a
-/// note parser to restate something both ends already know. The line
-/// below says where to get it instead.
 fn print_version_and_exit_if_asked() {
-    let asked = std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V");
+    let asked = std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--version" || arg == "-V");
     if !asked {
         return;
     }
     println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-    println!("build id: run `readelf -n \"$(command -v {})\"` (coredumpctl prints the core's own)", env!("CARGO_PKG_NAME"));
+    println!("source: {}", chonk_build_info::SOURCE_ID);
+    match chonk_build_info::current_elf_build_id() {
+        Ok(build_id) => println!("build id: {build_id}"),
+        Err(error) => println!("build id: unavailable ({error})"),
+    }
     std::process::exit(0);
 }
 

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -21,7 +21,36 @@ use chonk_shell::spawn;
 use chonk_shell::startup::{ensure_xcursor_size, SessionRequestPoller, SessionState};
 use chonk_xsettings::{DesktopAppearance, XSettingsManager};
 
+/// Answers `--version` and `-V` before anything else starts, and
+/// nothing else — these binaries take no other arguments.
+///
+/// It exists so a bug report can name its build. The version was
+/// previously reachable only through `pacman -Qi`, which is one more
+/// thing a user has to know to produce a report the crash itself
+/// cannot produce for them.
+///
+/// The ELF build id, which is what actually matches a coredump to a
+/// symbol package, is deliberately NOT embedded here: `coredumpctl
+/// info` already prints it for the core, and `readelf -n` prints it
+/// for the binary, so embedding a copy would add a build script and a
+/// note parser to restate something both ends already know. The line
+/// below says where to get it instead.
+fn print_version_and_exit_if_asked() {
+    let asked = std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V");
+    if !asked {
+        return;
+    }
+    println!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    println!("build id: run `readelf -n \"$(command -v {})\"` (coredumpctl prints the core's own)", env!("CARGO_PKG_NAME"));
+    std::process::exit(0);
+}
+
 fn main() {
+    // Before the subscriber, so `--version` prints one clean line
+    // rather than a line preceded by whatever RUST_LOG asked for.
+    // Also before `restart_in_place`'s re-exec can ever matter: that
+    // path passes no arguments, so a restarted session never sees one.
+    print_version_and_exit_if_asked();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),

--- a/crates/chonkstep/tests/version.rs
+++ b/crates/chonkstep/tests/version.rs
@@ -1,0 +1,41 @@
+#[cfg(target_os = "linux")]
+// This is a test process waiting for the CLI it deliberately spawned,
+// not the compositor's event/repaint thread.
+#[allow(clippy::disallowed_methods)]
+fn assert_version(flag: &str) {
+    let binary = env!("CARGO_BIN_EXE_chonkstep");
+    let output = std::process::Command::new(binary)
+        .arg(flag)
+        .output()
+        .expect("run chonkstep");
+    assert!(output.status.success(), "{flag}: {:?}", output.status);
+    assert!(
+        output.stderr.is_empty(),
+        "{flag}: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let build_id = chonk_build_info::elf_build_id(binary).unwrap();
+    let expected = format!(
+        "chonkstep {}\nsource: {}\nbuild id: {build_id}\n",
+        env!("CARGO_PKG_VERSION"),
+        chonk_build_info::SOURCE_ID,
+    );
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        expected,
+        "{flag}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn long_version_names_the_source_and_executable_build_id() {
+    assert_version("--version");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn short_version_is_the_same_report() {
+    assert_version("-V");
+}

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,6 +11,28 @@
 # identical to PKGBUILD-release - see its comments for how the
 # dependency list was derived.
 
+# Ship the debug information rather than discarding it.
+#
+# `makepkg`'s stock `OPTIONS` include `strip` and `!debug`, and
+# `STRIP_BINARIES="--strip-all"`, so the default behaviour is to throw
+# away everything the release profile now emits — leaving a package
+# whose crashes symbolise as `??` for everyone, including the
+# maintainer on any machine but the build host. Arch's debuginfod
+# carries only official packages, so it cannot fill that gap for a
+# package installed from a GitHub release or the AUR.
+#
+# `!strip` keeps `makepkg` from stripping blindly; `debug` makes it do
+# the split properly instead — `objcopy --only-keep-debug` into a
+# separate `%s-debug` package, then strip the shipped binary. Measured
+# on aarch64: the shipped executable comes out at ~33 MB, SMALLER than
+# the ~44 MB it was before the release profile existed, because a full
+# strip also drops the `.symtab` the old build kept. The debug package
+# carries the ~101 MB nobody downloads unless they are reading a core.
+#
+# `.eh_frame` survives the strip, so stack unwinding from a coredump
+# works off the shipped binary alone; the debug package is what turns
+# those frames into `file:line`.
+options=(!strip debug)
 pkgname=chonkstep-git
 pkgver=0.2.0.r76.ge1b4e54
 pkgrel=1

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -21,18 +21,19 @@
 # carries only official packages, so it cannot fill that gap for a
 # package installed from a GitHub release or the AUR.
 #
-# `!strip` keeps `makepkg` from stripping blindly; `debug` makes it do
-# the split properly instead — `objcopy --only-keep-debug` into a
-# separate `%s-debug` package, then strip the shipped binary. Measured
-# on aarch64: the shipped executable comes out at ~33 MB, SMALLER than
-# the ~44 MB it was before the release profile existed, because a full
-# strip also drops the `.symtab` the old build kept. The debug package
-# carries the ~101 MB nobody downloads unless they are reading a core.
+# `strip` and `debug` must both be enabled: together they run
+# `objcopy --only-keep-debug` into a separate `%s-debug` package, then
+# strip the shipped binary. (`!strip debug` silently produces no debug
+# package at all.) Measured on aarch64: the shipped executable comes out
+# at ~33 MB, SMALLER than the ~44 MB it was before the release profile
+# existed, because a full strip also drops the `.symtab` the old build
+# kept. The debug package carries the ~101 MB nobody downloads unless
+# they are reading a core.
 #
 # `.eh_frame` survives the strip, so stack unwinding from a coredump
 # works off the shipped binary alone; the debug package is what turns
 # those frames into `file:line`.
-options=(!strip debug)
+options=(strip debug)
 pkgname=chonkstep-git
 pkgver=0.2.0.r76.ge1b4e54
 pkgrel=1
@@ -102,6 +103,8 @@ build() {
   cd chonkstep
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
+  # Record the exact checkout, not only the workspace package version.
+  export CHONKSTEP_GIT_DESCRIBE="$(git describe --tags --always --dirty)"
   cargo build --release --frozen --workspace
 }
 
@@ -109,6 +112,7 @@ check() {
   cd chonkstep
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
+  export CHONKSTEP_GIT_DESCRIBE="$(git describe --tags --always --dirty)"
   cargo test --frozen --workspace
 }
 

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -25,18 +25,19 @@
 # carries only official packages, so it cannot fill that gap for a
 # package installed from a GitHub release or the AUR.
 #
-# `!strip` keeps `makepkg` from stripping blindly; `debug` makes it do
-# the split properly instead — `objcopy --only-keep-debug` into a
-# separate `%s-debug` package, then strip the shipped binary. Measured
-# on aarch64: the shipped executable comes out at ~33 MB, SMALLER than
-# the ~44 MB it was before the release profile existed, because a full
-# strip also drops the `.symtab` the old build kept. The debug package
-# carries the ~101 MB nobody downloads unless they are reading a core.
+# `strip` and `debug` must both be enabled: together they run
+# `objcopy --only-keep-debug` into a separate `%s-debug` package, then
+# strip the shipped binary. (`!strip debug` silently produces no debug
+# package at all.) Measured on aarch64: the shipped executable comes out
+# at ~33 MB, SMALLER than the ~44 MB it was before the release profile
+# existed, because a full strip also drops the `.symtab` the old build
+# kept. The debug package carries the ~101 MB nobody downloads unless
+# they are reading a core.
 #
 # `.eh_frame` survives the strip, so stack unwinding from a coredump
 # works off the shipped binary alone; the debug package is what turns
 # those frames into `file:line`.
-options=(!strip debug)
+options=(strip debug)
 pkgname=chonkstep
 pkgver=0.2.0
 pkgrel=3
@@ -96,6 +97,11 @@ build() {
   cd "$pkgname-$pkgver"
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
+  # A tag archive has no `.git`. The release workflow passes its exact
+  # `git describe` through makepkg; a normal AUR build falls back to the
+  # tag this recipe downloads. Direct non-git Cargo builds have their
+  # own explicit `+unknown-source` fallback in chonk-build-info.
+  export CHONKSTEP_GIT_DESCRIBE="${CHONKSTEP_GIT_DESCRIBE:-v$pkgver}"
   # --frozen: build exactly the dependency tree the repository ships.
   cargo build --release --frozen --workspace
 }
@@ -104,6 +110,7 @@ check() {
   cd "$pkgname-$pkgver"
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
+  export CHONKSTEP_GIT_DESCRIBE="${CHONKSTEP_GIT_DESCRIBE:-v$pkgver}"
   # The backend-generic crates and the config round-trip; the Wayland
   # backend's suite needs the system libraries above and runs too.
   cargo test --frozen --workspace

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -15,6 +15,28 @@
 # The X11 session's own server and everything theme-optional is in
 # optdepends, so a Wayland-only install stays lean.
 
+# Ship the debug information rather than discarding it.
+#
+# `makepkg`'s stock `OPTIONS` include `strip` and `!debug`, and
+# `STRIP_BINARIES="--strip-all"`, so the default behaviour is to throw
+# away everything the release profile now emits — leaving a package
+# whose crashes symbolise as `??` for everyone, including the
+# maintainer on any machine but the build host. Arch's debuginfod
+# carries only official packages, so it cannot fill that gap for a
+# package installed from a GitHub release or the AUR.
+#
+# `!strip` keeps `makepkg` from stripping blindly; `debug` makes it do
+# the split properly instead — `objcopy --only-keep-debug` into a
+# separate `%s-debug` package, then strip the shipped binary. Measured
+# on aarch64: the shipped executable comes out at ~33 MB, SMALLER than
+# the ~44 MB it was before the release profile existed, because a full
+# strip also drops the `.symtab` the old build kept. The debug package
+# carries the ~101 MB nobody downloads unless they are reading a core.
+#
+# `.eh_frame` survives the strip, so stack unwinding from a coredump
+# works off the shipped binary alone; the debug package is what turns
+# those frames into `file:line`.
+options=(!strip debug)
 pkgname=chonkstep
 pkgver=0.2.0
 pkgrel=3

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -120,10 +120,10 @@ for binary in chonkstep chonkstep-wayland; do
     }
     reported_build_id="$(printf '%s\n' "$long_version" | sed -n 's/^build id: //p')"
     elf_build_id="$(readelf -n "$path" | sed -n 's/.*Build ID: //p' | head -n 1)"
-    [ -n "$elf_build_id" ] && [ "$reported_build_id" = "$elf_build_id" ] || {
+    if [ -z "$elf_build_id" ] || [ "$reported_build_id" != "$elf_build_id" ]; then
         echo "$binary reports build ID $reported_build_id, readelf reports $elf_build_id" >&2
         exit 1
-    }
+    fi
 done
 
 # And the split has to have actually happened: `options=(strip debug)`

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -24,7 +24,7 @@ case "$expected_arch" in
     *) echo "unsupported expected architecture: $expected_arch" >&2; exit 2 ;;
 esac
 
-for command in bsdtar desktop-file-validate file ldd qmllint; do
+for command in bsdtar desktop-file-validate file ldd qmllint readelf; do
     command -v "$command" >/dev/null 2>&1 || {
         echo "release verifier needs $command" >&2
         exit 2
@@ -83,6 +83,51 @@ do
         ldd "$path" >&2
         exit 1
     fi
+    # A shipped binary must still be unwindable from a coredump. The
+    # panic hook turns every panic into a SIGABRT so the session
+    # supervisor can recover, which makes the core the one durable
+    # artifact a lost session leaves — and a core is only a stack if
+    # `.eh_frame` survived the packaging strip. It does survive
+    # `--strip-all`; what would remove it is someone "fixing" the
+    # release profile or the PKGBUILD's `options=(!strip debug)` back
+    # to discarding debug information, which is the state this check
+    # exists to stop returning to.
+    if ! readelf -S "$path" | grep -q '\.eh_frame'; then
+        echo "$binary has no .eh_frame: a coredump from it cannot be unwound" >&2
+        exit 1
+    fi
 done
+
+# And the split has to have actually happened: `options=(!strip debug)`
+# is what puts the symbols in a -debug package instead of the bin, and
+# a packaging change that dropped it would leave crashes unreadable
+# again with nothing failing to say so.
+# `makepkg` names it "$pkgname-debug-$pkgver-$pkgrel-$arch.pkg.tar*"
+# and writes it beside the main package. `$expected_version` is
+# already "version-pkgrel" (see the usage line), so the only unknown
+# left is the compression suffix. An explicit `if` rather than
+# `[ -f ] && ...`: this script runs under `set -e`, where a failing
+# test as the last statement of a loop body would end the run instead
+# of trying the next candidate.
+debug_package=""
+for candidate in "$(dirname "$package")"/chonkstep-debug-"$expected_version"-"$expected_arch".pkg.tar*; do
+    if [ -f "$candidate" ]; then
+        debug_package="$candidate"
+        break
+    fi
+done
+if [ -z "$debug_package" ]; then
+    echo "no debug package beside $(basename "$package"): the symbols were not split out" >&2
+    echo "  expected chonkstep-debug-$expected_version-$expected_arch.pkg.tar*" >&2
+    echo "  check that the PKGBUILD still sets options=(!strip debug)" >&2
+    exit 1
+fi
+for binary in chonkstep chonkstep-wayland; do
+    bsdtar -tf "$debug_package" | grep -q "usr/lib/debug/usr/bin/$binary" || {
+        echo "the debug package carries no symbols for $binary" >&2
+        exit 1
+    }
+done
+echo "verify-release-package: debug symbols present in $(basename "$debug_package")"
 
 echo "verify-release-package: $expected_arch $expected_version passed"

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -2,14 +2,16 @@
 # Validate a release package from the outside, on its native architecture.
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "usage: $0 PACKAGE EXPECTED_ARCH EXPECTED_VERSION-PKGREL" >&2
+if [ "$#" -ne 4 ]; then
+    echo "usage: $0 PACKAGE EXPECTED_ARCH EXPECTED_VERSION-PKGREL EXPECTED_SOURCE_ID" >&2
     exit 2
 fi
 
 package="$1"
 expected_arch="$2"
 expected_version="$3"
+expected_source_id="$4"
+package_version="${expected_version%-*}"
 
 # Arch keeps Qt's development tools outside the default shell PATH. Make the
 # distribution's canonical Qt 6 location visible to this verifier and to the
@@ -88,17 +90,43 @@ do
     # supervisor can recover, which makes the core the one durable
     # artifact a lost session leaves — and a core is only a stack if
     # `.eh_frame` survived the packaging strip. It does survive
-    # `--strip-all`; what would remove it is someone "fixing" the
-    # release profile or the PKGBUILD's `options=(!strip debug)` back
-    # to discarding debug information, which is the state this check
-    # exists to stop returning to.
+    # `--strip-all`; this check protects that independent unwind
+    # contract while the debug-package checks below protect symbols.
     if ! readelf -S "$path" | grep -q '\.eh_frame'; then
         echo "$binary has no .eh_frame: a coredump from it cannot be unwound" >&2
         exit 1
     fi
 done
 
-# And the split has to have actually happened: `options=(!strip debug)`
+# Both session binaries name the exact source used before it became a
+# source archive and read their actual linker's GNU build-ID note. Check
+# both spellings and compare the report to `readelf`, so this is also a
+# test of the stripped binaries users actually install.
+for binary in chonkstep chonkstep-wayland; do
+    path="$stage/usr/bin/$binary"
+    long_version="$("$path" --version)"
+    short_version="$("$path" -V)"
+    [ "$long_version" = "$short_version" ] || {
+        echo "$binary -V and --version disagree" >&2
+        exit 1
+    }
+    printf '%s\n' "$long_version" | grep -Fxq "$binary $package_version" || {
+        echo "$binary reports the wrong package version: $long_version" >&2
+        exit 1
+    }
+    printf '%s\n' "$long_version" | grep -Fxq "source: $expected_source_id" || {
+        echo "$binary reports the wrong source identity: $long_version" >&2
+        exit 1
+    }
+    reported_build_id="$(printf '%s\n' "$long_version" | sed -n 's/^build id: //p')"
+    elf_build_id="$(readelf -n "$path" | sed -n 's/.*Build ID: //p' | head -n 1)"
+    [ -n "$elf_build_id" ] && [ "$reported_build_id" = "$elf_build_id" ] || {
+        echo "$binary reports build ID $reported_build_id, readelf reports $elf_build_id" >&2
+        exit 1
+    }
+done
+
+# And the split has to have actually happened: `options=(strip debug)`
 # is what puts the symbols in a -debug package instead of the bin, and
 # a packaging change that dropped it would leave crashes unreadable
 # again with nothing failing to say so.
@@ -119,7 +147,7 @@ done
 if [ -z "$debug_package" ]; then
     echo "no debug package beside $(basename "$package"): the symbols were not split out" >&2
     echo "  expected chonkstep-debug-$expected_version-$expected_arch.pkg.tar*" >&2
-    echo "  check that the PKGBUILD still sets options=(!strip debug)" >&2
+    echo "  check that the PKGBUILD still sets options=(strip debug)" >&2
     exit 1
 fi
 for binary in chonkstep chonkstep-wayland; do


### PR DESCRIPTION
Fixes #50

## Outcome

- Release builds keep line-table debug information and use the measured one-codegen-unit/thin-LTO profile.
- Both Arch recipes use `options=(strip debug)`, the makepkg combination that actually strips the installed binaries and emits `chonkstep-debug`.
- `chonkstep --version` / `-V` and `chonkstep-wayland --version` / `-V` print the workspace package version, the exact `git describe` source identity recorded at build time, and the running ELF executable actual GNU build ID.
- A source archive receives its source identity through `CHONKSTEP_GIT_DESCRIBE`; a direct non-git build reports the explicit `v<version>+unknown-source` fallback.
- The release workflow carries the checkout identity into makepkg, verifies both flag spellings on both stripped packaged binaries, compares each reported ID with `readelf`, verifies the split debug files, then digests, attests, and publishes both packages.

## Corrections made during review

The original PR head used `options=(!strip debug)`. makepkg requires both `strip` and `debug`; disabling `strip` silently prevents the debug package from being created. The original head also omitted the issue-required source identity and ELF build ID, and attributed deterministic output to one codegen unit. Those three defects are repaired at `2fa753d`; the reproducibility claim was removed.

## Artifact-level proof

The exact committed source was exported with `git archive` and built in the same native x86_64 Arch container as the tag workflow. `makepkg` completed its frozen workspace tests, stripped the installed binaries, and created both:

- `chonkstep-0.2.0-3-x86_64.pkg.tar.zst`
- `chonkstep-debug-0.2.0-3-x86_64.pkg.tar.zst`

`verify-release-package.sh` passed against those real archives. It confirmed session/install metadata, `.eh_frame`, exact source identity, both version flag spellings, printed-vs-ELF build-ID equality, and matching debug files for both binaries.

The no-git archive path was also built both without an override (`source: v0.2.0+unknown-source`) and with `CHONKSTEP_GIT_DESCRIBE=preview-v0.2.0-r3`; both reports matched the executable build ID from `readelf`.

## Exact-head validation

All passed at `2fa753ddef0f8c52e176fb758f491f08761d60e7`:

- `cargo test -p chonk-build-info`
- `cargo test -p chonkstep -p chonkstep-wayland`
- `cargo test --workspace --all-targets`
- strict workspace Clippy with all repository deny flags
- rustdoc with warnings denied
- `cargo test -p wm-wayland`
- `scripts/e2e.sh --headless`, including installed-Omarchy checks
- `bash -n`, workflow YAML parse, standalone verifier ShellCheck, and `git diff --check`

Fresh GitHub checks for this repaired head are required before merge.