### PR TITLE
Bridge D-Bus idle inhibition into the compositor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +265,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -673,6 +817,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +857,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -792,6 +983,25 @@ name = "futures-core"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-task"
@@ -927,6 +1137,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "image"
@@ -1208,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1541,6 +1766,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1812,17 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1952,6 +2204,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2248,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -2439,6 +2712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2751,17 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "uuid"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -3029,6 +3324,7 @@ dependencies = [
  "wm-theme",
  "wm-theme-api",
  "x11rb",
+ "zbus",
 ]
 
 [[package]]
@@ -3123,6 +3419,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zeno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,4 +3533,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
 ]

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -39,6 +39,11 @@ chonk-xsettings = { path = "../chonk-xsettings" }
 # and `chonk-xsettings` use so the workspace resolves one copy.
 x11rb = "0.13"
 tracing = "0.1"
+# The session-bus bridge for the two ecosystem idle-inhibition APIs
+# that cannot reach a Wayland compositor directly.  zbus is pure Rust;
+# its blocking facade owns a small off-loop service thread and sends
+# only policy edges into calloop (see `inhibit_bus.rs`).
+zbus = "5.19"
 # Smithay reexports this same version; enabling its Linux signalfd
 # source lets TERM/HUP/INT enter the compositor event loop and receive
 # orderly logout teardown.

--- a/crates/wm-wayland/src/idle.rs
+++ b/crates/wm-wayland/src/idle.rs
@@ -27,6 +27,8 @@
 //! is deliberately edge-oriented telemetry: a busy client that changes
 //! only pixels should produce no lines after the initial map.
 
+use std::sync::Arc;
+
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::IsAlive;
 use smithay::wayland::compositor::get_parent;
@@ -117,8 +119,16 @@ pub(crate) struct Idle {
     /// Surfaces with a live `zwp_idle_inhibitor_v1`. Liveness and
     /// visibility are judged after invalidation in [`refresh`].
     inhibitors: BoundedRefCounts<WlSurface, MAX_IDLE_INHIBITOR_SURFACES>,
-    /// A protocol inhibitor was added or removed. Window/layer/lock
-    /// visibility edges carry their own flag on `WaylandBackend`.
+    /// Session-bus inhibitors have no surface whose visibility can be
+    /// judged. Their service owns the per-caller ledger and publishes
+    /// this bounded aggregate into the compositor loop.
+    external_inhibits: u32,
+    /// Shared with the session-bus service so `GetActive` can answer
+    /// without making its worker thread synchronously call into the
+    /// compositor loop.
+    screen_saver_status: Option<Arc<crate::inhibit_bus::ScreenSaverStatus>>,
+    /// An inhibitor source changed. Window/layer/lock visibility edges
+    /// carry their own flag on `WaylandBackend`.
     inhibitors_dirty: bool,
     rejected_inhibitor_surfaces: u64,
 }
@@ -129,6 +139,8 @@ impl Idle {
             notifier,
             _inhibit: inhibit,
             inhibitors: BoundedRefCounts::new(),
+            external_inhibits: 0,
+            screen_saver_status: None,
             inhibitors_dirty: true,
             rejected_inhibitor_surfaces: 0,
         }
@@ -140,6 +152,23 @@ impl Idle {
 
     pub(crate) fn inhibitor_count(&self) -> usize {
         self.inhibitors.object_count()
+    }
+
+    pub(crate) fn attach_screen_saver_status(&mut self, status: Arc<crate::inhibit_bus::ScreenSaverStatus>) {
+        self.screen_saver_status = Some(status);
+    }
+
+    pub(crate) fn set_external_inhibitors(&mut self, count: u32) {
+        if self.external_inhibits != count {
+            self.external_inhibits = count;
+            self.inhibitors_dirty = true;
+        }
+    }
+
+    pub(crate) fn set_screen_saver_active(&self, active: bool) {
+        if let Some(status) = &self.screen_saver_status {
+            status.set_active(active);
+        }
     }
 }
 
@@ -195,16 +224,23 @@ pub(crate) fn refresh(comp: &mut Compositor) {
         return;
     }
     comp.idle.inhibitors.retain(IsAlive::alive);
