### PR TITLE
Bound client subsurface tree depth (#44)

### DIFF
--- a/crates/chonk-testkit/src/bin/chonk-subsurface-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-subsurface-probe.rs
@@ -1,0 +1,361 @@
+//! A `wl_subcompositor` client, in two halves.
+//!
+//! The honest half (`stack`) maps a toplevel with one subsurface under
+//! it and one over it, in colours a screenshot can tell apart. That is
+//! the shape the compositor's own scene walk has to keep in order: a
+//! surface's z-position among its children is a real protocol fact —
+//! `wl_subsurface.place_below` puts a video under its parent's chrome —
+//! and it is the fact an iterative rewrite of a recursive tree walk is
+//! most likely to lose.
+//!
+//! The hostile half (`deep-chain`, `deep-chain-root`) builds a
+//! subsurface chain past the compositor's depth ceiling, in both of the
+//! orders a client can build one. `deep-chain` is the cheap one:
+//! attaching leaf-first — S1 under S2, then S2 under S3 — presents a
+//! parent that has no parent of its own on every single call, so a
+//! compositor that bounds only the distance from the new child to its
+//! root reads zero every time and never fires. On an unbounded
+//! compositor the chain simply grows until a commit walks it off the
+//! end of the stack; here the link past the ceiling must be refused
+//! with a protocol error, and the chain exactly at the ceiling must
+//! still be accepted.
+
+use std::io::Write;
+use std::os::fd::AsFd;
+
+use wayland_client::protocol::{
+    wl_buffer, wl_compositor::WlCompositor, wl_registry, wl_shm, wl_shm_pool,
+    wl_subcompositor::WlSubcompositor, wl_subsurface::WlSubsurface, wl_surface::WlSurface,
+};
+use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_protocols::xdg::shell::client::{
+    xdg_surface::{self, XdgSurface},
+    xdg_toplevel::{self, XdgToplevel},
+    xdg_wm_base::{self, XdgWmBase},
+};
+
+fn fatal(message: &str) -> ! {
+    eprintln!("chonk-subsurface-probe: {message}");
+    std::process::exit(1);
+}
+
+/// Says a line and makes sure it is on disk: the harness reads this log
+/// while the process is still alive, so a buffered line is a line the
+/// test cannot see.
+fn say(line: &str) {
+    println!("{line}");
+    let _ = std::io::stdout().flush();
+}
+
+#[derive(Default)]
+struct Probe {
+    compositor: Option<WlCompositor>,
+    subcompositor: Option<WlSubcompositor>,
+    shm: Option<wl_shm::WlShm>,
+    wm_base: Option<XdgWmBase>,
+    /// The size the compositor last configured, when it named one.
+    size: (i32, i32),
+    configured: bool,
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
+    fn event(
+        probe: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, version } = event {
+            match interface.as_str() {
+                "wl_compositor" => probe.compositor = Some(registry.bind(name, version.min(4), qh, ())),
+                "wl_subcompositor" => {
+                    probe.subcompositor = Some(registry.bind(name, version.min(1), qh, ()))
+                }
+                "wl_shm" => probe.shm = Some(registry.bind(name, version.min(1), qh, ())),
+                "xdg_wm_base" => probe.wm_base = Some(registry.bind(name, version.min(3), qh, ())),
+                _ => {}
+            }
+        }
+    }
+}
+
+impl Dispatch<XdgWmBase, ()> for Probe {
+    fn event(
+        _: &mut Self,
+        base: &XdgWmBase,
+        event: xdg_wm_base::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        // An unanswered ping is a kill, and this probe is meant to be
+        // killed for exactly one reason.
+        if let xdg_wm_base::Event::Ping { serial } = event {
+            base.pong(serial);
+        }
+    }
+}
+
+impl Dispatch<XdgSurface, ()> for Probe {
+    fn event(
+        probe: &mut Self,
+        surface: &XdgSurface,
+        event: xdg_surface::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_surface::Event::Configure { serial } = event {
+            surface.ack_configure(serial);
+            probe.configured = true;
+        }
+    }
+}
+
+impl Dispatch<XdgToplevel, ()> for Probe {
+    fn event(
+        probe: &mut Self,
+        _: &XdgToplevel,
+        event: xdg_toplevel::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_toplevel::Event::Configure { width, height, .. } = event {
+            if width > 0 && height > 0 {
+                probe.size = (width, height);
+            }
+        }
+    }
+}
+
+macro_rules! ignore_events {
+    ($($proxy:ty),* $(,)?) => {$(
+        impl Dispatch<$proxy, ()> for Probe {
+            fn event(
+                _: &mut Self,
+                _: &$proxy,
+                _: <$proxy as wayland_client::Proxy>::Event,
+                _: &(),
+                _: &Connection,
+                _: &QueueHandle<Self>,
+            ) {
+            }
+        }
+    )*};
+}
+
+ignore_events!(
+    WlCompositor,
+    WlSubcompositor,
+    WlSurface,
+    WlSubsurface,
+    wl_shm::WlShm,
+    wl_shm_pool::WlShmPool,
+    wl_buffer::WlBuffer,
+);
+
+/// One opaque single-colour `wl_buffer`, in premultiplied
+/// little-endian ARGB — the order `wl_shm` means by `Argb8888`.
+fn color_buffer(
+    shm: &wl_shm::WlShm,
+    qh: &QueueHandle<Probe>,
+    serial: u32,
+    width: i32,
+    height: i32,
+    bgra: [u8; 4],
+) -> wl_buffer::WlBuffer {
+    let path = format!(
+        "{}/chonk-subsurface-probe-{}-{serial}",
+        std::env::var("XDG_RUNTIME_DIR").unwrap_or_else(|_| "/dev/shm".into()),
+        std::process::id()
+    );
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path)
+        .unwrap_or_else(|error| fatal(&format!("scratch file {path}: {error}")));
+    let _ = std::fs::remove_file(&path);
+    let (width, height) = (width.max(1), height.max(1));
+    let bytes: Vec<u8> = std::iter::repeat_n(bgra, (width * height) as usize).flatten().collect();
+    let mut writer = &file;
+    writer
+        .write_all(&bytes)
+        .unwrap_or_else(|error| fatal(&format!("filling the buffer: {error}")));
+    writer
+        .flush()
+        .unwrap_or_else(|error| fatal(&format!("flushing the buffer: {error}")));
+    let pool = shm.create_pool(file.as_fd(), width * height * 4, qh, ());
+    let buffer = pool.create_buffer(0, width, height, width * 4, wl_shm::Format::Argb8888, qh, ());
+    pool.destroy();
+    buffer
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let mode = args.next().unwrap_or_else(|| fatal("usage: chonk-subsurface-probe <mode> [...]"));
+
+    let connection = Connection::connect_to_env().unwrap_or_else(|e| fatal(&format!("connect: {e}")));
+    let mut queue = connection.new_event_queue::<Probe>();
+    let qh = queue.handle();
+    connection.display().get_registry(&qh, ());
+    let mut probe = Probe::default();
+    queue
+        .roundtrip(&mut probe)
+        .unwrap_or_else(|error| fatal(&format!("registry roundtrip: {error}")));
+
+    let compositor = probe.compositor.clone().unwrap_or_else(|| fatal("no wl_compositor"));
+    let subcompositor = probe
+        .subcompositor
+        .clone()
+        .unwrap_or_else(|| fatal("no wl_subcompositor"));
+
+    match mode.as_str() {
+        "stack" => {
+            let title = args.next().unwrap_or_else(|| "subsurface-stack".to_string());
+            stack(&mut queue, &mut probe, &compositor, &subcompositor, title);
+        }
+        "deep-chain" | "deep-chain-root" => {
+            let limit: usize = args
+                .next()
+                .unwrap_or_else(|| fatal("the depth limit is the second argument"))
+                .parse()
+                .unwrap_or_else(|error| fatal(&format!("depth limit: {error}")));
+            deep_chain(
+                &mut queue,
+                &mut probe,
+                &compositor,
+                &subcompositor,
+                limit,
+                mode == "deep-chain",
+            );
+        }
+        other => fatal(&format!("unknown mode {other:?}")),
+    }
+}
+
+/// The honest half: a toplevel with a subsurface below it and another
+/// above it, then hold the window open for the test to photograph.
+fn stack(
+    queue: &mut wayland_client::EventQueue<Probe>,
+    probe: &mut Probe,
+    compositor: &WlCompositor,
+    subcompositor: &WlSubcompositor,
+    title: String,
+) {
+    let qh = queue.handle();
+    let shm = probe.shm.clone().unwrap_or_else(|| fatal("no wl_shm"));
+    let wm_base = probe.wm_base.clone().unwrap_or_else(|| fatal("no xdg_wm_base"));
+
+    let parent = compositor.create_surface(&qh, ());
+    let xdg_surface = wm_base.get_xdg_surface(&parent, &qh, ());
+    let toplevel = xdg_surface.get_toplevel(&qh, ());
+    toplevel.set_title(title.clone());
+    toplevel.set_app_id("chonk-subsurface-probe".to_string());
+    parent.commit();
+    queue
+        .roundtrip(probe)
+        .unwrap_or_else(|error| fatal(&format!("initial configure: {error}")));
+    if !probe.configured {
+        fatal("the compositor never configured the toplevel");
+    }
+    let (width, height) = if probe.size.0 > 0 { probe.size } else { (300, 300) };
+
+    // Red is the parent's own pixels. The green sheet under it is the
+    // same size, so any pixel of the window that comes back green means
+    // a below-subsurface was drawn above its parent. The blue patch over
+    // it is small and in the corner, so a red corner means an
+    // above-subsurface was drawn below its parent. One screenshot
+    // decides both.
+    let parent_buffer = color_buffer(&shm, &qh, 0, width, height, [0x20, 0x20, 0xE0, 0xFF]);
+    let under_buffer = color_buffer(&shm, &qh, 1, width, height, [0x20, 0xE0, 0x20, 0xFF]);
+    let over_buffer = color_buffer(&shm, &qh, 2, 80, 80, [0xE0, 0x20, 0x20, 0xFF]);
+
+    let under = compositor.create_surface(&qh, ());
+    let under_role = subcompositor.get_subsurface(&under, &parent, &qh, ());
+    under_role.set_position(0, 0);
+    under_role.place_below(&parent);
+    under.attach(Some(&under_buffer), 0, 0);
+    under.damage(0, 0, width, height);
+    under.commit();
+
+    let over = compositor.create_surface(&qh, ());
+    let over_role = subcompositor.get_subsurface(&over, &parent, &qh, ());
+    over_role.set_position(0, 0);
+    over_role.place_above(&parent);
+    over.attach(Some(&over_buffer), 0, 0);
+    over.damage(0, 0, 80, 80);
+    over.commit();
+
+    // Both subsurfaces are synchronized, which is the default and the
+    // whole point: their state lands when the parent commits, through
+    // the same `commit_sync_surface_tree` walk the depth bound exists to
+    // protect.
+    parent.attach(Some(&parent_buffer), 0, 0);
+    parent.damage(0, 0, width, height);
+    parent.commit();
+    queue
+        .roundtrip(probe)
+        .unwrap_or_else(|error| fatal(&format!("mapping roundtrip: {error}")));
+    say(&format!("mapped title={title:?} {width}x{height} with 2 subsurfaces"));
+
+    loop {
+        if queue.blocking_dispatch(probe).is_err() {
+            return;
+        }
+    }
+}
+
+/// The hostile half. `leaf_first` picks the construction order: leaf
+/// first grows the chain upward from a leaf (every parent is a fresh
+/// root), root first grows it downward from a root (every child is a
+/// fresh leaf). Both must be accepted up to `limit` links and refused
+/// at `limit + 1`.
+fn deep_chain(
+    queue: &mut wayland_client::EventQueue<Probe>,
+    probe: &mut Probe,
+    compositor: &WlCompositor,
+    subcompositor: &WlSubcompositor,
+    limit: usize,
+    leaf_first: bool,
+) {
+    let qh = queue.handle();
+    let order = if leaf_first { "leaf-first" } else { "root-first" };
+    let chain: Vec<WlSurface> = (0..=limit + 1).map(|_| compositor.create_surface(&qh, ())).collect();
+
+    // `chain[i]` sits `i` links above the bottom either way; only the
+    // order the links are requested in differs.
+    let link = |child: usize, parent: usize| {
+        subcompositor.get_subsurface(&chain[child], &chain[parent], &qh, ());
+    };
+    for step in 0..limit {
+        if leaf_first {
+            link(step, step + 1);
+        } else {
+            link(limit - 1 - step, limit - step);
+        }
+    }
+    if let Err(error) = queue.roundtrip(probe) {
+        fatal(&format!("a chain of {limit} links ({order}) was refused: {error}"));
+    }
+    say(&format!("**{order} chain of {limit} links accepted**"));
+
+    // One link too many. The compositor must answer this with a
+    // protocol error and nothing else.
+    link(limit, limit + 1);
+    match queue.roundtrip(probe) {
+        Ok(_) => say(&format!("**{order} chain of {} links accepted**", limit + 1)),
+        Err(error) => say(&format!("**{order} refused at {} links: {error}**", limit + 1)),
+    }
+    // Whatever happened, report what the connection does next: a
+    // refusal that does not actually disconnect would leave the chain
+    // in the tree and the compositor still walking it.
+    match queue.roundtrip(probe) {
+        Ok(_) => say("**connection still alive**"),
+        Err(error) => say(&format!("**connection closed: {error}**")),
+    }
+}

