### PR TITLE
Bound glibc heap high-water mark (#93)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ name = "chonkstep-wayland"
 version = "0.2.0"
 dependencies = [
  "chonk-build-info",
+ "chonk-shell",
  "tracing",
  "tracing-subscriber",
  "wm-config",

--- a/README.md
+++ b/README.md
@@ -710,6 +710,8 @@ always available; it is not rebindable from the config file.
   complete Wayland integration suite one compositor at a time. It exercises
   real clients and captured pixels without touching the logged-in desktop;
   omit `--headless` to nest visibly in the current graphical session.
+- [docs/memory.md](docs/memory.md) explains the compositor's glibc
+  allocation policy and gives a reproducible `/proc` heap measurement.
 
 The workspace splits along seams that keep the core testable: `wm-core`
 (window management logic, no display server), `wm-theme` (decoration

--- a/crates/chonk-shell/src/startup.rs
+++ b/crates/chonk-shell/src/startup.rs
@@ -28,6 +28,43 @@ use wm_theme::{Appearance, Theme};
 
 use crate::theme_select;
 
+/// Keeps large, short-lived render buffers out of glibc's persistent
+/// heap arena.
+///
+/// glibc normally raises its mmap threshold after freeing a large
+/// allocation. A later allocation just below that new threshold then
+/// comes from the arena, and freeing it can leave the compositor's
+/// `[heap]` mapping at that high-water mark indefinitely. Overview,
+/// theme changes, and screenshots all create buffers with exactly
+/// that lifetime. Setting both thresholds disables the adaptive rule:
+/// allocations of at least 128 KiB use their own mappings, while idle
+/// arena space becomes eligible for trimming at 256 KiB.
+///
+/// Call this at the very beginning of each session binary, before
+/// logging setup or any worker thread. On targets without glibc there
+/// is no matching allocator policy to change, so this is a successful
+/// no-op.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+pub fn pin_glibc_large_allocation_policy() -> bool {
+    const MMAP_THRESHOLD_BYTES: libc::c_int = 128 * 1024;
+    const TRIM_THRESHOLD_BYTES: libc::c_int = 256 * 1024;
+
+    // SAFETY: `mallopt` changes process-global allocator policy and
+    // accepts these documented integer parameters. Both session
+    // binaries call this while startup is still single-threaded.
+    unsafe {
+        let mmap_set = libc::mallopt(libc::M_MMAP_THRESHOLD, MMAP_THRESHOLD_BYTES) != 0;
+        let trim_set = libc::mallopt(libc::M_TRIM_THRESHOLD, TRIM_THRESHOLD_BYTES) != 0;
+        mmap_set && trim_set
+    }
+}
+
+/// Non-glibc counterpart to [`pin_glibc_large_allocation_policy`].
+#[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+pub fn pin_glibc_large_allocation_policy() -> bool {
+    true
+}
+
 /// Everything about a running session that a user can change without
 /// restarting it: the look (theme and UI scale) and the policy the
 /// config file sets.
@@ -983,6 +1020,77 @@ mod tests {
     #[test]
     fn absent_config_theme_is_not_an_error() {
         assert!(config_theme_fallback(None).is_none());
+    }
+}
+
+#[cfg(all(test, target_os = "linux", target_env = "gnu"))]
+mod allocator_tests {
+    use std::hint::black_box;
+    use std::process::Command;
+
+    const CHILD_ENV: &str = "CHONKSTEP_GLIBC_ARENA_TEST_CHILD";
+    const MAX_ARENA_GROWTH: usize = 2 * 1024 * 1024;
+
+    fn touched_buffer(bytes: usize) -> Vec<u8> {
+        let mut buffer = vec![0_u8; bytes];
+        for offset in (0..bytes).step_by(4096) {
+            buffer[offset] = 1;
+        }
+        black_box(&buffer);
+        buffer
+    }
+
+    fn arena_bytes() -> usize {
+        // SAFETY: `mallinfo2` takes no pointers and returns a snapshot
+        // of glibc's allocator counters by value.
+        unsafe { libc::mallinfo2().arena }
+    }
+
+    #[test]
+    fn glibc_large_transients_stay_out_of_the_arena() {
+        if std::env::var_os(CHILD_ENV).is_none() {
+            // Run alone in a fresh process: `mallopt` is process-global,
+            // so applying it in the parent test runner would silently
+            // change the allocator beneath unrelated parallel tests.
+            #[allow(clippy::disallowed_methods)]
+            let output = Command::new(std::env::current_exe().expect("current test executable"))
+                .args([
+                    "--exact",
+                    "startup::allocator_tests::glibc_large_transients_stay_out_of_the_arena",
+                    "--nocapture",
+                ])
+                .env(CHILD_ENV, "1")
+                .output()
+                .expect("spawn isolated allocator test");
+            assert!(
+                output.status.success(),
+                "isolated allocator test failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        assert!(super::pin_glibc_large_allocation_policy(), "glibc accepted both fixed thresholds");
+        let before = arena_bytes();
+
+        // Without the startup policy, freeing the first transient
+        // raises glibc's adaptive mmap threshold above the second
+        // transient's size. That 15 MiB buffer then enters the arena
+        // and leaves its mapping behind. The small live buffer prevents
+        // a coincidental top-of-heap trim from masking that.
+        drop(touched_buffer(16 * 1024 * 1024));
+        let transient = touched_buffer(15 * 1024 * 1024);
+        let live = touched_buffer(64 * 1024);
+        drop(transient);
+        black_box(live);
+
+        let growth = arena_bytes().saturating_sub(before);
+        assert!(
+            growth < MAX_ARENA_GROWTH,
+            "large transients grew glibc's arena by {growth} bytes (before {before}, after {})",
+            arena_bytes()
+        );
     }
 }
 

--- a/crates/chonk-testkit/tests/memory.rs
+++ b/crates/chonk-testkit/tests/memory.rs
@@ -1,0 +1,182 @@
+//! The compositor's real transient-buffer workload must not ratchet
+//! glibc's main heap arena upward. This complements the allocator-level
+//! subprocess regression in `chonk-shell::startup`: it boots the
+//! Wayland binary, opens Overview, changes theme twice, captures real
+//! screenshots, and reads the compositor's own `/proc` accounting.
+
+use std::path::Path;
+use std::time::Duration;
+
+use chonk_testkit::{keys, poll_until, Session, SessionOptions, World};
+
+const SETTLE: Duration = Duration::from_secs(30);
+const MAX_HEAP_GROWTH_BYTES: usize = 4 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+struct HeapSnapshot {
+    extent_bytes: usize,
+    size_bytes: usize,
+    rss_bytes: usize,
+}
+
+fn heap_snapshot(pid: u32) -> Result<HeapSnapshot, String> {
+    let maps =
+        std::fs::read_to_string(format!("/proc/{pid}/maps")).map_err(|error| error.to_string())?;
+    let heap = maps
+        .lines()
+        .find(|line| line.ends_with("[heap]"))
+        .ok_or_else(|| format!("/proc/{pid}/maps has no [heap] mapping"))?;
+    let range = heap
+        .split_whitespace()
+        .next()
+        .ok_or("heap mapping has no address range")?;
+    let (start, end) = range
+        .split_once('-')
+        .ok_or("heap mapping has a malformed address range")?;
+    let start = usize::from_str_radix(start, 16).map_err(|error| error.to_string())?;
+    let end = usize::from_str_radix(end, 16).map_err(|error| error.to_string())?;
+
+    let smaps =
+        std::fs::read_to_string(format!("/proc/{pid}/smaps")).map_err(|error| error.to_string())?;
+    let mut lines = smaps.lines().skip_while(|line| !line.ends_with("[heap]"));
+    let _ = lines
+        .next()
+        .ok_or_else(|| format!("/proc/{pid}/smaps has no [heap] section"))?;
+    let mut size_bytes = None;
+    let mut rss_bytes = None;
+    for line in lines {
+        if line
+            .split_whitespace()
+            .next()
+            .is_some_and(|word| word.contains('-'))
+        {
+            break;
+        }
+        let kib = |prefix: &str| {
+            line.strip_prefix(prefix)
+                .and_then(|rest| rest.split_whitespace().next())
+                .and_then(|value| value.parse::<usize>().ok())
+                .map(|value| value * 1024)
+        };
+        size_bytes = size_bytes.or_else(|| kib("Size:"));
+        rss_bytes = rss_bytes.or_else(|| kib("Rss:"));
+    }
+
+    Ok(HeapSnapshot {
+        extent_bytes: end.saturating_sub(start),
+        size_bytes: size_bytes.ok_or("heap smaps section has no Size")?,
+        rss_bytes: rss_bytes.ok_or("heap smaps section has no Rss")?,
+    })
+}
+
+fn save_proc_snapshot(pid: u32, dir: &Path, label: &str) {
+    for file in ["maps", "smaps", "smaps_rollup"] {
+        std::fs::copy(
+            format!("/proc/{pid}/{file}"),
+            dir.join(format!("{label}.{file}")),
+        )
+        .unwrap_or_else(|error| panic!("save {label} {file}: {error}"));
+    }
+}
+
+fn overview_is_open(world: &World) -> bool {
+    world.shells.iter().any(|surface| {
+        surface.mapped
+            && surface.above
+            && surface.w == world.output_w
+            && surface.h == world.output_h
+    })
+}
+
+fn set_theme(session: &mut Session, theme: &str) {
+    session
+        .rewrite_config(&format!(
+            "omarchy_shell = false\nscale = 2\ntheme = \"{theme}\"\n"
+        ))
+        .expect("rewrite isolated config");
+    session.request_reload().expect("request live theme reload");
+    let door = session.door();
+    poll_until(
+        SETTLE,
+        &format!("the {theme} theme to become observable"),
+        || {
+            door.windows()
+                .ok()
+                .filter(|world| world.theme.id == theme)
+                .map(|_| ())
+        },
+    )
+    .unwrap_or_else(|error| panic!("{error}: theme reload never settled"));
+}
+
+#[test]
+#[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit -- --ignored --test-threads=1"]
+fn overview_theme_and_screenshot_transients_do_not_raise_the_heap_high_water() {
+    let mut session = Session::boot(
+        "memory-high-water",
+        SessionOptions {
+            scale: Some(2.0),
+            ..SessionOptions::default()
+        },
+    )
+    .expect("session boots");
+    session.door().barrier().expect("initial frame settles");
+
+    let pid = session.compositor_pid();
+    let before = heap_snapshot(pid).expect("read initial compositor heap");
+    save_proc_snapshot(pid, &session.dir, "before");
+
+    session
+        .door()
+        .chord(keys::LEFTMETA, keys::UP)
+        .expect("open Overview");
+    {
+        let door = session.door();
+        poll_until(SETTLE, "the Overview transient surface to map", || {
+            door.windows().ok().filter(overview_is_open).map(|_| ())
+        })
+        .expect("Overview opens");
+    }
+    session
+        .screenshot("overview")
+        .expect("capture Overview through screencopy");
+    session.door().tap_key(keys::ESC).expect("close Overview");
+    {
+        let door = session.door();
+        poll_until(SETTLE, "the Overview transient surface to unmap", || {
+            door.windows()
+                .ok()
+                .filter(|world| !overview_is_open(world))
+                .map(|_| ())
+        })
+        .expect("Overview closes");
+    }
+
+    set_theme(&mut session, "graphite");
+    set_theme(&mut session, "nextstep-classic");
+    session.door().barrier().expect("final theme frame settles");
+    session
+        .screenshot("after-transients")
+        .expect("capture the settled desktop");
+    session
+        .door()
+        .barrier()
+        .expect("screenshot resources are released");
+
+    let after = heap_snapshot(pid).expect("read final compositor heap");
+    save_proc_snapshot(pid, &session.dir, "after");
+    let extent_growth = after.extent_bytes.saturating_sub(before.extent_bytes);
+    let size_growth = after.size_bytes.saturating_sub(before.size_bytes);
+    let rss_growth = after.rss_bytes.saturating_sub(before.rss_bytes);
+    eprintln!(
+        "glibc heap sample: before={before:?} after={after:?} growth: extent={extent_growth} size={size_growth} rss={rss_growth}; artifacts: {}",
+        session.dir.display()
+    );
+    assert!(
+        extent_growth <= MAX_HEAP_GROWTH_BYTES
+            && size_growth <= MAX_HEAP_GROWTH_BYTES
+            && rss_growth <= MAX_HEAP_GROWTH_BYTES,
+        "Overview/theme/screenshot workload raised the glibc heap by more than 4 MiB: before={before:?}, after={after:?}; artifacts: {}",
+        session.dir.display()
+    );
+}

--- a/crates/chonkstep-wayland/Cargo.toml
+++ b/crates/chonkstep-wayland/Cargo.toml
@@ -11,9 +11,11 @@ license.workspace = true
 # on purpose — `wm_wayland::run` owns the compositor, the shell, and
 # the event loop, so this binary reaches `chonk-shell`/`wm-core`
 # through `wm-wayland` rather than naming them itself; only the config
-# loader and the compositor crate appear here.
+# loader, the shared startup policy, and the compositor crate appear
+# here.
 [target.'cfg(target_os = "linux")'.dependencies]
 chonk-build-info = { path = "../chonk-build-info" }
+chonk-shell = { path = "../chonk-shell" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wm-config = { path = "../wm-config" }

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -39,7 +39,11 @@ fn main() {
     // Before the subscriber, so `--version` prints one clean line
     // rather than a line preceded by whatever RUST_LOG asked for.
     print_version_and_exit_if_asked();
+    let allocator_policy_pinned = chonk_shell::startup::pin_glibc_large_allocation_policy();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
+    if !allocator_policy_pinned {
+        tracing::warn!("glibc rejected the fixed mmap/trim thresholds; transient buffers may raise the heap high-water mark");
+    }
 
     // A panic anywhere in this process must become an abnormal *process
     // exit* — that is the entire signal the session watchdog

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -18,7 +18,9 @@ use wm_x11::X11Backend;
 use chonk_shell::dockapp::Farewell;
 use chonk_shell::shell::{Shell, ShellOutcome};
 use chonk_shell::spawn;
-use chonk_shell::startup::{ensure_xcursor_size, SessionRequestPoller, SessionState};
+use chonk_shell::startup::{
+    ensure_xcursor_size, pin_glibc_large_allocation_policy, SessionRequestPoller, SessionState,
+};
 use chonk_xsettings::{DesktopAppearance, XSettingsManager};
 
 /// Answers `--version` and `-V` before anything else starts.
@@ -50,7 +52,11 @@ fn main() {
     // Also before `restart_in_place`'s re-exec can ever matter: that
     // path passes no arguments, so a restarted session never sees one.
     print_version_and_exit_if_asked();
+    let allocator_policy_pinned = pin_glibc_large_allocation_policy();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
+    if !allocator_policy_pinned {
+        tracing::warn!("glibc rejected the fixed mmap/trim thresholds; transient buffers may raise the heap high-water mark");
+    }
     tracing::info!(
         version = env!("CARGO_PKG_VERSION"),
         "chonkstep starting \u{2014} a modern window manager in the classic NeXTSTEP style"

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,75 @@
+# Memory behaviour and measurement
+
+chonkstep creates large, short-lived pixel buffers while opening the
+Overview, changing themes, and serving screenshots. On glibc, the
+allocator's adaptive mmap threshold can move one of those buffers into
+the main heap arena after an earlier large allocation. Freeing the
+buffer returns it to the allocator but may leave the process's `[heap]`
+mapping at its high-water mark, making an idle compositor look as if it
+still owns the buffer.
+
+Both the X11 and Wayland session binaries therefore set glibc's
+`M_MMAP_THRESHOLD` to 128 KiB and `M_TRIM_THRESHOLD` to 256 KiB before
+logging or worker-thread startup. Large transient allocations get
+separate mappings that disappear when freed, and excess arena space is
+eligible for trimming without a periodic maintenance wakeup. Other
+libc implementations keep their native allocator policy.
+
+## Reproducing the measurement
+
+Use the same release build, output layout, theme, and client set for
+both snapshots. First identify the compositor process and create an
+artifact directory:
+
+```sh
+pid=$(pidof chonkstep-wayland 2>/dev/null || pidof chonkstep)
+pid=${pid%% *}
+test -n "$pid"
+artifact_dir=$(mktemp -d /tmp/chonkstep-memory.XXXXXX)
+```
+
+Capture the initial mappings and glibc heap details:
+
+```sh
+cp "/proc/$pid/maps" "$artifact_dir/before.maps"
+cp "/proc/$pid/smaps" "$artifact_dir/before.smaps"
+grep '\[heap\]' "$artifact_dir/before.maps"
+awk '
+  $NF == "[heap]" { heap = 1; print; next }
+  heap && /^(Size|Rss|Private_Dirty|Swap):/ { print }
+  heap && /^VmFlags:/ { exit }
+' "$artifact_dir/before.smaps"
+```
+
+Now open and close the Overview, switch to another theme and back, and
+take a screenshot with `grim`. Wait five seconds for the compositor to
+become idle, then capture the same files again:
+
+```sh
+grim "$artifact_dir/screenshot.png"
+sleep 5
+cp "/proc/$pid/maps" "$artifact_dir/after.maps"
+cp "/proc/$pid/smaps" "$artifact_dir/after.smaps"
+grep '\[heap\]' "$artifact_dir/after.maps"
+awk '
+  $NF == "[heap]" { heap = 1; print; next }
+  heap && /^(Size|Rss|Private_Dirty|Swap):/ { print }
+  heap && /^VmFlags:/ { exit }
+' "$artifact_dir/after.smaps"
+```
+
+Compare the `[heap]` mapping range and its `Size`, `Rss`,
+`Private_Dirty`, and `Swap` values. After the transient workload, the
+heap extent and resident size should remain within a few MiB of the
+initial snapshot. `/proc/$pid/smaps_rollup` is useful as an additional
+whole-process snapshot, but it includes mapped libraries, shared
+buffers, graphics allocations, and clients embedded in the shell; it
+is not a measurement of the glibc heap alone.
+
+For the allocator-level regression, the sequence that exposed the
+adaptive-threshold ratchet grew the arena from 132 KiB to 15,496 KiB
+under glibc's defaults. With chonkstep's fixed policy, the same
+allocate, touch, and free sequence left the arena at 132 KiB and only
+68 KiB of additional heap pages resident. The subprocess test in
+`chonk-shell::startup` repeats that allocation shape without changing
+the allocator used by unrelated tests.

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -218,6 +218,7 @@ DESKTOP
   install -Dm644 docs/omarchy-integration.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/appearance.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/control-socket.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/memory.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 README.md CHANGELOG.md -t "$pkgdir/usr/share/doc/$pkgname"
 
   for plugin in omarchy/plugins/*/; do

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -225,6 +225,7 @@ DESKTOP
   install -Dm644 docs/omarchy-integration.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/appearance.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/control-socket.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/memory.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 README.md CHANGELOG.md -t "$pkgdir/usr/share/doc/$pkgname"
 
   # The Omarchy bar widgets that read the control socket, and the guide


### PR DESCRIPTION
Closes #93

## Summary

- pin glibc `M_MMAP_THRESHOLD` at 128 KiB and `M_TRIM_THRESHOLD` at 256 KiB before logging or worker startup in both session binaries
- keep non-glibc targets unchanged and warn if glibc rejects either setting
- add an isolated allocator regression plus a real nested-compositor Overview/theme/screenshot heap check
- document a reproducible `/proc/<pid>/maps` and `smaps` measurement and ship it in both Arch package recipes

## Measurements

A standalone allocate/touch/free reproduction grew the glibc arena from 132 KiB to 15,496 KiB under adaptive defaults. With the fixed policy, the arena stayed at 132 KiB and heap RSS rose only 68 KiB.

The real compositor E2E opened and closed Overview, changed theme to graphite and back, and captured two screenshots. Its `[heap]` mapping grew 460 KiB and heap RSS 464 KiB, with raw maps, smaps, smaps_rollup, and PNG artifacts preserved by the test.

## Validation

- `cargo test -p chonk-shell`
- `cargo test -p chonkstep -p chonkstep-wayland`
- `cargo test --workspace --all-targets`
- strict workspace Clippy gate
- locked private-item rustdoc gate
- `scripts/e2e.sh --headless`
- `git diff --check`
- both Arch PKGBUILDs pass `bash -n`