-    let inhibited = !comp.wm.backend().locked && {
+    let locked = comp.wm.backend().locked;
+    if let Some(status) = &comp.idle.screen_saver_status {
+        status.set_active(locked);
+    }
+    let inhibited = !locked && {
         let rule_inhibited = comp.wm.rule_idle_inhibited();
         let backend = comp.wm.backend();
-        rule_inhibited || comp.idle.inhibitors.iter().any(|surface| surface_visible(backend, surface))
+        comp.idle.external_inhibits > 0
+            || rule_inhibited
+            || comp.idle.inhibitors.iter().any(|surface| surface_visible(backend, surface))
     };
     comp.idle.notifier.set_is_inhibited(inhibited);
     if idle_log_enabled() {
         tracing::info!(
             inhibited,
             protocol_inhibitors = comp.idle.inhibitors.object_count(),
+            external_inhibitors = comp.idle.external_inhibits,
             "idle policy reconciled"
         );
     }

--- a/crates/wm-wayland/src/inhibit_bus.rs
+++ b/crates/wm-wayland/src/inhibit_bus.rs
@@ -1,0 +1,750 @@
+//! Session-bus idle-inhibition bridges.
+//!
+//! Native Wayland clients inhibit idle with `zwp_idle_inhibit_manager_v1`,
+//! but a large part of the desktop ecosystem instead calls either
+//! `org.freedesktop.ScreenSaver` directly or the Inhibit desktop portal.
+//! This module owns both service names on one small blocking zbus thread.
+//! It keeps caller/request lifetime bookkeeping there and sends only an
+//! absolute inhibitor count (or a user-activity edge) into calloop.  Idle
+//! policy consequently remains single-threaded in [`crate::idle`].
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use calloop::channel::{self, Event, SyncSender};
+use calloop::LoopHandle;
+use zbus::message::Header;
+use zbus::object_server::{ObjectServer, ResponseDispatchNotifier};
+use zbus::zvariant::{OwnedObjectPath, OwnedValue};
+
+use crate::state::Compositor;
+
+const SCREEN_SAVER_NAME: &str = "org.freedesktop.ScreenSaver";
+const SCREEN_SAVER_PATH: &str = "/org/freedesktop/ScreenSaver";
+const PORTAL_NAME: &str = "org.freedesktop.impl.portal.desktop.chonkstep";
+const PORTAL_PATH: &str = "/org/freedesktop/portal/desktop";
+const PORTAL_IDLE_FLAG: u32 = 8;
+
+/// Bounds both the compositor count and the dynamic portal objects a
+/// hostile bus peer can make the service retain.
+const MAX_EXTERNAL_REQUESTS: usize = 4096;
+
+#[derive(Debug)]
+enum BusEvent {
+    Refresh,
+}
+
+/// The one bit of compositor state a synchronous D-Bus getter needs.
+/// Lock/unlock edges publish it from `idle::refresh`; no policy travels
+/// in the other direction through this atomic.
+#[derive(Debug, Default)]
+pub(crate) struct ScreenSaverStatus {
+    active: AtomicBool,
+    external_inhibitors: AtomicU32,
+    activity_pending: AtomicBool,
+}
+
+impl ScreenSaverStatus {
+    pub(crate) fn set_active(&self, active: bool) {
+        self.active.store(active, Ordering::Release);
+    }
+
+    fn active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
+
+    fn set_external_inhibitors(&self, count: u32) {
+        self.external_inhibitors.store(count, Ordering::Release);
+    }
+
+    fn external_inhibitors(&self) -> u32 {
+        self.external_inhibitors.load(Ordering::Acquire)
+    }
+
+    fn request_activity(&self) {
+        self.activity_pending.store(true, Ordering::Release);
+    }
+
+    fn take_activity(&self) -> bool {
+        self.activity_pending.swap(false, Ordering::AcqRel)
+    }
+}
+
+/// Register the compositor-side channel first, then start the service.
+/// A missing session bus is not fatal to a nested/development compositor:
+/// native Wayland inhibition remains available and the thread reports the
+/// unavailable compatibility bridge in the log.
+pub(crate) fn init(
+    loop_handle: &LoopHandle<'static, Compositor>,
+) -> Option<Arc<ScreenSaverStatus>> {
+    let status = Arc::new(ScreenSaverStatus::default());
+    let event_status = Arc::clone(&status);
+    // A single queued wake is enough: the atomics hold the newest
+    // aggregate and activity is an idempotent timer reset. This keeps
+    // D-Bus churn from growing an unbounded event queue.
+    let (sender, receiver) = channel::sync_channel(1);
+    if let Err(error) = loop_handle.insert_source(receiver, move |event, _, comp| match event {
+        Event::Msg(BusEvent::Refresh) => {
+            comp.idle
+                .set_external_inhibitors(event_status.external_inhibitors());
+            if event_status.take_activity() {
+                crate::idle::note_activity(comp);
+            }
+        }
+        Event::Closed => tracing::debug!("session-bus inhibit bridge stopped"),
+    }) {
+        tracing::warn!(?error, "could not register session-bus inhibit events");
+        return None;
+    }
+
+    let thread_status = Arc::clone(&status);
+    if let Err(error) = std::thread::Builder::new()
+        .name("chonkstep-inhibit-bus".into())
+        .spawn(move || {
+            if let Err(error) = serve(sender, thread_status) {
+                tracing::warn!(?error, "session-bus idle inhibition unavailable");
+            }
+        })
+    {
+        tracing::warn!(?error, "could not start session-bus inhibit service");
+        return None;
+    }
+
+    Some(status)
+}
+
+fn serve(sender: SyncSender<BusEvent>, status: Arc<ScreenSaverStatus>) -> zbus::Result<()> {
+    let shared = Shared::new(sender, status);
+    let connection = zbus::blocking::connection::Builder::session()?
+        .serve_at(
+            SCREEN_SAVER_PATH,
+            ScreenSaver {
+                shared: shared.clone(),
+            },
+        )?
+        .serve_at(
+            PORTAL_PATH,
+            PortalInhibit {
+                shared: shared.clone(),
+            },
+        )?
+        .build()?;
+
+    // Subscribe before publishing either service name.  Otherwise a
+    // client could acquire and crash in the small gap between name
+    // publication and the NameOwnerChanged match becoming active.
+    let proxy = zbus::blocking::fdo::DBusProxy::new(&connection)?;
+    let changes = proxy.receive_name_owner_changed()?;
+    let name_flags = zbus::fdo::RequestNameFlags::DoNotQueue.into();
+    let screen_saver_owned = matches!(
+        connection.request_name_with_flags(SCREEN_SAVER_NAME, name_flags)?,
+        zbus::fdo::RequestNameReply::PrimaryOwner | zbus::fdo::RequestNameReply::AlreadyOwner
+    );
+    let portal_owned = matches!(
+        connection.request_name_with_flags(PORTAL_NAME, name_flags)?,
+        zbus::fdo::RequestNameReply::PrimaryOwner | zbus::fdo::RequestNameReply::AlreadyOwner
+    );
+
+    tracing::info!(
+        screen_saver = SCREEN_SAVER_NAME,
+        portal = PORTAL_NAME,
+        screen_saver_owned,
+        portal_owned,
+        "session-bus idle inhibition ready"
+    );
+
+    // Every held item records the unique sender name that created it.
+    // The bus emits this edge when that connection vanishes, including
+    // crashes; release all its items instead of leaving the session awake.
+    for change in changes {
+        let args = match change.args() {
+            Ok(args) => args,
+            Err(error) => {
+                tracing::warn!(?error, "ignored malformed NameOwnerChanged signal");
+                continue;
+            }
+        };
+        if args.new_owner().as_ref().is_some() {
+            continue;
+        }
+        let removed_paths = shared.release_peer(args.name().as_str());
+        for path in removed_paths {
+            if let Err(error) = connection.object_server().remove::<PortalRequest, _>(&path) {
+                tracing::debug!(?error, request = %path, "portal request already removed");
+            }
+        }
+    }
+    // The bus itself went away. Every peer and request went with it;
+    // publish zero before the service thread exits so a dead bus cannot
+    // leave the compositor permanently inhibited.
+    shared.release_all();
+    Ok(())
+}
+
+#[derive(Clone)]
+struct Shared {
+    inner: Arc<SharedInner>,
+}
+
+struct SharedInner {
+    sender: SyncSender<BusEvent>,
+    status: Arc<ScreenSaverStatus>,
+    ledger: Mutex<Ledger>,
+}
+
+impl Shared {
+    fn new(sender: SyncSender<BusEvent>, status: Arc<ScreenSaverStatus>) -> Self {
+        Self {
+            inner: Arc::new(SharedInner {
+                sender,
+                status,
+                ledger: Mutex::new(Ledger::default()),
+            }),
+        }
+    }
+
+    fn ledger(&self) -> MutexGuard<'_, Ledger> {
+        self.inner
+            .ledger
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn publish_count(&self, ledger: &Ledger) {
+        self.inner
+            .status
+            .set_external_inhibitors(ledger.external_count());
+        self.wake_compositor();
+    }
+
+    fn wake_compositor(&self) {
+        // Full means an equivalent refresh is already queued; its
+        // callback reads the newest atomic values above.
+        let _ = self.inner.sender.try_send(BusEvent::Refresh);
+    }
+
+    fn acquire_direct(&self, peer: String) -> zbus::fdo::Result<u32> {
+        let mut ledger = self.ledger();
+        let cookie = ledger.acquire_direct(peer)?;
+        self.publish_count(&ledger);
+        Ok(cookie)
+    }
+
+    fn release_direct(&self, peer: &str, cookie: u32) -> zbus::fdo::Result<()> {
+        let mut ledger = self.ledger();
+        ledger.release_direct(peer, cookie)?;
+        self.publish_count(&ledger);
+        Ok(())
+    }
+
+    fn reserve_portal(
+        &self,
+        path: OwnedObjectPath,
+        peer: String,
+        idle: bool,
+    ) -> zbus::fdo::Result<()> {
+        let mut ledger = self.ledger();
+        ledger.reserve_portal(path, peer, idle)?;
+        self.publish_count(&ledger);
+        Ok(())
+    }
+
+    fn release_portal(&self, peer: &str, path: &OwnedObjectPath) -> zbus::fdo::Result<()> {
+        let mut ledger = self.ledger();
+        ledger.release_portal(peer, path)?;
+        self.publish_count(&ledger);
+        Ok(())
+    }
+
+    fn roll_back_portal(&self, path: &OwnedObjectPath) {
+        let mut ledger = self.ledger();
+        if ledger.portal.remove(path).is_some() {
+            self.publish_count(&ledger);
+        }
+    }
+
+    fn portal_is_reserved(&self, path: &OwnedObjectPath) -> bool {
+        self.ledger().portal.contains_key(path)
+    }
+
+    fn release_peer(&self, peer: &str) -> Vec<OwnedObjectPath> {
+        let mut ledger = self.ledger();
+        let before = ledger.request_count();
+        let paths = ledger.release_peer(peer);
+        if ledger.request_count() != before {
+            self.publish_count(&ledger);
+        }
+        paths
+    }
+
+    fn release_all(&self) {
+        let mut ledger = self.ledger();
+        if ledger.request_count() == 0 {
+            return;
+        }
+        ledger.direct.clear();
+        ledger.portal.clear();
+        self.publish_count(&ledger);
+    }
+
+    fn note_activity(&self) {
+        self.inner.status.request_activity();
+        self.wake_compositor();
+    }
+}
+
+#[derive(Debug)]
+struct PortalEntry {
+    peer: String,
+    idle: bool,
+}
+
+#[derive(Debug, Default)]
+struct Ledger {
+    next_cookie: u32,
+    direct: HashMap<u32, String>,
+    portal: HashMap<OwnedObjectPath, PortalEntry>,
+}
+
+impl Ledger {
+    fn request_count(&self) -> usize {
+        self.direct.len().saturating_add(self.portal.len())
+    }
+
+    fn external_count(&self) -> u32 {
+        let count = self
+            .direct
+            .len()
+            .saturating_add(self.portal.values().filter(|entry| entry.idle).count());
+        u32::try_from(count).unwrap_or(u32::MAX)
+    }
+
+    fn acquire_direct(&mut self, peer: String) -> zbus::fdo::Result<u32> {
+        if self.request_count() >= MAX_EXTERNAL_REQUESTS {
+            return Err(zbus::fdo::Error::LimitsExceeded(
+                "too many live ChonkStep idle-inhibit requests".into(),
+            ));
+        }
+        loop {
+            self.next_cookie = self.next_cookie.wrapping_add(1);
+            if self.next_cookie != 0 && !self.direct.contains_key(&self.next_cookie) {
+                self.direct.insert(self.next_cookie, peer);
+                return Ok(self.next_cookie);
+            }
+        }
+    }
+
+    fn release_direct(&mut self, peer: &str, cookie: u32) -> zbus::fdo::Result<()> {
+        match self.direct.get(&cookie) {
+            Some(owner) if owner == peer => {
+                self.direct.remove(&cookie);
+                Ok(())
+            }
+            Some(_) => Err(zbus::fdo::Error::AccessDenied(
+                "idle-inhibit cookie belongs to another D-Bus peer".into(),
+            )),
+            None => Err(zbus::fdo::Error::InvalidArgs(
+                "unknown idle-inhibit cookie".into(),
+            )),
+        }
+    }
+
+    fn reserve_portal(
+        &mut self,
+        path: OwnedObjectPath,
+        peer: String,
+        idle: bool,
+    ) -> zbus::fdo::Result<()> {
+        if self.request_count() >= MAX_EXTERNAL_REQUESTS {
+            return Err(zbus::fdo::Error::LimitsExceeded(
+                "too many live ChonkStep idle-inhibit requests".into(),
+            ));
+        }
+        if self.portal.contains_key(&path) {
+            return Err(zbus::fdo::Error::InvalidArgs(
+                "duplicate portal request path".into(),
+            ));
+        }
+        self.portal.insert(path, PortalEntry { peer, idle });
+        Ok(())
+    }
+
+    fn release_portal(&mut self, peer: &str, path: &OwnedObjectPath) -> zbus::fdo::Result<()> {
+        match self.portal.get(path) {
+            Some(entry) if entry.peer == peer => {
+                self.portal.remove(path);
+                Ok(())
+            }
+            Some(_) => Err(zbus::fdo::Error::AccessDenied(
+                "portal request belongs to another D-Bus peer".into(),
+            )),
+            // Close is deliberately idempotent: a frontend may close a
+            // request while its own disconnect cleanup is already in flight.
+            None => Ok(()),
+        }
+    }
+
+    fn release_peer(&mut self, peer: &str) -> Vec<OwnedObjectPath> {
+        self.direct.retain(|_, owner| owner != peer);
+        let removed = self
+            .portal
+            .iter()
+            .filter(|(_, entry)| entry.peer == peer)
+            .map(|(path, _)| path.clone())
+            .collect::<Vec<_>>();
+        self.portal.retain(|_, entry| entry.peer != peer);
+        removed
+    }
+}
+
+fn sender(header: &Header<'_>) -> zbus::fdo::Result<String> {
+    header
+        .sender()
+        .map(ToString::to_string)
+        .ok_or_else(|| zbus::fdo::Error::Failed("D-Bus call has no sender identity".into()))
+}
+
+struct ScreenSaver {
+    shared: Shared,
+}
+
+#[zbus::interface(name = "org.freedesktop.ScreenSaver")]
+impl ScreenSaver {
+    fn inhibit(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+        _application_name: &str,
+        _reason_for_inhibit: &str,
+    ) -> zbus::fdo::Result<u32> {
+        self.shared.acquire_direct(sender(&header)?)
+    }
+
+    #[zbus(name = "UnInhibit")]
+    fn un_inhibit(&self, #[zbus(header)] header: Header<'_>, cookie: u32) -> zbus::fdo::Result<()> {
+        self.shared.release_direct(&sender(&header)?, cookie)
+    }
+
+    fn get_active(&self) -> bool {
+        self.shared.inner.status.active()
+    }
+
+    fn simulate_user_activity(&self) {
+        self.shared.note_activity();
+    }
+}
+
+struct PortalInhibit {
+    shared: Shared,
+}
+
+#[zbus::interface(name = "org.freedesktop.impl.portal.Inhibit")]
+impl PortalInhibit {
+    #[allow(clippy::too_many_arguments)] // The portal ABI fixes all seven input/context arguments.
+    async fn inhibit(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+        #[zbus(object_server)] server: &ObjectServer,
+        handle: OwnedObjectPath,
+        _app_id: &str,
+        _window: &str,
+        flags: u32,
+        _options: HashMap<String, OwnedValue>,
+    ) -> zbus::fdo::Result<()> {
+        let peer = sender(&header)?;
+        self.shared
+            .reserve_portal(handle.clone(), peer.clone(), flags & PORTAL_IDLE_FLAG != 0)?;
+        let added = match server
+            .at(
+                handle.clone(),
+                PortalRequest {
+                    path: handle.clone(),
+                    shared: self.shared.clone(),
+                },
+            )
+            .await
+        {
+            Ok(added) => added,
+            Err(error) => {
+                self.shared.roll_back_portal(&handle);
+                return Err(zbus::fdo::Error::Failed(error.to_string()));
+            }
+        };
+        if !added {
+            self.shared.roll_back_portal(&handle);
+            return Err(zbus::fdo::Error::InvalidArgs(
+                "portal request path is already exported".into(),
+            ));
+        }
+        // Peer-loss cleanup can race this asynchronous object export.
+        // If it already removed the reservation, do not strand the new
+        // request object (or claim an inhibit that no caller owns).
+        if !self.shared.portal_is_reserved(&handle) {
+            let _ = server.remove::<PortalRequest, _>(&handle).await;
+            return Err(zbus::fdo::Error::Failed(
+                "portal requester disconnected while inhibition was being created".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// ChonkStep has no login-manager state machine to monitor.  Keep
+    /// the method in introspection and answer with a clean cancellation
+    /// instead of advertising a method that disappears at call time.
+    fn create_monitor(
+        &self,
+        _handle: OwnedObjectPath,
+        _session_handle: OwnedObjectPath,
+        _app_id: &str,
+        _window: &str,
+    ) -> u32 {
+        2
+    }
+
+    fn query_end_response(&self, _session_handle: OwnedObjectPath) {}
+}
+
+struct PortalRequest {
+    path: OwnedObjectPath,
+    shared: Shared,
+}
+
+#[zbus::interface(name = "org.freedesktop.impl.portal.Request")]
+impl PortalRequest {
+    fn close(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+        #[zbus(connection)] connection: &zbus::Connection,
+    ) -> zbus::fdo::Result<ResponseDispatchNotifier<()>> {
+        self.shared.release_portal(&sender(&header)?, &self.path)?;
+
+        // Removing the interface from inside its own method would wait
+        // on the method's live interface reference.  The notifier fires
+        // after the empty reply has left; remove it from a zbus task then.
+        let (response, sent) = ResponseDispatchNotifier::new(());
+        let connection = connection.clone();
+        let task_connection = connection.clone();
+        let path = self.path.clone();
+        connection
+            .executor()
+            .spawn(
+                async move {
+                    sent.await;
+                    let _ = task_connection
+                        .object_server()
+                        .remove::<PortalRequest, _>(&path)
+                        .await;
+                },
+                "remove closed ChonkStep inhibit request",
+            )
+            .detach();
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn path(value: &str) -> OwnedObjectPath {
+        OwnedObjectPath::try_from(value).unwrap()
+    }
+
+    #[test]
+    fn ledger_counts_only_idle_portal_requests() {
+        let mut ledger = Ledger::default();
+        assert_eq!(ledger.acquire_direct(":1.1".into()).unwrap(), 1);
+        ledger
+            .reserve_portal(path("/request/idle"), ":1.2".into(), true)
+            .unwrap();
+        ledger
+            .reserve_portal(path("/request/logout"), ":1.2".into(), false)
+            .unwrap();
+        assert_eq!(ledger.external_count(), 2);
+    }
+
+    #[test]
+    fn cookies_are_owned_and_peer_loss_releases_every_kind() {
+        let mut ledger = Ledger::default();
+        let mine = ledger.acquire_direct(":1.7".into()).unwrap();
+        let theirs = ledger.acquire_direct(":1.8".into()).unwrap();
+        ledger
+            .reserve_portal(path("/request/mine"), ":1.7".into(), true)
+            .unwrap();
+
+        assert!(matches!(
+            ledger.release_direct(":1.8", mine),
+            Err(zbus::fdo::Error::AccessDenied(_))
+        ));
+        assert_eq!(ledger.release_peer(":1.7"), vec![path("/request/mine")]);
+        assert_eq!(ledger.external_count(), 1);
+        ledger.release_direct(":1.8", theirs).unwrap();
+        assert_eq!(ledger.external_count(), 0);
+    }
+
+    #[test]
+    fn portal_close_is_idempotent_but_not_cross_peer() {
+        let mut ledger = Ledger::default();
+        let request = path("/request/one");
+        ledger
+            .reserve_portal(request.clone(), ":1.4".into(), true)
+            .unwrap();
+        assert!(matches!(
+            ledger.release_portal(":1.5", &request),
+            Err(zbus::fdo::Error::AccessDenied(_))
+        ));
+        ledger.release_portal(":1.4", &request).unwrap();
+        ledger.release_portal(":1.4", &request).unwrap();
+        assert_eq!(ledger.external_count(), 0);
+    }
+
+    #[test]
+    fn a_queued_wake_coalesces_to_the_latest_count() {
+        let (sender, receiver) = channel::sync_channel(1);
+        let status = Arc::new(ScreenSaverStatus::default());
+        let shared = Shared::new(sender, Arc::clone(&status));
+        shared.acquire_direct(":1.20".into()).unwrap();
+        shared.acquire_direct(":1.21".into()).unwrap();
+
+        assert!(matches!(receiver.try_recv(), Ok(BusEvent::Refresh)));
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+        assert_eq!(status.external_inhibitors(), 2);
+    }
+
+    fn next_event(receiver: &channel::Channel<BusEvent>) -> BusEvent {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        loop {
+            match receiver.try_recv() {
+                Ok(event) => return event,
+                Err(std::sync::mpsc::TryRecvError::Empty) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("timed out waiting for inhibit-bus event: {error}"),
+            }
+        }
+    }
+
+    /// Run the real zbus object server under a private bus so this test
+    /// neither collides with nor replaces the developer's desktop
+    /// ScreenSaver service. The child marker prevents recursive buses.
+    #[test]
+    #[allow(clippy::disallowed_methods)] // This blocks only the unit-test harness, never the compositor thread.
+    fn dbus_contract_round_trip() {
+        const CHILD: &str = "CHONKSTEP_INHIBIT_BUS_TEST_CHILD";
+        const TEST: &str = "inhibit_bus::tests::dbus_contract_round_trip";
+        if std::env::var_os(CHILD).is_none() {
+            let output = std::process::Command::new("dbus-run-session")
+                .arg("--")
+                .arg(std::env::current_exe().unwrap())
+                .args([TEST, "--exact", "--nocapture"])
+                .env(CHILD, "1")
+                .output()
+                .expect("dbus-run-session must be installed for the Wayland session");
+            assert!(
+                output.status.success(),
+                "private-bus child test failed ({status}):\nstdout:\n{stdout}\nstderr:\n{stderr}",
+                status = output.status,
+                stdout = String::from_utf8_lossy(&output.stdout),
+                stderr = String::from_utf8_lossy(&output.stderr),
+            );
+            return;
+        }
+
+        let (sender, receiver) = channel::sync_channel(1);
+        let status = Arc::new(ScreenSaverStatus::default());
+        let service_status = Arc::clone(&status);
+        std::thread::spawn(move || serve(sender, service_status).unwrap());
+
+        let client = zbus::blocking::Connection::session().unwrap();
+        let dbus = zbus::blocking::fdo::DBusProxy::new(&client).unwrap();
+        let name = zbus::names::BusName::try_from(SCREEN_SAVER_NAME).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        while !dbus.name_has_owner(name.clone()).unwrap() {
+            assert!(
+                Instant::now() < deadline,
+                "ScreenSaver service name was not acquired"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let screen_saver = zbus::blocking::Proxy::new(
+            &client,
+            SCREEN_SAVER_NAME,
+            SCREEN_SAVER_PATH,
+            SCREEN_SAVER_NAME,
+        )
+        .unwrap();
+        let cookie: u32 = screen_saver
+            .call("Inhibit", &("test", "playing video"))
+            .unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 1);
+        let active: bool = screen_saver.call("GetActive", &()).unwrap();
+        assert!(!active);
+        status.set_active(true);
+        let active: bool = screen_saver.call("GetActive", &()).unwrap();
+        assert!(active);
+        let _: () = screen_saver.call("SimulateUserActivity", &()).unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert!(status.take_activity());
+        let _: () = screen_saver.call("UnInhibit", &cookie).unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 0);
+
+        let portal = zbus::blocking::Proxy::new(
+            &client,
+            PORTAL_NAME,
+            PORTAL_PATH,
+            "org.freedesktop.impl.portal.Inhibit",
+        )
+        .unwrap();
+        let request = path("/org/freedesktop/portal/desktop/request/1_0/chonkstep_test");
+        let options = HashMap::<String, OwnedValue>::new();
+        let _: () = portal
+            .call(
+                "Inhibit",
+                &(
+                    request.clone(),
+                    "org.example.Test",
+                    "",
+                    PORTAL_IDLE_FLAG,
+                    options,
+                ),
+            )
+            .unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 1);
+        let request_proxy = zbus::blocking::Proxy::new(
+            &client,
+            PORTAL_NAME,
+            request.as_str(),
+            "org.freedesktop.impl.portal.Request",
+        )
+        .unwrap();
+        let _: () = request_proxy.call("Close", &()).unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 0);
+
+        // The connection owns this cookie and then disappears without
+        // UnInhibit. NameOwnerChanged must return the aggregate to zero.
+        let abandoned = zbus::blocking::Connection::session().unwrap();
+        let abandoned_proxy = zbus::blocking::Proxy::new(
+            &abandoned,
+            SCREEN_SAVER_NAME,
+            SCREEN_SAVER_PATH,
+            SCREEN_SAVER_NAME,
+        )
+        .unwrap();
+        let _cookie: u32 = abandoned_proxy.call("Inhibit", &("test", "crash")).unwrap();
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 1);
+        drop(abandoned_proxy);
+        drop(abandoned);
+        assert!(matches!(next_event(&receiver), BusEvent::Refresh));
+        assert_eq!(status.external_inhibitors(), 0);
+    }
+}

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -41,6 +41,7 @@ mod hyprland_ipc;
 // the honest nested answer.
 mod gamma;
 mod idle;
+mod inhibit_bus;
 mod input;
 mod layers;
 mod lock;

--- a/crates/wm-wayland/src/lock.rs
+++ b/crates/wm-wayland/src/lock.rs
@@ -279,6 +279,7 @@ impl UnlockRequest {
 fn enter_lock_domain(comp: &mut Compositor) {
     comp.mark_hyprland_state_dirty();
     comp.session_lock.mark_dirty();
+    comp.idle.set_screen_saver_active(true);
     let backend = comp.wm.backend_mut();
     backend.locked = true;
     backend.mark_idle_policy_dirty();
@@ -351,6 +352,7 @@ impl SessionLockHandler for Compositor {
     fn unlock(&mut self) {
         tracing::info!("session unlocked");
         self.mark_hyprland_state_dirty();
+        self.idle.set_screen_saver_active(false);
         self.session_lock.machine.unlocked();
         self.session_lock.pending_ack = None;
         self.session_lock.holder = None;

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -3230,10 +3230,13 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         Compositor,
         _,
     >(&display_handle, |_| true));
-    let idle = crate::idle::Idle::new(
+    let mut idle = crate::idle::Idle::new(
         smithay::wayland::idle_notify::IdleNotifierState::<Compositor>::new(&display_handle, loop_handle.clone()),
         smithay::wayland::idle_inhibit::IdleInhibitManagerState::new::<Compositor>(&display_handle),
     );
+    if let Some(status) = crate::inhibit_bus::init(&loop_handle) {
+        idle.attach_screen_saver_status(status);
+    }
     tracing::info!("layer-shell, session-lock and idle-notify advertised");
     // Same timing rule again, plus one of its own: the seat this is
     // handed must already carry a keyboard, because smithay's handler

--- a/docs/bluetooth.md
+++ b/docs/bluetooth.md
@@ -307,10 +307,9 @@ The exception is also unavoidable. **Pairing requires an agent**: BlueZ
 will not pair without a process registering an `org.bluez.Agent1` object
 it can call back into to ask "is the passkey the same on both screens?".
 Registering a D-Bus *object* means serving a bus name, and `busctl` — a
-client tool — cannot do it. The alternatives were to implement `Agent1`
-against a D-Bus library (a dependency this workspace does not have and
-would acquire for one dialog) or to use the agent BlueZ already ships in
-its own control program. This takes the second.
+client tool — cannot do it. The alternatives were to implement and own a
+second D-Bus service lifecycle for one dialog or to use the agent BlueZ
+already ships in its own control program. This takes the second.
 
 ### The agent mode: `DisplayYesNo`
 

--- a/docs/idle-inhibition.md
+++ b/docs/idle-inhibition.md
@@ -1,0 +1,30 @@
+# Idle inhibition
+
+ChonkStep accepts all three idle-inhibition routes used by desktop
+applications:
+
+- `zwp_idle_inhibit_manager_v1` for native Wayland clients;
+- `org.freedesktop.ScreenSaver.Inhibit` on the session bus;
+- `org.freedesktop.portal.Inhibit`, routed by
+  `packaging/portal/chonkstep-portals.conf` to the compositor's
+  `org.freedesktop.impl.portal.Inhibit` backend.
+
+The D-Bus service runs off the compositor thread. It records the unique
+bus peer behind every ScreenSaver cookie and portal request, then sends an
+absolute external-inhibitor count into the compositor event loop. A normal
+`UnInhibit`, a portal request's `Close`, and `NameOwnerChanged` when a peer
+crashes all release the corresponding count. Portal flags other than Idle
+are accepted for request-lifecycle compatibility but do not affect the idle
+timer.
+
+External inhibition is subject to the same lock boundary as native
+Wayland inhibition and window rules. Once the session is locked it cannot
+be kept awake by an inhibitor held behind the lock screen. The
+`org.freedesktop.ScreenSaver.GetActive` reply follows that lock state, and
+`SimulateUserActivity` enters the same idle notifier path as real input.
+
+Set `CHONKSTEP_IDLE_LOG=1` before starting the session to log reconciliations.
+Each line reports `protocol_inhibitors` and `external_inhibitors` separately.
+At startup, the line `session-bus idle inhibition ready` reports whether the
+compositor acquired both service names. A missing session bus is non-fatal
+and leaves the native Wayland mechanism available.

--- a/docs/screen-sharing.md
+++ b/docs/screen-sharing.md
@@ -82,9 +82,9 @@ already has the KMS node.
 - **xdg-desktop-portal** is the D-Bus frontend, activated on demand
   into the systemd user session.
 - **xdg-desktop-portal-wlr** is the ScreenCast/Screenshot backend.
-- **xdg-desktop-portal-gtk** answers everything else — the file
-  chooser a browser opens for uploads, notifications, settings — so
-  the desktop is not left portal-less outside of capture.
+- **xdg-desktop-portal-gtk** answers the toolkit portals — the file
+  chooser a browser opens for uploads, notifications, settings — while
+  ChonkStep itself answers Inhibit because it owns the idle timers.
 
 ## How the pieces find each other
 
@@ -102,6 +102,7 @@ managers — both spellings installed by `scripts/install.sh`), and
 
     [preferred]
     default=gtk
+    org.freedesktop.impl.portal.Inhibit=chonkstep
     org.freedesktop.impl.portal.ScreenCast=wlr
     org.freedesktop.impl.portal.Screenshot=wlr
 
@@ -126,8 +127,8 @@ crash recovery re-execs the compositor):
         WAYLAND_DISPLAY=<socket> XDG_CURRENT_DESKTOP=chonkstep \
         XDG_SESSION_TYPE=wayland
 
-Nothing in the compositor itself touches D-Bus; the session script
-owns this, as it owns the rest of the session environment.
+The compositor's D-Bus use is deliberately limited to its idle-inhibit
+service. The session script still owns activation-environment publishing.
 
 ## Portal interface status
 
@@ -137,6 +138,7 @@ Checked against the frontend with the chonkstep config active:
 | --- | --- | --- |
 | ScreenCast | wlr | **Works** — verified end to end; node id returned, frames flowing, pixels correct |
 | Screenshot | wlr | **Works** — `Screenshot()` returned a real PNG of the session (xdg-desktop-portal-wlr shells out to `grim`, which is also installed) |
+| Inhibit | chonkstep | Idle requests feed the compositor's own timers and are released on request close or caller disconnect |
 | FileChooser, Notification, Settings, and the rest | gtk | **Backend activates and answers** (D-Bus ping + interface version 4 confirmed); the dialogs themselves are ordinary windows and were not driven headlessly |
 | Window/toplevel capture (`types=2` in SelectSources) | wlr | **Not available** — xdg-desktop-portal-wlr only captures outputs (`AvailableSourceTypes=1`); this is an upstream backend limitation, not a chonkstep gap. "Share entire screen" works; "share a single window" is not offered |
 

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -198,10 +198,12 @@ DESKTOP
   install -Dm755 scripts/omarchy-remove-desktop-chonkstep \
     "$pkgdir/usr/bin/omarchy-remove-desktop-chonkstep"
 
-  # Portal backend map: ScreenCast/Screenshot to xdg-desktop-portal-wlr
-  # (chonkstep-wayland advertises zwlr_screencopy), the rest to the GTK
-  # backend. Matched by XDG_CURRENT_DESKTOP=chonkstep, which the session
-  # script exports and the .desktop entry's DesktopNames sets.
+  # Portal backend declaration and map: Inhibit to chonkstep-wayland,
+  # ScreenCast/Screenshot to xdg-desktop-portal-wlr, the rest to GTK.
+  # Matched by XDG_CURRENT_DESKTOP=chonkstep, which the session script
+  # exports and the .desktop entry's DesktopNames sets.
+  install -Dm644 packaging/portal/chonkstep.portal \
+    "$pkgdir/usr/share/xdg-desktop-portal/portals/chonkstep.portal"
   install -Dm644 packaging/portal/chonkstep-portals.conf \
     "$pkgdir/usr/share/xdg-desktop-portal/chonkstep-portals.conf"
 
@@ -212,6 +214,7 @@ DESKTOP
   install -Dm644 docs/dockapp-protocol.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/xwayland-compatibility.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/screen-sharing.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/idle-inhibition.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/night-light.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/hyprland-ipc.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/hyprland-config.md -t "$pkgdir/usr/share/doc/$pkgname"

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -202,10 +202,12 @@ DESKTOP
   install -Dm755 scripts/omarchy-remove-desktop-chonkstep \
     "$pkgdir/usr/bin/omarchy-remove-desktop-chonkstep"
 
-  # Portal backend map: ScreenCast/Screenshot to xdg-desktop-portal-wlr
-  # (chonkstep-wayland advertises zwlr_screencopy), the rest to the GTK
-  # backend. Matched by XDG_CURRENT_DESKTOP=chonkstep, which the session
-  # script exports and the .desktop entry's DesktopNames sets.
+  # Portal backend declaration and map: Inhibit to chonkstep-wayland,
+  # ScreenCast/Screenshot to xdg-desktop-portal-wlr, the rest to GTK.
+  # Matched by XDG_CURRENT_DESKTOP=chonkstep, which the session script
+  # exports and the .desktop entry's DesktopNames sets.
+  install -Dm644 packaging/portal/chonkstep.portal \
+    "$pkgdir/usr/share/xdg-desktop-portal/portals/chonkstep.portal"
   install -Dm644 packaging/portal/chonkstep-portals.conf \
     "$pkgdir/usr/share/xdg-desktop-portal/chonkstep-portals.conf"
 
@@ -219,6 +221,7 @@ DESKTOP
   install -Dm644 docs/dockapp-protocol.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/xwayland-compatibility.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/screen-sharing.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/idle-inhibition.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/night-light.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/hyprland-ipc.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/hyprland-config.md -t "$pkgdir/usr/share/doc/$pkgname"

--- a/packaging/portal/chonkstep-portals.conf
+++ b/packaging/portal/chonkstep-portals.conf
@@ -11,8 +11,11 @@
 # wlr-protocols (zwlr_screencopy_manager_v1, xdg-output and linux-dmabuf),
 # all of which chonkstep-wayland advertises, so screen sharing in a browser
 # call and portal screenshots work even though the compositor is not
-# wlroots. Everything else falls back to the toolkit-generic GTK backend.
+# wlroots. Inhibit goes to ChonkStep itself because only the compositor
+# owns its idle timers; everything else falls back to the toolkit-generic
+# GTK backend.
 [preferred]
 default=gtk
+org.freedesktop.impl.portal.Inhibit=chonkstep
 org.freedesktop.impl.portal.ScreenCast=wlr
 org.freedesktop.impl.portal.Screenshot=wlr

--- a/packaging/portal/chonkstep.portal
+++ b/packaging/portal/chonkstep.portal
@@ -1,0 +1,4 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.chonkstep
+Interfaces=org.freedesktop.impl.portal.Inhibit;
+UseIn=chonkstep

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,9 +21,10 @@
 #      (scripts/wayland-session.sh) - so a login manager offers
 #      chonkstep in either flavour, and a machine with no login manager
 #      can start either one from a TTY.
-#   4. Installs the portal backend map,
+#   4. Installs the portal backend declaration and map,
 #      /usr/share/xdg-desktop-portal/chonkstep-portals.conf, which
-#      routes screen sharing to xdg-desktop-portal-wlr.
+#      route idle inhibition to the compositor and screen sharing to
+#      xdg-desktop-portal-wlr.
 #   5. Seeds ~/.config/chonkstep/config.toml from the fully commented
 #      example, only if there is none.
 #   6. Links the two user-facing tools into ~/.local/bin: chonk-get (the
@@ -115,8 +116,9 @@ echo "Installing dependencies (sudo)..."
 # talks to. xdg-desktop-portal is the D-Bus frontend, xdg-desktop-
 # portal-wlr the ScreenCast/Screenshot backend that speaks the
 # zwlr_screencopy protocol chonkstep-wayland advertises, xdg-desktop-
-# portal-gtk the fallback for everything else (file chooser and
-# friends), and pipewire carries the frames from backend to browser.
+# portal-gtk the fallback for everything except idle inhibition (which
+# the compositor answers), and pipewire carries the frames from backend
+# to browser.
 # See docs/screen-sharing.md.
 # JetBrains Mono Nerd comes in two conflicting packages and stock
 # Omarchy ships the -basic variant; demanding the full one makes
@@ -256,10 +258,13 @@ fi
 sudo rm -f /etc/sddm.conf.d/20-chonkstep-theme.conf
 echo "Installed chonkstep's SDDM integration. Undo: sudo rm -f /etc/sddm.conf.d/zz-chonkstep-{theme,autologin}.conf /etc/systemd/system/sddm.service.d/90-chonkstep-resilience.conf"
 
-# The portal backend map: ScreenCast/Screenshot to the wlr backend
-# (screen sharing — see docs/screen-sharing.md), the rest to GTK. The
-# file is matched by the XDG_CURRENT_DESKTOP value set above, and a
-# user can override it in ~/.config/xdg-desktop-portal/.
+# The portal backend declaration and map: Inhibit to the compositor,
+# ScreenCast/Screenshot to the wlr backend (screen sharing — see
+# docs/screen-sharing.md), and the rest to GTK. The map is matched by
+# the XDG_CURRENT_DESKTOP value set above, and a user can override it
+# in ~/.config/xdg-desktop-portal/.
+sudo install -Dm644 packaging/portal/chonkstep.portal \
+    /usr/share/xdg-desktop-portal/portals/chonkstep.portal
 sudo install -Dm644 packaging/portal/chonkstep-portals.conf \
     /usr/share/xdg-desktop-portal/chonkstep-portals.conf
 

--- a/scripts/wayland-session.sh
+++ b/scripts/wayland-session.sh
@@ -225,9 +225,10 @@ if the checkout moved), or install the chonkstep package"
 # environment.
 [ -n "${XDG_RUNTIME_DIR:-}" ] || fail "XDG_RUNTIME_DIR is not set - a Wayland compositor has nowhere to put its socket"
 
-# A session bus is not optional plumbing for a modern desktop —
-# chonkstep itself never touches D-Bus, but the applications its menus
-# launch expect $DBUS_SESSION_BUS_ADDRESS to exist. Unlike the X11
+# A session bus is not optional plumbing for a modern desktop — the
+# compositor owns its ScreenSaver and portal idle-inhibit bridges there,
+# and the applications its menus launch expect $DBUS_SESSION_BUS_ADDRESS
+# to exist. Unlike the X11
 # script this wraps conditionally: a display manager that starts
 # sessions through the systemd user instance has already given us a
 # bus, and starting a second one inside it would split the session in


### PR DESCRIPTION
Closes #45

## Summary
- serve org.freedesktop.ScreenSaver and the Inhibit portal backend from an off-loop zbus thread
- feed bounded, coalesced external-inhibitor state into the compositor while preserving the lock boundary
- release inhibitors on UnInhibit, portal Close, caller disconnect, or bus loss
- install and document the ChonkStep portal backend

## Verification
- cargo test -p wm-wayland
- cargo clippy -p wm-wayland --tests -- -D warnings
- cargo check --workspace
- bash syntax checks for installer, session script, and Arch package recipes
- private-session-bus integration round trip