--- a/crates/chonk-testkit/tests/subsurface_depth.rs
+++ b/crates/chonk-testkit/tests/subsurface_depth.rs
@@ -1,0 +1,159 @@
+//! The unbounded subsurface tree, spelled as assertions.
+//!
+//! # The defect
+//!
+//! `wl_subcompositor.get_subsurface` rejects self-parenting and cycles
+//! and nothing else, so how *deep* a client nests its surfaces was a
+//! number the client chose. Every walk of that tree is recursive — two
+//! of them run on an ordinary commit, a third under every scene build,
+//! bounding box, frame callback and presentation feedback the
+//! compositor performs — and the stack they run on is 8 MiB. Tens of
+//! thousands of `wl_surface`/`wl_subsurface` pairs is a few hundred
+//! thousand protocol messages and a fraction of a second's work for a
+//! client; it is also a `SIGSEGV` against the guard page for the
+//! compositor, which runs no panic hook, restores no gamma ramp,
+//! unlinks no socket and names no culprit in the log. An unprivileged
+//! client ended the session and every application in it, and left the
+//! supervisor with "compositor exited abnormally".
+//!
+//! # What these tests drive
+//!
+//! `chonk-subsurface-probe`, in both halves (see its module doc). The
+//! hostile half builds its chain in both constructions a client can
+//! use, because they are not equally easy to catch: growing the chain
+//! *leaf-first* presents a parent with no parent of its own on every
+//! call, so a depth counter that measures only from the new child up to
+//! its root reads zero on every link of a chain of any length. The
+//! honest half exists for the other half of the fix — the compositor's
+//! own scene walk became iterative, and a subsurface's z-position
+//! relative to its parent is exactly what that rewrite could silently
+//! lose.
+
+use std::time::Duration;
+
+use chonk_testkit::{near, poll_until, profile_binary, Screenshot, Session, SessionOptions, WindowInfo};
+use wm_theme_api::MAX_SUBSURFACE_DEPTH;
+
+/// The probe's three colours, as a screenshot sees them.
+const PARENT_RGB: [u8; 3] = [0xE0, 0x20, 0x20];
+const OVER_RGB: [u8; 3] = [0x20, 0x20, 0xE0];
+const UNDER_RGB: [u8; 3] = [0x20, 0xE0, 0x20];
+
+/// Both stacking facts the probe's window encodes, checked at once.
+///
+/// The corner belongs to the subsurface placed *above* the parent and
+/// the middle to the parent itself, which sits above a green sheet of
+/// its own size. Green anywhere means a below-subsurface was drawn over
+/// its parent; red in the corner means an above-subsurface was drawn
+/// under it. Either is the ordering bug the iterative scene walk had to
+/// avoid, and neither is visible from a window's geometry.
+fn assert_subsurface_stacking(shot: &Screenshot, window: &WindowInfo, when: &str) {
+    let (x, y) = (window.x.max(0) as u32, window.y.max(0) as u32);
+    let corner = shot.mean_rgb(x + 16, y + 16, 16, 16);
+    assert!(
+        near(corner, OVER_RGB),
+        "{when}: the subsurface placed above the parent must own the window's corner, \
+         got {corner:?} (parent {PARENT_RGB:?}, above {OVER_RGB:?}) in {}",
+        shot.path.display()
+    );
+    let middle = shot.mean_rgb(x + window.w / 2 - 8, y + window.h / 2 - 8, 16, 16);
+    assert!(
+        near(middle, PARENT_RGB),
+        "{when}: the parent must stay above the subsurface placed below it, \
+         got {middle:?} (parent {PARENT_RGB:?}, below {UNDER_RGB:?}) in {}",
+        shot.path.display()
+    );
+}
+
+/// Waits for a line in one launched client's log.
+fn wait_for_client_line(session: &Session, log_name: &str, needle: &str) {
+    let path = session.dir.join(log_name);
+    poll_until(Duration::from_secs(15), &format!("{log_name} to say {needle:?}"), || {
+        std::fs::read_to_string(&path).ok().filter(|text| text.contains(needle)).map(|_| ())
+    })
+    .unwrap_or_else(|timeout| {
+        panic!("{timeout}\n{}", std::fs::read_to_string(&path).unwrap_or_default())
+    });
+}
+
+/// The load-bearing regression, in one session because the point of it
+/// is that the three clients share one.
+///
+/// The honest client maps first and is photographed before and after
+/// the two hostile ones run. On the unfixed compositor the second
+/// photograph never happens: the session is gone.
+#[test]
+#[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit -- --ignored --test-threads=1"]
+fn an_over_deep_subsurface_chain_kills_its_own_client_and_nothing_else() {
+    let probe = profile_binary("chonk-subsurface-probe")
+        .expect("cargo build -p chonk-testkit builds the probe");
+    let probe = probe.to_string_lossy().to_string();
+    let mut session = Session::boot(
+        "bounded-subsurface-depth",
+        SessionOptions { scale: Some(1.0), ..SessionOptions::default() },
+    )
+    .expect("the nested compositor boots");
+
+    session
+        .launch(&probe, &["stack", "subsurface-stack"])
+        .expect("the honest probe launches");
+    let window = session
+        .wait_for_window("subsurface-stack")
+        .expect("the honest probe maps its toplevel");
+    assert!(
+        window.w >= 200 && window.h >= 200,
+        "the probe's window is the canvas these assertions sample: {window:?}"
+    );
+    session.door().barrier().expect("the compositor settles");
+    let before = session.screenshot("subsurface-stack-before").unwrap();
+    assert_subsurface_stacking(&before, &window, "before the hostile clients");
+
+    // Both constructions, one after the other. Each is accepted up to
+    // the ceiling and refused one link past it.
+    let limit = MAX_SUBSURFACE_DEPTH.to_string();
+    session
+        .launch(&probe, &["deep-chain", &limit])
+        .expect("the leaf-first probe launches");
+    session
+        .launch(&probe, &["deep-chain-root", &limit])
+        .expect("the root-first probe launches");
+
+    for (log, order) in [
+        ("client-1-chonk-subsurface-probe.log", "leaf-first"),
+        ("client-2-chonk-subsurface-probe.log", "root-first"),
+    ] {
+        wait_for_client_line(
+            &session,
+            log,
+            &format!("**{order} chain of {MAX_SUBSURFACE_DEPTH} links accepted**"),
+        );
+        wait_for_client_line(
+            &session,
+            log,
+            &format!("**{order} refused at {} links:", MAX_SUBSURFACE_DEPTH + 1),
+        );
+        // A refusal that does not disconnect leaves the over-deep chain
+        // standing in the tree, and the next commit walks it.
+        wait_for_client_line(&session, log, "**connection closed:");
+    }
+
+    session
+        .door()
+        .barrier()
+        .expect("the compositor answers after both hostile clients have run");
+    let log = session.log();
+    assert_eq!(
+        log.matches("client subsurface tree exceeded the compositor's depth limit")
+            .count(),
+        2,
+        "one diagnostic per offending client, naming the depth it asked for:\n{log}"
+    );
+
+    // The other half of "nothing else": the innocent client kept its
+    // window, its pixels, and its stacking order.
+    let after = session
+        .wait_for_window("subsurface-stack")
+        .expect("the honest client outlives the hostile ones");
+    let shot = session.screenshot("subsurface-stack-after").unwrap();
+    assert_subsurface_stacking(&shot, &after, "after the hostile clients");
+}

