### PR TITLE
Package chonk-about and verify its symbols (#111)

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -127,6 +127,9 @@ package() {
   # with no saved profile, so it has to be on PATH or that row silently
   # does nothing. See docs/link-panel.md.
   install -Dm755 target/release/chonk-netjoin "$pkgdir/usr/bin/chonk-netjoin"
+  # The SDK showcase launched by both desktop About menu entries. It
+  # must be a sibling of the installed compositor or available on PATH.
+  install -Dm755 target/release/chonk-about "$pkgdir/usr/bin/chonk-about"
   # The Omarchy bridge: writes chonkstep's built-in themes out as
   # Omarchy themes, so `omarchy-theme-set` can dress the rest of the
   # machine to match (see README, "Installing on Omarchy").

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -128,6 +128,9 @@ package() {
   # with no saved profile, so it has to be on PATH or that row silently
   # does nothing. See docs/link-panel.md.
   install -Dm755 target/release/chonk-netjoin "$pkgdir/usr/bin/chonk-netjoin"
+  # The SDK showcase launched by both desktop About menu entries. It
+  # must be a sibling of the installed compositor or available on PATH.
+  install -Dm755 target/release/chonk-about "$pkgdir/usr/bin/chonk-about"
   # The Omarchy bridge: writes chonkstep's built-in themes out as
   # Omarchy themes, so `omarchy-theme-set` can dress the rest of the
   # machine to match (see README, "Installing on Omarchy").

--- a/scripts/verify-release-package.sh
+++ b/scripts/verify-release-package.sh
@@ -68,12 +68,16 @@ bsdtar -xf "$package" -C "$stage"
 
 "$stage/usr/lib/chonkstep/verify-install.sh" --root "$stage"
 
-for binary in \
-    chonkstep \
-    chonkstep-wayland \
-    chonk-netjoin \
+# Keep every packaged ELF in one list so presence, architecture,
+# dependencies, unwindability, and split debug symbols cannot drift apart.
+release_binaries=(
+    chonkstep
+    chonkstep-wayland
+    chonk-about
+    chonk-netjoin
     omarchy-export-themes
-do
+)
+for binary in "${release_binaries[@]}"; do
     path="$stage/usr/bin/$binary"
     [ -x "$path" ] || { echo "missing executable: $path" >&2; exit 1; }
     case "$expected_arch" in
@@ -150,7 +154,7 @@ if [ -z "$debug_package" ]; then
     echo "  check that the PKGBUILD still sets options=(strip debug)" >&2
     exit 1
 fi
-for binary in chonkstep chonkstep-wayland; do
+for binary in "${release_binaries[@]}"; do
     bsdtar -tf "$debug_package" | grep -q "usr/lib/debug/usr/bin/$binary" || {
         echo "the debug package carries no symbols for $binary" >&2
         exit 1


### PR DESCRIPTION
Fixes #111

Root cause
- Both Arch recipes built the workspace-wide chonk-about binary but omitted it from package().
- The release verifier maintained separate incomplete runtime and debug-symbol lists, so an omitted binary was invisible to the release gate.

Behavioral change
- Install chonk-about as /usr/bin/chonk-about in both the branch-head and release recipes.
- Define one authoritative packaged-ELF list in verify-release-package.sh and use it for executable/architecture/ldd/.eh_frame checks and split-debug sidecar checks.
- Keep the source/build-ID version check restricted to chonkstep and chonkstep-wayland, the only binaries implementing that interface.

Evidence
- The strengthened verifier rejects the previous real package with: missing executable: .../usr/bin/chonk-about.
- A native x86_64 Arch makepkg build produced chonkstep-0.2.0-3-x86_64.pkg.tar.zst and chonkstep-debug-0.2.0-3-x86_64.pkg.tar.zst.
- The real release verifier passed that pair and confirmed every packaged ELF and debug sidecar.
- The main archive contains usr/bin/chonk-about.
- The debug archive contains usr/lib/debug/usr/bin/chonk-about.debug.
- From the unpacked package root, chonk-about resolved via PATH and stayed alive under Xvfb until the expected 3-second timeout (status 124), proving package-only launch.

Validation
- Native Arch package makepkg build() and complete check(): passed.
- scripts/verify-release-package.sh against the built package pair: passed.
- timeout --signal=TERM 3s xvfb-run -a chonk-about from unpacked package PATH: expected status 124.
- cargo test --workspace --all-targets: passed.
- cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks: passed.
- RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' cargo doc --workspace --no-deps --locked --document-private-items: passed.
- bash -n on both PKGBUILDs and the verifier: passed.
- shellcheck scripts/verify-release-package.sh: passed.
- git diff --check: passed.

Known limitation
- The local native package proof is x86_64. The existing release workflow builds and runs the same verifier natively on both x86_64 and aarch64 when packaging is dispatched.
