### PR TITLE
Separate focus from raise so sloppy focus stops restacking (#82)

### DIFF
--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -1302,6 +1302,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
     pub fn apply_session_state(&mut self, wm: &mut WindowManager<B>, next: SessionState) {
         // 1. Policy.
         wm.set_focus_policy(next.focus);
+        wm.set_raise_on_focus(next.autoraise);
         wm.set_placement_policy(next.placement);
         wm.set_snap_threshold(next.edge_resistance);
         wm.set_drag_modifier(next.drag_modifier);

--- a/crates/chonk-shell/src/startup.rs
+++ b/crates/chonk-shell/src/startup.rs
@@ -106,6 +106,9 @@ pub struct SessionState {
     /// [`resolve_scale`]).
     pub scale: f32,
     pub focus: FocusPolicy,
+    /// Whether focus also raises. Only the focus a pointer crossing
+    /// hands out consults this; a click raises regardless.
+    pub autoraise: bool,
     pub placement: PlacementPolicy,
     pub edge_resistance: u32,
     pub terminal_font_px: f32,
@@ -243,6 +246,7 @@ impl SessionState {
             } else {
                 FocusPolicy::ClickToFocus
             },
+            autoraise: config.autoraise,
             placement: config.placement,
             edge_resistance: config.edge_resistance,
             terminal_font_px: config.terminal_font_px,
@@ -896,6 +900,7 @@ mod tests {
             following: None,
             scale: 2.0,
             focus: FocusPolicy::ClickToFocus,
+            autoraise: true,
             placement: PlacementPolicy::Smart,
             edge_resistance: 10,
             terminal_font_px: 20.0,

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -31,6 +31,7 @@
 //! desktop = "omarchy"                # optional; a whole posture's defaults (see `preset`)
 //! keymap = "omarchy"                 # optional; which binding vocabulary (see `preset`)
 //! focus_follows_mouse = false        # optional; default false
+//! autoraise = true                   # optional; does taking focus also raise?
 //! scale = 2.0                        # optional; UI scale factor
 //! theme = "nextstep-classic"         # optional; theme name
 //! appearance = "dark"                # optional; "light" | "dark"
@@ -341,6 +342,15 @@ fn workspace_index(number: &str) -> Option<usize> {
 #[derive(Clone, Debug)]
 pub struct Config {
     pub focus_follows_mouse: bool,
+    /// Whether a window that takes focus is also brought to the front.
+    ///
+    /// Orthogonal to [`Self::focus_follows_mouse`], and only that
+    /// setting makes it interesting: a click always raises what it
+    /// lands on, so with click-to-focus this changes nothing. With
+    /// sloppy focus, `false` is what stops the pointer from reordering
+    /// every window it travels across. Defaults to `true`, which is the
+    /// behaviour every earlier release had.
+    pub autoraise: bool,
     pub scale: Option<f32>,
     pub theme: Option<String>,
     /// The session-wide light/dark appearance the desktop starts in:
@@ -562,6 +572,7 @@ impl Config {
         }
         Config {
             focus_follows_mouse: false,
+            autoraise: true,
             scale: None,
             theme: None,
             appearance: None,
@@ -1053,6 +1064,13 @@ pub fn parse_with(
                 other => tracing::warn!(
                     value = ?other,
                     "config: focus_follows_mouse must be a boolean, keeping default"
+                ),
+            },
+            "autoraise" => match value {
+                toml::Value::Boolean(b) => config.autoraise = *b,
+                other => tracing::warn!(
+                    value = ?other,
+                    "config: autoraise must be a boolean, keeping default"
                 ),
             },
             "scale" => match scale_from_value(value) {
@@ -1805,6 +1823,18 @@ mod tests {
         assert_eq!(config.placement, defaults.placement);
         assert_eq!(config.edge_resistance, defaults.edge_resistance);
         assert_eq!(config.keybindings, defaults.keybindings);
+    }
+
+    #[test]
+    fn autoraise_defaults_on_and_can_be_turned_off() {
+        // Every earlier release behaved as `true`, so the default is
+        // what keeps a session that sets nothing bit-identical.
+        assert!(parse("").unwrap().autoraise);
+        assert!(!parse("autoraise = false").unwrap().autoraise);
+        assert!(parse("autoraise = true").unwrap().autoraise);
+        // Wrong type keeps the default rather than breaking startup,
+        // the same contract `focus_follows_mouse` has.
+        assert!(parse("autoraise = \"no\"").unwrap().autoraise);
     }
 
     #[test]

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -274,6 +274,20 @@ pub struct WindowManager<B: Backend> {
     float_policy: Option<std::sync::Arc<dyn FloatPolicy>>,
     notifications: VecDeque<Notification>,
     focus_policy: FocusPolicy,
+    /// Whether taking focus also takes the top of the stack.
+    ///
+    /// Orthogonal to [`Self::focus_policy`] on purpose. Focus and
+    /// stacking are two things on a floating desktop, and the pair a
+    /// user wants is not a third focus mode: under click-to-focus the
+    /// raise belongs to the *click* and must survive whatever this
+    /// says, while under focus-follows-mouse an unconditional raise
+    /// reorders every window the pointer merely travels across on its
+    /// way somewhere else. Installed by the shell through
+    /// [`Self::set_raise_on_focus`], from the config's `autoraise`.
+    ///
+    /// `true` by default, so a session that sets nothing behaves
+    /// exactly as it did before this existed.
+    raise_on_focus: bool,
     /// 0-based, matching `Client::workspace`. Grows on demand up to
     /// [`MAX_WORKSPACES`] the first time something switches to or moves
     /// a client onto an index past the current row's end. There is no
@@ -359,6 +373,7 @@ impl<B: Backend> WindowManager<B> {
             float_policy: None,
             notifications: VecDeque::new(),
             focus_policy: FocusPolicy::default(),
+            raise_on_focus: true,
             current_workspace: 0,
             workspace_count: 1,
             cycle: None,
@@ -375,6 +390,17 @@ impl<B: Backend> WindowManager<B> {
     /// path needing to know the other exists.
     pub fn set_focus_policy(&mut self, policy: FocusPolicy) {
         self.focus_policy = policy;
+    }
+
+    /// Whether a window that *takes* focus is also brought to the front
+    /// — the config's `autoraise`, and the axis that makes sloppy focus
+    /// usable on an overlapping desktop.
+    ///
+    /// Only the focus a pointer crossing hands out is governed by this.
+    /// A click still raises what it lands on, because that raise is the
+    /// click's, not the focus's; see [`Self::focus_client_with`].
+    pub fn set_raise_on_focus(&mut self, raise: bool) {
+        self.raise_on_focus = raise;
     }
 
     /// Selects the initial-placement policy for windows that request no
@@ -835,6 +861,21 @@ impl<B: Backend> WindowManager<B> {
             return false;
         }
         self.raise_client(id);
+        true
+    }
+
+    /// The other half of [`Self::raise_client_to_top`]: give a window
+    /// the keyboard and leave the stack exactly as it is.
+    ///
+    /// What a stacking desktop needs to type into a half-visible window
+    /// without covering the reference material in front of it. Unlike
+    /// the pointer-crossing path this ignores `autoraise` — a caller
+    /// asking for this by name has already decided.
+    pub fn focus_client_without_raising(&mut self, id: ClientId) -> bool {
+        if !self.clients.contains_key(id) {
+            return false;
+        }
+        self.focus_client_with(id, false);
         true
     }
 
@@ -1770,7 +1811,10 @@ impl<B: Backend> WindowManager<B> {
             SurfaceRef::Client(window) => self.window_index.get(&window).copied(),
         };
         if let Some(id) = id {
-            self.focus_client(id);
+            // The one focus in the crate that is not a click. `autoraise`
+            // exists for exactly this call: crossing a window on the way
+            // to somewhere else should not bury what the pointer left.
+            self.focus_client_with(id, self.raise_on_focus);
         }
     }
 
@@ -2947,7 +2991,20 @@ impl<B: Backend> WindowManager<B> {
         tracing::debug!(?id, "drag broke the maximized state");
     }
 
+    /// Focus `id` and bring it to the front — what a click means, and
+    /// what every caller that is not a bare pointer crossing wants.
     fn focus_client(&mut self, id: ClientId) {
+        self.focus_client_with(id, true);
+    }
+
+    /// Focus `id`, raising it only if `raise`.
+    ///
+    /// The raise used to be welded in here, which made "focus this
+    /// window" and "put this window on top" the same verb and left
+    /// focus-follows-mouse restacking the desktop as the pointer merely
+    /// crossed it. Splitting them costs one parameter and leaves every
+    /// existing caller bit-identical through [`Self::focus_client`].
+    fn focus_client_with(&mut self, id: ClientId, raise: bool) {
         if self.clients.get(id).is_some_and(|client| client.flags.contains(ClientFlags::NO_FOCUS)) {
             tracing::debug!(?id, "window rule refused focus");
             return;
@@ -2964,7 +3021,9 @@ impl<B: Backend> WindowManager<B> {
             // free whenever they already agree.
             if let Some(window) = self.clients.get(id).map(|client| client.window) {
                 self.backend.set_input_focus(window);
-                self.raise_client(id);
+                if raise {
+                    self.raise_client(id);
+                }
             }
             return;
         }
@@ -3003,7 +3062,9 @@ impl<B: Backend> WindowManager<B> {
         self.backend.ungrab_button_passive(window, MouseButton::Left);
         self.backend.set_input_focus(window);
         self.backend.publish_active_window(Some(window));
-        self.raise_client(id);
+        if raise {
+            self.raise_client(id);
+        }
         self.repaint_decoration(id);
     }
 
@@ -4124,6 +4185,127 @@ mod tests {
 
         assert!(wm.client(id1).unwrap().flags.contains(ClientFlags::FOCUSED));
         assert!(!wm.client(id2).unwrap().flags.contains(ClientFlags::FOCUSED));
+    }
+
+    /// The incident, in three windows: a palette on top of an editor,
+    /// and a pointer travelling past the editor on its way elsewhere.
+    /// With `autoraise` off the crossing must move the keyboard and
+    /// nothing else — the stack the user arranged stays arranged.
+    #[test]
+    fn sloppy_focus_without_autoraise_moves_focus_without_restacking() {
+        let mut backend = FakeBackend::new();
+        let editor = backend.create_window();
+        let palette = backend.create_window();
+        let mut wm = wm(backend);
+        wm.set_focus_policy(FocusPolicy::FocusFollowsMouse);
+        wm.set_raise_on_focus(false);
+        wm.dispatch(BackendEvent::MapRequest(editor));
+        wm.dispatch(BackendEvent::MapRequest(palette));
+        let editor_id = wm.client_for_window(editor).unwrap();
+        let editor_frame = wm.client(editor_id).unwrap().frame.unwrap();
+        let palette_id = wm.client_for_window(palette).unwrap();
+        let palette_frame = wm.client(palette_id).unwrap().frame.unwrap();
+        wm.backend_mut().raised_frames.clear();
+
+        wm.dispatch(BackendEvent::PointerEnter { surface: SurfaceRef::Frame(editor_frame) });
+
+        assert!(
+            wm.client(editor_id).unwrap().flags.contains(ClientFlags::FOCUSED),
+            "the crossing must still hand over the keyboard"
+        );
+        assert!(
+            wm.backend().raised_frames.is_empty(),
+            "no window may be restacked by a pointer merely crossing it: {:?}",
+            wm.backend().raised_frames
+        );
+        // And the palette is still the front window, which is the whole
+        // point: it is what the user would otherwise have to fish out.
+        assert_ne!(editor_frame, palette_frame);
+    }
+
+    /// The default is unchanged, so a session that sets nothing behaves
+    /// exactly as every release before this one did.
+    #[test]
+    fn sloppy_focus_raises_on_crossing_by_default() {
+        let mut backend = FakeBackend::new();
+        let editor = backend.create_window();
+        let palette = backend.create_window();
+        let mut wm = wm(backend);
+        wm.set_focus_policy(FocusPolicy::FocusFollowsMouse);
+        wm.dispatch(BackendEvent::MapRequest(editor));
+        wm.dispatch(BackendEvent::MapRequest(palette));
+        let editor_id = wm.client_for_window(editor).unwrap();
+        let editor_frame = wm.client(editor_id).unwrap().frame.unwrap();
+        wm.backend_mut().raised_frames.clear();
+
+        wm.dispatch(BackendEvent::PointerEnter { surface: SurfaceRef::Frame(editor_frame) });
+
+        assert_eq!(
+            wm.backend().raised_frames,
+            vec![editor_frame],
+            "autoraise defaults to on, and on means the crossing raises"
+        );
+    }
+
+    /// The raise belongs to the click, not to the focus. `autoraise`
+    /// governs pointer crossings only, and must not disarm a click.
+    #[test]
+    fn a_click_still_raises_with_autoraise_off() {
+        let mut backend = FakeBackend::new();
+        let editor = backend.create_window();
+        let palette = backend.create_window();
+        let mut wm = wm(backend);
+        wm.set_focus_policy(FocusPolicy::FocusFollowsMouse);
+        wm.set_raise_on_focus(false);
+        wm.dispatch(BackendEvent::MapRequest(editor));
+        wm.dispatch(BackendEvent::MapRequest(palette));
+        let editor_id = wm.client_for_window(editor).unwrap();
+        let editor_frame = wm.client(editor_id).unwrap().frame.unwrap();
+        wm.backend_mut().raised_frames.clear();
+
+        wm.dispatch(BackendEvent::PointerButton {
+            surface: SurfaceRef::Client(editor),
+            local: Point::new(20, 20),
+            button: MouseButton::Left,
+            pressed: true,
+            time_ms: 100,
+            mods: Modifiers::empty(),
+        });
+
+        assert_eq!(
+            wm.backend().raised_frames,
+            vec![editor_frame],
+            "a click raises what it lands on whatever autoraise says"
+        );
+    }
+
+    /// The counterpart to `raise_client_to_top`, which had no opposite
+    /// number before: keyboard without stack.
+    #[test]
+    fn focus_client_without_raising_is_focus_without_stack() {
+        let mut backend = FakeBackend::new();
+        let editor = backend.create_window();
+        let palette = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(editor));
+        wm.dispatch(BackendEvent::MapRequest(palette));
+        let editor_id = wm.client_for_window(editor).unwrap();
+        let palette_id = wm.client_for_window(palette).unwrap();
+        wm.backend_mut().raised_frames.clear();
+
+        assert!(wm.focus_client_without_raising(editor_id));
+
+        assert!(wm.client(editor_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+        assert!(!wm.client(palette_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+        assert!(
+            wm.backend().raised_frames.is_empty(),
+            "asking for focus by name must not move the stack: {:?}",
+            wm.backend().raised_frames
+        );
+        // A dead id is refused rather than panicking, exactly as
+        // `raise_client_to_top` refuses one.
+        wm.dispatch(BackendEvent::Destroyed(palette));
+        assert!(!wm.focus_client_without_raising(palette_id));
     }
 
     #[test]

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -137,6 +137,15 @@
 # forces it on, anything else forces it off).
 #focus_follows_mouse = false
 
+# Whether taking focus also brings the window to the front. This is a
+# separate axis from the focus policy above, not a third focus mode: a
+# click always raises what it lands on, so with click-to-focus this
+# changes nothing. It is focus-follows-mouse that needs it — with the
+# default `true`, the pointer raises every window it merely crosses on
+# its way somewhere else, burying whatever it started from. Set it to
+# false for sloppy focus that leaves the stack alone.
+#autoraise = true
+
 # UI scale factor for HiDPI displays: multiplies every pixel dimension
 # in the window chrome, dock, cursors, and terminal font as one system.
 # The CHONKSTEP_SCALE environment variable, when set to a valid value,

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -254,7 +254,9 @@ transfer; whole-desktop interaction policy does not. In particular,
 Hyprland's `follow_mouse` is logged and ignored—even when it is `1` in
 Omarchy's shipped defaults—so a stock Omarchy install retains
 chonkstep's click-to-focus default. Set `focus_follows_mouse = true` in
-chonkstep's own `config.toml` to opt in. Environment `XKB_DEFAULT_*`
+chonkstep's own `config.toml` to opt in. Focus-follows-mouse pairs with
+`autoraise = false`, which stops a window from being brought to the
+front merely because the pointer crossed it; a click still raises. Environment `XKB_DEFAULT_*`
 values remain more specific and win. If libxkbcommon rejects a
 configured map, the error is logged and the session falls back to the
 default usable keymap instead of aborting the login.


### PR DESCRIPTION
Fixes #82

## Root cause

`focus_client` raised on both of its exits — the `focused == Some(id)` re-assert and the normal path — so every caller got the raise whether or not it wanted one. `handle_pointer_enter`, which *is* the whole of focus-follows-mouse, is one of those callers. The event reaching it is a genuine boundary crossing, so under sloppy focus every window the pointer merely travelled across was pulled to the front. The palette you started from ends up buried under the editor you crossed, and nothing was clicked.

There was also no verb anywhere for the other half. `raise_client_to_top` (stack without keyboard) existed; keyboard without stack did not.

## Behavioral change

- `focus_client_with(id, raise)` holds the old body with both `raise_client` calls gated. `focus_client` is now `focus_client_with(id, true)`, so every existing caller is unchanged **by construction** rather than by inspection.
- `WindowManager::raise_on_focus`, beside `focus_policy` and set the same way — `Shell::apply_session_state`, next to `set_focus_policy`. Default `true`, so a session that sets nothing behaves exactly as every earlier release did.
- `handle_pointer_enter` is the only caller that consults it. **A click still raises**, because that raise belongs to the click, not to the focus — asserted, not assumed (test below).
- New config key `autoraise` (bool, default `true`), documented in `docs/config.example.toml` and `docs/hyprland-config.md` next to the `focus_follows_mouse` paragraph it pairs with.
- New public `focus_client_without_raising(id) -> bool`, the counterpart to `raise_client_to_top`, refusing a dead id the same way. It ignores `autoraise` on purpose: a caller asking for this by name has already decided.

Kept as a `bool` rather than an enum, per the issue's own reading of what can land now. If a raise *delay* is wanted later it is a strictly additive widening of this one field, and nothing outside `wm-core` has to move for it.

## Invariants and edge cases

- Click-to-focus is untouched in every configuration: with the default policy `handle_pointer_enter` returns before it reaches any of this.
- The `focused == Some(id)` re-assert path still raises when it is reached from a click and honours the policy when reached from a crossing — the `raise` parameter gives that for free, which is why the gate is inside that branch rather than around the call.
- `autoraise` with a non-boolean value keeps the default and warns, matching `focus_follows_mouse`'s contract of never breaking startup over a bad key.

## Tests added

Four in `wm-core`, over `FakeBackend::raised_frames` (which records raises in call order):

- `sloppy_focus_without_autoraise_moves_focus_without_restacking` — the incident itself: palette over editor, pointer crosses the editor, keyboard moves and **nothing** is restacked.
- `sloppy_focus_raises_on_crossing_by_default` — the default is still the old behaviour.
- `a_click_still_raises_with_autoraise_off` — the guarantee that this change is not allowed to break.
- `focus_client_without_raising_is_focus_without_stack` — the new verb, including the dead-id refusal.

Plus `autoraise_defaults_on_and_can_be_turned_off` in `wm-config` for the key and its bad-type fallback.

### Fails without the fix

Reverting only `handle_pointer_enter` to the raising form, rebuilding, and re-running:

```
test manager::tests::sloppy_focus_without_autoraise_moves_focus_without_restacking ... FAILED
no window may be restacked by a pointer merely crossing it: [FakeFrameId(3)]
test result: FAILED. 205 passed; 1 failed
```

## Commands run

```
cargo test -p wm-core                                        206 passed
cargo test -p wm-config -p chonk-shell                       all ok
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
```

`scripts/e2e.sh --headless` could not run on the development machine: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. The change is confined to `wm-core` focus logic and is default-preserving, and its venue is the unit suite above (the nested harness does not expose stack order through its window query); CI's `wayland` job has the full client set and covers the nested suite.

## Known limitations / follow-up

- A raise *delay* — raise only after the pointer rests for N ms — is the more refined answer for sloppy focus and is not implemented; it needs a timer in the core that does not exist yet. `autoraise` is the on/off version, and the field widens to carry a delay without any caller changing.
- `focus_client_without_raising` is public but not yet reachable from the Hyprland IPC dispatcher or the control socket; wiring a verb to it is a separate, additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