--- a/crates/wm-theme-api/src/geometry.rs
+++ b/crates/wm-theme-api/src/geometry.rs
@@ -55,6 +55,52 @@ pub const fn client_size_limit(screen: Size) -> Size {
     )
 }
 
+/// Absolute ceiling on how many `wl_subsurface` links may separate a
+/// surface tree's root from its deepest leaf.
+///
+/// The second client-controlled quantity that reaches into the
+/// compositor, and the one with the worse failure. A size becomes an
+/// allocation, and a refused allocation is a `SIGABRT` that at least
+/// runs the panic hook; a *depth* becomes recursion, and every
+/// traversal of a surface tree — three of them inside smithay, one
+/// commit is enough to enter all three — is recursive. Running out of
+/// stack is not a panic: the guard page faults, the kernel delivers
+/// `SIGSEGV`, and nothing runs. No `tracing::error!`, no gamma-ramp
+/// restore, no IPC-socket unlink, no dockapp teardown — the supervisor
+/// sees only "compositor exited abnormally".
+///
+/// Nothing in the protocol bounds this. `wl_subcompositor.get_subsurface`
+/// rejects only self-parenting and cycles, so a client that spends a
+/// few hundred thousand messages — a fraction of a second — arrives at
+/// tens of thousands of frames on an 8 MiB stack.
+///
+/// 64 is generous by two orders of magnitude in the direction that
+/// matters. Real toolkits nest in single digits: the deepest tree this
+/// desktop actually runs is a video surface under a decoration under a
+/// toplevel.
+pub const MAX_SUBSURFACE_DEPTH: u32 = 64;
+
+/// Whether attaching a child to a parent would push some root-to-leaf
+/// path past [`MAX_SUBSURFACE_DEPTH`].
+///
+/// `parent_depth` is how many links already separate the parent from
+/// its own root; `child_height` is how many already separate the child
+/// from the deepest leaf *below* it. Both halves are needed, and the
+/// second is the one that is easy to miss: `wl_subcompositor` lets a
+/// client build its chain leaf-first — attach S1 under S2, then S2
+/// under S3 — and every one of those calls presents a parent that has
+/// no parent of its own. A bound that counted only the distance to the
+/// root would read zero on every link of that construction and never
+/// fire.
+///
+/// The sum is the length of the longest path through the new link, and
+/// it is the same number for the parent and for every ancestor above
+/// it, which is why one check at one link is enough to keep the whole
+/// tree bounded. Saturating, because both halves are client-driven.
+pub const fn subsurface_link_exceeds_depth(parent_depth: u32, child_height: u32) -> bool {
+    parent_depth.saturating_add(1).saturating_add(child_height) > MAX_SUBSURFACE_DEPTH
+}
+
 /// Bounds an untrusted client size before it can reach layout or
 /// raster allocation. Zero is preserved because protocol-specific
 /// callers use it to mean "unspecified"; positive dimensions are
@@ -115,5 +161,24 @@ mod tests {
             clamp_client_size(Size::new(640, 480), Size::new(2560, 1600)),
             Size::new(640, 480)
         );
+    }
+
+    #[test]
+    fn subsurface_depth_counts_both_sides_of_a_new_link() {
+        // A toolkit's real tree: two links under a toplevel.
+        assert!(!subsurface_link_exceeds_depth(2, 0));
+        // The last link that fits, and the first that does not.
+        assert!(!subsurface_link_exceeds_depth(MAX_SUBSURFACE_DEPTH - 1, 0));
+        assert!(subsurface_link_exceeds_depth(MAX_SUBSURFACE_DEPTH, 0));
+        // The leaf-first construction: the parent is a fresh root every
+        // time, and the whole chain hangs below the child. A bound that
+        // read only `parent_depth` would pass every one of these.
+        assert!(!subsurface_link_exceeds_depth(0, MAX_SUBSURFACE_DEPTH - 1));
+        assert!(subsurface_link_exceeds_depth(0, MAX_SUBSURFACE_DEPTH));
+        // Meeting in the middle is the same arithmetic.
+        assert!(!subsurface_link_exceeds_depth(31, 32));
+        assert!(subsurface_link_exceeds_depth(32, 32));
+        // Neither client-supplied half can wrap the sum past the bound.
+        assert!(subsurface_link_exceeds_depth(u32::MAX, u32::MAX));
     }
 }

--- a/crates/wm-theme-api/src/lib.rs
+++ b/crates/wm-theme-api/src/lib.rs
@@ -14,7 +14,7 @@ pub use decoration::{
     ResizeEdge, ThemeEngine,
 };
 pub use geometry::{
-    clamp_client_size, client_size_limit, Point, Rect, Size,
-    MAX_CLIENT_WINDOW_DIMENSION,
+    clamp_client_size, client_size_limit, subsurface_link_exceeds_depth, Point, Rect, Size,
+    MAX_CLIENT_WINDOW_DIMENSION, MAX_SUBSURFACE_DEPTH,
 };
 pub use popup::{PopupGrab, PopupHost};

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -79,6 +79,7 @@
 //! is the size the ledger recorded for it
 //! (`xdg::committed_content_size`) and the frame was drawn around.
 
+use std::cell::RefCell;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -96,6 +97,7 @@ use smithay::desktop::utils::{
 };
 use smithay::input::pointer::{CursorImageAttributes, CursorImageStatus};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::Resource;
 use smithay::render_elements;
 use smithay::utils::{IsAlive, Physical, Point as SPoint, Rectangle as SRect, Scale};
 use smithay::wayland::compositor::{self, with_states, TraversalAction};
@@ -1113,48 +1115,132 @@ pub(crate) fn push_surface_tree(
     // storage became reusable. Pushing the same elements straight into
     // the retained scene keeps ordering and import semantics identical
     // while removing the hidden inner allocation.
+    //
+    // It is also driven from an explicit stack rather than by recursing
+    // on itself, so this walk's stack cost is a constant that does not
+    // depend on how deep a client chose to nest its subsurfaces. Depth
+    // is bounded at the protocol edge now (`xdg::Compositor::new_subsurface`
+    // and `MAX_SUBSURFACE_DEPTH`), which is what protects the recursions
+    // inside smithay that cannot be rewritten from here — but the walk
+    // this compositor owns should not need that bound to be safe, and
+    // does not.
     let tree_origin = location;
-    let location = tree_origin.to_f64();
     let scale: Scale<f64> = render_scale.into();
-    compositor::with_surface_tree_downward(
-        surface,
-        location,
-        |_, states, location| {
-            let mut location = *location;
-            let data = states.data_map.get::<RendererSurfaceStateUserData>();
-            if let Some(data) = data {
-                if let Some(view) = data.lock().unwrap().view() {
-                    location += view.offset.to_f64().to_physical(scale);
-                    TraversalAction::DoChildren(location)
-                } else {
-                    TraversalAction::SkipChildren
+    let mut pending = take_walk_stack();
+    // The root is carried in hand rather than pushed, so a tree with no
+    // subsurfaces at all — nearly every window — touches the stack zero
+    // times and its scratch capacity stays at whatever the frame before
+    // needed.
+    let mut next = Some(TreeStep::Descend(surface.clone(), tree_origin.to_f64()));
+    while let Some(step) = next.take().or_else(|| pending.pop()) {
+        match step {
+            TreeStep::Descend(node, location) => {
+                // One level, and one level only: the filter answers for
+                // `node` and refuses children to everything else, so
+                // upstream's recursion turns around after a single step
+                // no matter what the tree looks like below. What comes
+                // back is the exact order upstream would have walked in,
+                // including `node`'s own place among its children — a
+                // subsurface may sit below its parent, and that position
+                // lives in a child list this crate cannot read directly.
+                let mark = pending.len();
+                compositor::with_surface_tree_downward(
+                    &node,
+                    location,
+                    |visited, states, location| {
+                        if visited.id() != node.id() {
+                            return TraversalAction::SkipChildren;
+                        }
+                        let mut location = *location;
+                        let data = states.data_map.get::<RendererSurfaceStateUserData>();
+                        if let Some(data) = data {
+                            if let Some(view) = data.lock().unwrap().view() {
+                                location += view.offset.to_f64().to_physical(scale);
+                                TraversalAction::DoChildren(location)
+                            } else {
+                                TraversalAction::SkipChildren
+                            }
+                        } else {
+                            TraversalAction::SkipChildren
+                        }
+                    },
+                    |visited, _, location| {
+                        pending.push(if visited.id() == node.id() {
+                            TreeStep::Draw(node.clone(), *location)
+                        } else {
+                            TreeStep::Descend(visited.clone(), *location)
+                        });
+                    },
+                    |_, _, _| true,
+                );
+                // A stack pops backwards; the level was collected
+                // forwards. Reversing the segment this level just added
+                // makes the pops come out in display order, and leaves
+                // the siblings still queued below it untouched.
+                pending[mark..].reverse();
+            }
+            TreeStep::Draw(node, location) => {
+                let drawn = with_states(&node, |states| {
+                    let mut location = location;
+                    let data = states.data_map.get::<RendererSurfaceStateUserData>();
+                    let has_view = data
+                        .and_then(|data| data.lock().unwrap().view())
+                        .map(|view| {
+                            location += view.offset.to_f64().to_physical(scale);
+                        })
+                        .is_some();
+                    if !has_view {
+                        return None;
+                    }
+                    Some(WaylandSurfaceRenderElement::from_surface(
+                        renderer, &node, states, location, 1.0, kind,
+                    ))
+                });
+                match drawn {
+                    Some(Ok(Some(element))) => elements.push(
+                        RescaleRenderElement::from_element(element, tree_origin, factor).into(),
+                    ),
+                    Some(Ok(None)) | None => {}
+                    Some(Err(error)) => tracing::warn!(%error, "failed to import a Wayland surface"),
                 }
-            } else {
-                TraversalAction::SkipChildren
             }
-        },
-        |surface, states, location| {
-            let mut location = *location;
-            let data = states.data_map.get::<RendererSurfaceStateUserData>();
-            let has_view = data
-                .and_then(|data| data.lock().unwrap().view())
-                .map(|view| {
-                    location += view.offset.to_f64().to_physical(scale);
-                })
-                .is_some();
-            if !has_view {
-                return;
-            }
-            match WaylandSurfaceRenderElement::from_surface(renderer, surface, states, location, 1.0, kind) {
-                Ok(Some(element)) => elements.push(
-                    RescaleRenderElement::from_element(element, tree_origin, factor).into(),
-                ),
-                Ok(None) => {}
-                Err(error) => tracing::warn!(%error, "failed to import a Wayland surface"),
-            }
-        },
-        |_, _, _| true,
-    );
+        }
+    }
+    return_walk_stack(pending);
+}
+
+/// One entry of [`push_surface_tree`]'s explicit walk.
+enum TreeStep {
+    /// Expand this surface's own level: its children, and its own
+    /// position among them.
+    Descend(WlSurface, SPoint<f64, Physical>),
+    /// Emit this surface's element, at the location the walk resolved
+    /// for it.
+    Draw(WlSurface, SPoint<f64, Physical>),
+}
+
+thread_local! {
+    /// Scratch for the walk above, so replacing a recursion with a
+    /// stack does not reintroduce the per-tree allocation the function
+    /// was written to remove. Only the capacity is retained: the stack
+    /// is emptied before it is parked, so no `WlSurface` outlives the
+    /// frame that walked it.
+    ///
+    /// Taken rather than borrowed across the walk. `push_surface_tree`
+    /// is not reentrant and runs on the repaint thread, but a `take`
+    /// costs a pointer swap and makes that a fact about performance
+    /// instead of a `RefCell` panic waiting for the day it stops being
+    /// true.
+    static WALK_STACK: RefCell<Vec<TreeStep>> = const { RefCell::new(Vec::new()) };
+}
+
+fn take_walk_stack() -> Vec<TreeStep> {
+    WALK_STACK.with(|stack| std::mem::take(&mut *stack.borrow_mut()))
+}
+
+fn return_walk_stack(mut stack: Vec<TreeStep>) {
+    stack.clear();
+    WALK_STACK.with(|slot| *slot.borrow_mut() = stack);
 }
 
 /// Pushes the pointer's elements, picking the image by what the

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -36,7 +36,7 @@
 #[cfg(test)]
 use std::collections::HashMap;
 use std::os::fd::OwnedFd;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use smithay::backend::renderer::utils::{on_commit_buffer_handler, with_renderer_surface_state};
 use smithay::desktop::{find_popup_root_surface, PopupKind};
@@ -50,6 +50,7 @@ use smithay::reexports::wayland_protocols::xdg::xdg_output::zv1::server::{
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_output;
 use smithay::reexports::wayland_server::protocol::wl_seat::WlSeat;
+use smithay::reexports::wayland_server::protocol::wl_subcompositor;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::{
     Client, DataInit, DisplayHandle, GlobalDispatch, New, Resource,
@@ -84,7 +85,10 @@ use smithay::{
 };
 
 use wm_core::{BackendEvent, NetState, NetStateAction};
-use wm_theme_api::{clamp_client_size, client_size_limit, Point, Rect, ResizeEdge, Size};
+use wm_theme_api::{
+    clamp_client_size, client_size_limit, subsurface_link_exceeds_depth, Point, Rect, ResizeEdge, Size,
+    MAX_SUBSURFACE_DEPTH,
+};
 
 use crate::state::{ClientState, Compositor, ManagedSurface, WaylandBackend, WindowRecord, WlFrameId, WlWindowId};
 #[cfg(test)]
@@ -138,6 +142,111 @@ fn warn_geometry_offset_clamped(surface: &WlSurface, requested: Point, accepted:
             ?requested,
             ?accepted,
             "client-declared xdg window-geometry origin exceeded the desktop coordinate limit; clamping"
+        );
+    }
+}
+
+/// How many `wl_subsurface` links separate this surface from the
+/// deepest leaf *below* it. A surface with no subsurfaces of its own
+/// is 0. Parked in the surface's own data map, so its lifetime is
+/// exactly the surface's, the same discipline as [`MappedMarker`].
+///
+/// This is the half of the depth bound that a check written only
+/// against the parent's distance-to-root cannot see. `wl_subcompositor`
+/// happily builds a chain leaf-first — `get_subsurface(child = S1,
+/// parent = S2)`, then `get_subsurface(child = S2, parent = S3)` — and
+/// on every one of those calls the parent is a fresh root. Recording
+/// what hangs *below* each surface is what makes the check O(1) in the
+/// subtree while still seeing that construction coming.
+///
+/// It is a high-water mark, not a live measurement. Destroying a
+/// `wl_subsurface` unparents its surface, and smithay offers no hook on
+/// that edge, so a former ancestor keeps the height its deepest child
+/// once gave it. The error is always in the safe direction — an
+/// overestimate refuses a link the real tree could have taken — and
+/// reaching it needs a client that repeatedly builds and tears down
+/// chains on the *same* surfaces, at increasing depth, which is not a
+/// shape any toolkit produces.
+#[derive(Default)]
+struct SubsurfaceHeight(AtomicU32);
+
+/// One warning bit per parent surface for a refused subsurface link,
+/// the same shape as [`GeometryClampMarker`]. The refusal is fatal to
+/// the connection, so in practice a client gets exactly one; the bit
+/// keeps that true independently of when smithay decides to call the
+/// hook.
+#[derive(Default)]
+struct SubsurfaceDepthMarker(AtomicBool);
+
+fn subsurface_height(surface: &WlSurface) -> u32 {
+    with_states(surface, |states| {
+        states
+            .data_map
+            .insert_if_missing_threadsafe(SubsurfaceHeight::default);
+        states
+            .data_map
+            .get::<SubsurfaceHeight>()
+            .unwrap()
+            .0
+            .load(Ordering::Relaxed)
+    })
+}
+
+/// Raises a surface's recorded subtree height to at least `height`.
+fn raise_subsurface_height(surface: &WlSurface, height: u32) {
+    with_states(surface, |states| {
+        states
+            .data_map
+            .insert_if_missing_threadsafe(SubsurfaceHeight::default);
+        states
+            .data_map
+            .get::<SubsurfaceHeight>()
+            .unwrap()
+            .0
+            .fetch_max(height, Ordering::Relaxed);
+    });
+}
+
+/// The ancestors of `surface`, nearest first.
+///
+/// Iterative on purpose: this list exists to defend the recursive tree
+/// walks, and reading it with a recursion of its own would be the same
+/// bug one level up. The hard stop is not redundant either — it is what
+/// makes the very first call safe on a tree that predates the bound, and
+/// it errs long: a chain that hits it reports a depth past the ceiling,
+/// so the caller refuses the link rather than accepting an undercount.
+fn ancestor_chain(surface: &WlSurface) -> Vec<WlSurface> {
+    let mut chain = Vec::new();
+    let mut next = get_parent(surface);
+    while let Some(current) = next {
+        next = get_parent(&current);
+        chain.push(current);
+        if chain.len() > MAX_SUBSURFACE_DEPTH as usize {
+            break;
+        }
+    }
+    chain
+}
+
+fn warn_subsurface_depth_refused(surface: &WlSurface, parent_depth: u32, child_height: u32) {
+    let first = with_states(surface, |states| {
+        states
+            .data_map
+            .insert_if_missing_threadsafe(SubsurfaceDepthMarker::default);
+        !states
+            .data_map
+            .get::<SubsurfaceDepthMarker>()
+            .unwrap()
+            .0
+            .swap(true, Ordering::Relaxed)
+    });
+    if first {
+        tracing::warn!(
+            surface = ?surface.id(),
+            parent_depth,
+            child_height,
+            limit = MAX_SUBSURFACE_DEPTH,
+            "client subsurface tree exceeded the compositor's depth limit; refusing the link and disconnecting the client"
         );
     }
 }
@@ -514,6 +623,80 @@ impl CompositorHandler for Compositor {
         // for Omarchy's Quickshell that connection is also the bar and
         // the OSDs. See `lock::install_defunct_lock_role_guard`.
         crate::lock::install_defunct_lock_role_guard(surface);
+    }
+
+    /// The one hook the protocol gives before a subsurface tree can
+    /// grow, and this compositor's only bound on its depth.
+    ///
+    /// smithay calls this from `wl_subcompositor.get_subsurface` after
+    /// `set_parent` has already linked the pair, and `set_parent`
+    /// rejects only self-parenting and cycles. So depth is whatever the
+    /// client says it is, and *every* traversal of the resulting tree
+    /// is recursive — `commit_sync_surface_tree` and
+    /// `is_effectively_sync` on the commit path, `PrivateSurfaceData::map`
+    /// under every helper the renderer, the bounding box, the frame
+    /// callbacks and the presentation feedback use. One commit on a deep
+    /// chain's root walks the whole thing. Running out of stack there is
+    /// a `SIGSEGV` against the guard page: the panic hook in
+    /// `chonkstep-wayland`'s `main` never runs, the teardown in
+    /// `state.rs` never runs, and the supervisor is left with a status
+    /// code and no account of which client did it.
+    ///
+    /// # Why the check is what it is
+    ///
+    /// The link is already made when this runs, so the ceiling is
+    /// enforced by refusing the *client*, not the link — one link past
+    /// the bound is harmless, tens of thousands are not. A protocol
+    /// error is fatal to the connection, and wayland-server stops
+    /// dispatching a killed client's remaining requests (its
+    /// `next_request` returns `EPIPE` on the killed flag), so the rest
+    /// of a flood that arrived in the same read never reaches the tree.
+    /// Nothing else on the desktop notices: one connection dies, the
+    /// session and every other client keep running.
+    ///
+    /// The measured quantity is the longest root-to-leaf path *through
+    /// this link* — the parent's distance to its own root, plus one, plus
+    /// what already hangs below the child ([`SubsurfaceHeight`]). Both
+    /// halves are load-bearing: the cheap way to build a deep chain is
+    /// leaf-first, and a check that counted only the parent's depth
+    /// would read zero on every link of it. That sum is the same number
+    /// for the parent and for every ancestor above it, so this single
+    /// check keeps the invariant "distance-to-root + height ≤
+    /// [`MAX_SUBSURFACE_DEPTH`]" true for every surface in the tree,
+    /// which is what makes the walk up bounded in turn.
+    ///
+    /// # The error object
+    ///
+    /// The request that broke the rule is `wl_subcompositor.get_subsurface`
+    /// and the fitting error is its `bad_parent` — the parent really is
+    /// unusable, because attaching to it would put the tree past the
+    /// ceiling. smithay's hook hands over the two surfaces and not the
+    /// `wl_subcompositor` resource, so the error travels on the child
+    /// surface, the only object of the offending request in reach.
+    /// `wl_display.error` kills the connection whichever object carries
+    /// it, and the message is what a client developer reads.
+    fn new_subsurface(&mut self, surface: &WlSurface, parent: &WlSurface) {
+        let child_height = subsurface_height(surface);
+        let ancestors = ancestor_chain(parent);
+        let parent_depth = ancestors.len() as u32;
+        if subsurface_link_exceeds_depth(parent_depth, child_height) {
+            warn_subsurface_depth_refused(parent, parent_depth, child_height);
+            surface.post_error(
+                wl_subcompositor::Error::BadParent,
+                format!(
+                    "subsurface tree would be {} links deep; this compositor allows {MAX_SUBSURFACE_DEPTH}",
+                    parent_depth.saturating_add(1).saturating_add(child_height)
+                ),
+            );
+            return;
+        }
+        // The child's subtree now hangs one link lower under the parent,
+        // two under its grandparent, and so on. Bounded by the ceiling
+        // this walk just enforced, so it is a handful of steps.
+        raise_subsurface_height(parent, child_height + 1);
+        for (above, ancestor) in ancestors.iter().enumerate() {
+            raise_subsurface_height(ancestor, child_height + 2 + above as u32);
+        }
     }
 
     fn destroyed(&mut self, surface: &WlSurface) {


### PR DESCRIPTION
Fixes #44

## Root cause

`wl_subcompositor.get_subsurface` rejects self-parenting and cycles and nothing else, so the *depth* of a client's subsurface tree was a number the client chose. Smithay hands the compositor `CompositorHandler::new_subsurface` (`compositor/mod.rs:584`, called at `compositor/handlers.rs:481`) and this crate never implemented it, so nothing anywhere bounded that depth.

Four recursions run over it, all reachable from ordinary requests:

| recursion | where | how it is reached |
| --- | --- | --- |
| `commit_sync_surface_tree` | `compositor/tree.rs:258`, recurses `:267` | subsurfaces are sync by default, so one commit on the chain's root takes the branch at `tree.rs:301` and walks to the leaf |
| `is_effectively_sync` | `compositor/handlers.rs:546`, recurses `:558` | called on every commit (`tree.rs:282`); `set_desync` down the chain then a commit on the *leaf* walks all the way up |
| `PrivateSurfaceData::map` | `compositor/tree.rs:488`, recurses `:510`/`:518`, holding a `MutexGuard` per level | the engine under `with_surface_tree_downward`, `bbox_from_surface_tree`, `send_frames_surface_tree`, `take_presentation_feedback_surface_tree` — an ordinary frame |
| `is_ancestor` | `compositor/tree.rs:338`, recurses `:346` | root-first construction recurses while the tree is still being built |

Running out of stack there is not a panic — it is `SIGSEGV` against the guard page, so the panic hook in `chonkstep-wayland/src/main.rs` never runs, the teardown in `state.rs` never runs, and the supervisor is left with "compositor exited abnormally" and no name for the culprit.

## A correction to the issue's proposed fix

The issue proposes storing `SubsurfaceDepth(parent_depth + 1)`. That does not stop the attack the issue itself describes. Building the chain **leaf-first** — `get_subsurface(child = S₁, parent = S₂)`, then `get_subsurface(child = S₂, parent = S₃)` — presents a parent with *no parent of its own* on every call, so `parent_depth` reads 0 and the stored depth reads 1 on every link of a chain of any length.

Verified by ablation, not by reading: with the check compiled as `subsurface_link_exceeds_depth(parent_depth, 0)`, the new regression test's 65-link leaf-first chain is accepted and the test fails at exactly that assertion.

So the bound measures **both** sides of the new link: the parent's distance to its own root, plus one, plus what already hangs *below* the child. That sum is the length of the longest root-to-leaf path through the link, and — this is what makes one check sufficient — it is the same number for the parent and for every ancestor above it. Checking it once at one link maintains `distance-to-root + height ≤ MAX_SUBSURFACE_DEPTH` for every surface in the tree, which is in turn what keeps the walk up bounded.

## Behavioral change

- **`MAX_SUBSURFACE_DEPTH = 64`** and `subsurface_link_exceeds_depth` in `crates/wm-theme-api/src/geometry.rs`, beside `MAX_CLIENT_WINDOW_DIMENSION`, so the project's client-bounds constants stay in one place. 64 is two orders of magnitude above what real toolkits use; the deepest legitimate tree this desktop runs is a video surface under a decoration under a toplevel.
- **`CompositorHandler::new_subsurface`** in `crates/wm-wayland/src/xdg.rs`. Each surface carries a `SubsurfaceHeight(AtomicU32)` in its own `data_map` (same lifetime discipline as `MappedMarker`), so the check is O(1) in the subtree and O(depth ≤ 64) in the ancestor walk, which is itself iterative.
- **Refusal is a protocol error on the offending client only.** The link is already made when the hook runs — smithay calls `set_parent` first — so the ceiling is enforced by refusing the *client*, not the link. That is sufficient: `wayland-backend`'s `Client::post_error` sends `wl_display.error`, flushes, and sets `killed` synchronously, and `next_request` then returns `EPIPE` (`rs/server_impl/client.rs:350`), so the rest of a flood that arrived in the same read never reaches `set_parent`. One link past the ceiling is harmless; tens of thousands are not.
- **The error object.** The offending request is `wl_subcompositor.get_subsurface` and the fitting error is its `bad_parent` — the parent really is unusable. Smithay's hook hands over the two surfaces and not the `wl_subcompositor` resource, so the error travels on the child surface, the only object of the request in reach. `wl_display.error` is connection-fatal whichever object carries it, and the message is what a client developer reads:
  `subsurface tree would be 65 links deep; this compositor allows 64`
- **`renderer::push_surface_tree` is now iterative** (`crates/wm-wayland/src/renderer.rs`). It drives an explicit stack; the one-level `with_surface_tree_downward` call it makes per node turns around after a single step regardless of what is below. The compositor's own walk therefore no longer depends on the bound to be safe.

## Invariants and edge cases

- **Display order is preserved exactly.** A surface's z-position among its children is a real protocol fact (`wl_subsurface.place_below` puts a video under its parent's chrome) and it lives in a child list this crate cannot read directly — `get_children` filters the self-sentinel out. The rewrite keeps it by expanding one level through upstream's own traversal and reversing the pushed segment, so pops come out in display order. Covered by a screenshot assertion, and verified to fail without the reverse (ablation below).
- **No per-tree allocation was reintroduced.** The root is carried in hand rather than pushed, so a tree with no subsurfaces — nearly every window — touches the stack zero times; the scratch stack is a thread-local whose capacity is retained and whose contents are cleared before parking, so no `WlSurface` outlives its frame.
- **`SubsurfaceHeight` is a high-water mark.** Destroying a `wl_subsurface` unparents its surface and smithay exposes no hook on that edge, so a former ancestor keeps the height its deepest child once gave it. The error is always in the safe direction (an overestimate refuses a link the real tree could have taken), and reaching it needs a client that repeatedly builds and tears down chains on the *same* surfaces at increasing depth. Documented at the type.
- **The ancestor walk carries its own hard stop** rather than trusting the bound it exists to enforce, and errs long: a chain that hits the stop reports a depth past the ceiling, so the link is refused rather than accepted on an undercount.
- Other clients are untouched — asserted, not assumed (below).

## Tests added

`crates/chonk-testkit/tests/subsurface_depth.rs` + `crates/chonk-testkit/src/bin/chonk-subsurface-probe.rs`, one session, three clients:

1. `stack` — an honest toplevel with one subsurface `place_below` it and one `place_above` it, in three colours. Photographed before and after the hostile clients run. The corner must be the above-subsurface's blue and the middle must be the parent's red; green anywhere is a below-subsurface drawn over its parent.
2. `deep-chain` — leaf-first. 64 links must be **accepted**, the 65th refused.
3. `deep-chain-root` — root-first. Same boundary, through the other construction.

Both hostile clients must report the protocol error *and* an already-closed connection: a refusal that does not disconnect leaves the over-deep chain standing in the tree. The compositor log must carry exactly two refusal diagnostics, one per offending client. Then the honest client's window and its stacking order must still be there.

Unit tests for the arithmetic in `crates/wm-theme-api/src/geometry.rs`, including the leaf-first shape (`parent_depth = 0`, `child_height = MAX`) that the naive bound misses, and saturation on both client-supplied halves.

### The test fails without the fix — three ablations, each rebuilt and re-run

| ablation | result |
| --- | --- |
| bound disabled entirely | `timed out after 15s waiting for … "**leaf-first refused at 65 links:"` |
| bound as the issue proposed it (`parent_depth` only, blind to the child's subtree) | same failure — the leaf-first chain is accepted |
| `pending[mark..].reverse()` removed from the iterative walk | `the subsurface placed above the parent must own the window's corner, got [32.0, 224.0, 32.0]` — the below-subsurface drawn on top |

## Commands run

```
cargo test -p wm-theme-api                                   ok
cargo test -p wm-wayland                                     201 passed, 0 failed
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
cargo test -p chonk-testkit --test subsurface_depth -- \
  --ignored --test-threads=1                                 1 passed
cargo test -p chonk-testkit --tests --no-fail-fast -- \
  --ignored --test-threads=1                                 85 passed, 8 failed, 44 ignored
```

### The nested suite's 8 failures are environmental, and pre-exist this branch

All eight are `could not launch zenity: No such file or directory (os error 2)` (the eighth is its consequence — `timed out after 10s waiting for a mapped window matching "TestMini"`). `zenity` is not installed on this machine. Confirmed by running the same two targets on `origin/main` with this branch's sources removed: `tests/e2e.rs` fails the same 5 (`click_lands_where_it_visually_lands`, `drag_ends_when_the_button_comes_up`, `frameless_resize_works`, `restore_after_miniaturize_is_a_real_focus_cycle`, `scale_2_composition_stays_intact`) and `tests/hyprland_ipc.rs` the same 3 (`a_real_window_appears_in_the_stream_and_the_client_list`, `foreign_toplevel_mapping_returns_the_same_live_ipc_address`, `window_geometry_plain_fields_and_monitor_eval_are_applied_before_ok`). Same set, same reason, on both.

`scripts/e2e.sh --headless` could not be used here: `weston`, `zenity` and `wlr-randr` are all absent, and the script refuses to start without them. The suite was therefore driven directly with the command the script itself runs. CI's Wayland job has all three and should run the full script.

## Known limitations / follow-up

- **The three smithay recursions are not reported upstream yet.** A complete report — the four call sites with exact line numbers, the leaf-first reproduction that makes them O(1) per link, and the note that a `parent_depth`-only bound does not catch it — is written and posted as a comment on #44, ready to file. Filing on a third-party tracker is not something this branch does on its own initiative; say the word and it goes to Smithay/smithay.
- `new_subsurface` running *after* `set_parent` means a compositor cannot refuse the link, only the client. That is a smithay API limitation and part of the upstream report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
