### PR TITLE
Batch Wayland frame timing, hotplug, input, metrics, and capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ crate and both session binaries carry the same number.
 
 ### Fixed
 
+- **Monitor hot-plug now reconciles the live desktop instead of leaving
+  dark or phantom outputs.** Debounced DRM probes adopt new connectors,
+  withdraw unplugged output globals, rebuild output-management and gamma
+  state, reapply monitor rules, and rescue windows stranded on a removed
+  screen without restarting the session
+  ([#47](https://github.com/iconidentify/chonkstep/issues/47)).
+- **Touchscreens now reach native clients and compositor chrome.** The
+  Wayland seat advertises `wl_touch`, libinput touch slots keep their
+  down-time focus through motion/up, and taps or drags on titlebars, the
+  desktop, and shell furniture use the existing click machinery. Lid and
+  tablet-mode switch events are now named in the log instead of discarded
+  ([#48](https://github.com/iconidentify/chonkstep/issues/48)).
+- **Single-window screen sharing is now a compositor capability.** The
+  standard foreign-toplevel list and all three ext image-capture globals
+  expose output and toplevel sources, long-lived shm capture sessions
+  refresh constraints after geometry/scale changes and stop on source
+  removal, and window capture shares the existing offscreen pixel path
+  without bypassing the lock screen. Legacy wlr screencopy remains as a
+  fallback ([#51](https://github.com/iconidentify/chonkstep/issues/51)).
 - **Local socket connection storms can no longer grow compositor work
   without bound.** The Hyprland request/event sockets and native control
   socket retain at most 64 clients apiece, accept-and-close overflow with
@@ -78,6 +97,18 @@ crate and both session binaries carry the same number.
 
 ### Performance
 
+- **DRM composition is deadline-scheduled against predicted vblank.** A
+  per-output, time-based asymmetric render estimator delays steady-cadence
+  composition for fresher input, grows its safety margin after misses, and
+  keeps first/post-idle frames immediate. Synchronous preview readback now
+  runs after submission instead of widening the deadline path
+  ([#46](https://github.com/iconidentify/chonkstep/issues/46)).
+- **Frame performance is measurable in live and CI sessions.** Fixed-size
+  per-phase totals, maxima, and power-of-two dispatch/render histograms are
+  readable and resettable through the opt-in test door; the E2E harness
+  brackets visible and hidden workloads with them. An off-by-default
+  `profile` feature also enables ChonkStep and Smithay tracing spans
+  ([#49](https://github.com/iconidentify/chonkstep/issues/49)).
 - **The native control socket now builds desktop snapshots only on a
   semantic edge or readable request.** A cheap stamp covers window-manager
   state, output/workarea changes, the monitor under the pointer, and shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,6 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
+ "tracing",
 ]
 
 [[package]]
@@ -3315,6 +3316,7 @@ dependencies = [
  "chonk-hyprland-ipc",
  "chonk-shell",
  "chonk-xsettings",
+ "profiling",
  "smithay",
  "tiny-skia",
  "tracing",

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1148,6 +1148,26 @@ pub struct ProtocolPublishes {
     pub foreign_drag: u64,
 }
 
+/// Per-phase compositor timings returned by the opt-in test door. A read
+/// consumes the current bracket so callers can measure one interaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FrameStats {
+    pub dispatch_calls: u64,
+    pub dispatch_us: u128,
+    pub dispatch_max_us: u128,
+    pub input_us: u128,
+    pub shell_us: u128,
+    pub protocol_us: u128,
+    pub layout_us: u128,
+    pub render_calls: u64,
+    pub render_us: u128,
+    pub render_max_us: u128,
+    pub flush_us: u128,
+    pub ipc_us: u128,
+    pub dispatch_histogram: [u64; 16],
+    pub render_histogram: [u64; 16],
+}
+
 /// Entries retained by compositor protocol ledgers that participate in
 /// rendering, hit-testing, or idle-policy walks.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1322,6 +1342,38 @@ impl Door {
         })
     }
 
+    /// Reads and resets compositor frame/pass timings. Histogram buckets
+    /// use power-of-two microsecond ceilings and always contain 16 entries.
+    pub fn frame_stats(&mut self) -> Result<FrameStats, String> {
+        self.send("frame-stats")?;
+        let line = self.read_line()?;
+        if !line.starts_with("frame-stats ") {
+            return Err(format!("unexpected frame-stats reply: {line}"));
+        }
+        macro_rules! required {
+            ($name:literal) => {
+                field(&line, $name)
+                    .ok_or_else(|| format!("frame-stats reply has no {} field: {line}", $name))?
+            };
+        }
+        Ok(FrameStats {
+            dispatch_calls: required!("dispatch_calls="),
+            dispatch_us: required!("dispatch_us="),
+            dispatch_max_us: required!("dispatch_max_us="),
+            input_us: required!("input_us="),
+            shell_us: required!("shell_us="),
+            protocol_us: required!("protocol_us="),
+            layout_us: required!("layout_us="),
+            render_calls: required!("render_calls="),
+            render_us: required!("render_us="),
+            render_max_us: required!("render_max_us="),
+            flush_us: required!("flush_us="),
+            ipc_us: required!("ipc_us="),
+            dispatch_histogram: histogram_field(&line, "dispatch_hist=")?,
+            render_histogram: histogram_field(&line, "render_hist=")?,
+        })
+    }
+
     /// Exact Hyprland IPC source population from inside the
     /// compositor. Unlike `/proc/<pid>/fd`, this excludes independent
     /// render, D-Bus, XWayland, and child-process descriptor churn.
@@ -1440,6 +1492,21 @@ impl Door {
             }
         }
     }
+}
+
+fn histogram_field(line: &str, name: &str) -> Result<[u64; 16], String> {
+    let value = line
+        .split_whitespace()
+        .find_map(|part| part.strip_prefix(name))
+        .ok_or_else(|| format!("frame-stats reply has no {name} field: {line}"))?;
+    let values = value
+        .split(',')
+        .map(str::parse)
+        .collect::<Result<Vec<u64>, _>>()
+        .map_err(|error| format!("invalid {name} histogram in {line}: {error}"))?;
+    values
+        .try_into()
+        .map_err(|values: Vec<u64>| format!("{name} histogram has {} buckets instead of 16", values.len()))
 }
 
 /// Value of `key=` in a `key=value` word list, numerics only.
@@ -1649,6 +1716,16 @@ mod tests {
         let frame = parse_frame_line(line).unwrap();
         assert_eq!(frame.window, 3);
         assert!(!frame.mapped);
+    }
+
+    #[test]
+    fn frame_histograms_require_all_sixteen_buckets() {
+        let line = "frame-stats dispatch_hist=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15";
+        assert_eq!(
+            histogram_field(line, "dispatch_hist=").unwrap(),
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        );
+        assert!(histogram_field("frame-stats dispatch_hist=1,2", "dispatch_hist=").is_err());
     }
 
     /// The optional rows drop out without disturbing the order of the

--- a/crates/chonk-testkit/tests/hidden_surface_damage.rs
+++ b/crates/chonk-testkit/tests/hidden_surface_damage.rs
@@ -230,18 +230,31 @@ fn a_self_timed_client_on_a_parked_workspace_schedules_no_frames() {
 
     wait_for_animation(&session, &program, 30);
     session.door().barrier().expect("visible sample starts at a rendered boundary");
+    let _ = session.door().frame_stats().expect("visible timing bracket resets");
     let visible_start = rendered_frames(&session);
     let visible_target = animation_frame(&session.client_log(&program)).unwrap() + 60;
     wait_for_animation(&session, &program, visible_target);
     session.door().barrier().expect("visible sample ends at a rendered boundary");
+    let visible_stats = session.door().frame_stats().expect("visible timing bracket is readable");
     let visible_frames = rendered_frames(&session) - visible_start;
     assert!(
         visible_frames >= 50,
         "60 independently committed visible frames produced only {visible_frames} renders; compositor log:\n{}",
         session.log()
     );
+    assert!(
+        visible_stats.render_calls >= 50,
+        "the timing bracket counted only {} renders across 60 visible commits",
+        visible_stats.render_calls
+    );
+    assert_eq!(
+        visible_stats.render_histogram.iter().sum::<u64>(),
+        visible_stats.render_calls,
+        "every timed render belongs to exactly one histogram bucket"
+    );
 
     send_to_workspace_two(&mut session);
+    let _ = session.door().frame_stats().expect("hidden timing bracket resets");
     let hidden_start = rendered_frames(&session);
     let sample_commits = hidden_sample_commits();
     let cpu_start = process_cpu_ticks(session.compositor_pid()).expect("Linux process accounting is readable");
@@ -251,6 +264,10 @@ fn a_self_timed_client_on_a_parked_workspace_schedules_no_frames() {
         animation_frame(&session.client_log(&program)).filter(|frame| *frame >= hidden_target)
     })
     .unwrap_or_else(|error| panic!("{error}; client log:\n{}", session.client_log(&program)));
+    // `frame-stats` is itself an ordered test-door command. Do not use the
+    // rendering barrier here: barriers deliberately damage the backend, which
+    // would manufacture exactly one frame inside an otherwise idle sample.
+    let hidden_stats = session.door().frame_stats().expect("hidden timing bracket is readable");
     let cpu_ticks = process_cpu_ticks(session.compositor_pid())
         .expect("Linux process accounting remains readable")
         .saturating_sub(cpu_start);
@@ -267,6 +284,11 @@ fn a_self_timed_client_on_a_parked_workspace_schedules_no_frames() {
         "a parked client's {sample_commits}-commit burst scheduled {hidden_frames} invisible renders \
          (allowance {allowed_background_frames} with {static_clients} profiling surfaces); compositor log:\n{}",
         session.log()
+    );
+    assert!(
+        hidden_stats.render_calls <= allowed_background_frames as u64,
+        "frame-stats observed {} renders for a parked client (allowance {allowed_background_frames})",
+        hidden_stats.render_calls
     );
 }
 

--- a/crates/chonk-testkit/tests/wayland_globals.rs
+++ b/crates/chonk-testkit/tests/wayland_globals.rs
@@ -49,6 +49,10 @@ fn ordinary_desktop_globals_bind_successfully() {
         "xdg_system_bell_v1",
         "xdg_toplevel_tag_manager_v1",
         "zxdg_output_manager_v1",
+        "ext_foreign_toplevel_list_v1",
+        "ext_image_copy_capture_manager_v1",
+        "ext_output_image_capture_source_manager_v1",
+        "ext_foreign_toplevel_image_capture_source_manager_v1",
         "hyprland_toplevel_mapping_manager_v1",
         "hyprland_focus_grab_manager_v1",
     ] {

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -685,6 +685,67 @@ impl<B: Backend> WindowManager<B> {
             .unwrap_or(NO_MONITOR_FALLBACK)
     }
 
+    /// Re-homes windows whose physical monitor disappeared. The
+    /// backend updates its monitor list first, then calls this once per
+    /// departed rect; keeping the policy here makes X11 and Wayland
+    /// geometry obey the same rules if the X backend grows RandR
+    /// hotplug later.
+    pub fn rescue_clients_from_removed_monitor(&mut self, departed: Rect) {
+        let monitors = self.backend.monitors();
+        if monitors.is_empty() {
+            return;
+        }
+        let affected: Vec<ClientId> = self
+            .clients
+            .iter()
+            .filter_map(|(id, client)| {
+                let frame = client_frame_rect(client);
+                let center = Point::new(
+                    frame.pos.x + frame.size.w as i32 / 2,
+                    frame.pos.y + frame.size.h as i32 / 2,
+                );
+                let visible_somewhere = monitors.iter().any(|monitor| {
+                    let other = monitor.geometry;
+                    frame.pos.x < other.pos.x.saturating_add(other.size.w as i32)
+                        && other.pos.x < frame.pos.x.saturating_add(frame.size.w as i32)
+                        && frame.pos.y < other.pos.y.saturating_add(other.size.h as i32)
+                        && other.pos.y < frame.pos.y.saturating_add(frame.size.h as i32)
+                });
+                (departed.contains(center) || !visible_somewhere).then_some(id)
+            })
+            .collect();
+
+        for id in affected {
+            if self.clients.get(id).is_some_and(|client| client.flags.contains(ClientFlags::FULLSCREEN)) {
+                self.unfullscreen(id);
+            }
+            if self.clients.get(id).is_some_and(|client| {
+                client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V)
+            }) {
+                self.unmaximize(id);
+            }
+            let Some(client) = self.clients.get(id) else { continue };
+            let frame = client_frame_rect(client);
+            let center = Point::new(
+                frame.pos.x + frame.size.w as i32 / 2,
+                frame.pos.y + frame.size.h as i32 / 2,
+            );
+            let target = monitors
+                .iter()
+                .min_by_key(|monitor| squared_distance_to(monitor.geometry, center))
+                .map(|monitor| monitor.geometry)
+                .unwrap_or(NO_MONITOR_FALLBACK);
+            let frame_pos = placement::clamp_to(target, frame.size, frame.pos);
+            let Some(client) = self.clients.get_mut(id) else { continue };
+            client.geometry.pos = Point::new(
+                frame_pos.x + client.layout.client_offset.x,
+                frame_pos.y + client.layout.client_offset.y,
+            );
+            self.reflow_frame(id);
+            tracing::info!(?id, ?departed, ?target, "rescued window from a removed monitor");
+        }
+    }
+
     /// That monitor's workarea: the shell-reserved area if one was set
     /// for it, else its full geometry. The per-monitor twin of
     /// `usable_area`, and what maximize actually measures against.
@@ -7427,6 +7488,36 @@ mod tests {
     const RIGHT_HEAD: Rect = Rect { pos: Point { x: 800, y: 0 }, size: Size { w: 800, h: 600 } };
     /// The left head with a 40px dock strip carved off its bottom.
     const LEFT_WORKAREA: Rect = Rect { pos: Point { x: 0, y: 0 }, size: Size { w: 800, h: 560 } };
+
+    #[test]
+    fn removing_a_monitor_rescues_and_unmaximizes_its_windows() {
+        let mut backend = FakeBackend::new();
+        backend.set_monitors(dual_monitors());
+        let window = backend.create_window();
+        backend.set_geometry(window, Rect { pos: Point::new(1000, 100), size: Size::new(240, 180) });
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        let id = wm.client_for_window(window).unwrap();
+        wm.maximize(id, MaximizeDirections::FULL);
+        wm.fullscreen(id);
+
+        wm.backend_mut().set_monitors(vec![MonitorInfo {
+            geometry: LEFT_HEAD,
+            name: "left".to_string(),
+            primary: true,
+        }]);
+        wm.rescue_clients_from_removed_monitor(RIGHT_HEAD);
+
+        let client = wm.client(id).unwrap();
+        assert!(!client.flags.intersects(
+            ClientFlags::FULLSCREEN | ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V
+        ));
+        let frame = client_frame_rect(client);
+        assert!(LEFT_HEAD.contains(Point::new(
+            frame.pos.x + frame.size.w as i32 / 2,
+            frame.pos.y + frame.size.h as i32 / 2,
+        )));
+    }
 
     #[test]
     fn maximize_fills_the_workarea_of_the_monitor_holding_the_window() {

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -5,6 +5,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+default = []
+# Enables Smithay's existing `profiling` annotations and the matching
+# spans on ChonkStep's frame path. Off by default; fixed-size frame
+# counters remain available through the opt-in E2E door in every build.
+profile = ["dep:profiling", "profiling/profile-with-tracing"]
+
 # Linux-only by nature: on other hosts this crate compiles to an empty
 # library (see lib.rs's cfg gate) so the whole workspace still builds
 # and tests on a macOS dev machine.
@@ -39,6 +46,7 @@ chonk-xsettings = { path = "../chonk-xsettings" }
 # and `chonk-xsettings` use so the workspace resolves one copy.
 x11rb = "0.13"
 tracing = "0.1"
+profiling = { version = "1.0", default-features = false, optional = true }
 # The session-bus bridge for the two ecosystem idle-inhibition APIs
 # that cannot reach a Wayland compositor directly.  zbus is pure Rust;
 # its blocking facade owns a small off-loop service thread and sends

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -422,6 +422,59 @@ fn snapshot_window(
     render_offscreen(renderer, &elements, size, scale, Color32F::new(0.0, 0.0, 0.0, 0.0))
 }
 
+/// Captures one managed toplevel at its full compositor size for
+/// ext-image-copy-capture. This deliberately shares the preview path's
+/// surface-tree construction and offscreen readback while removing only
+/// its thumbnail downscale.
+pub(crate) fn capture_window_full(
+    comp: &mut Compositor,
+    window: WlWindowId,
+    paint_cursor: bool,
+) -> Option<DecorationBuffer> {
+    let (surface, viewport, factor) = {
+        let backend = comp.wm.backend();
+        let record = backend.windows.get(&window)?;
+        if !record.mapped || !record.surface.alive() {
+            return None;
+        }
+        (record.surface.wl_surface()?, record.content, backend.window_surface_scale(record))
+    };
+    let Compositor { wm, graphics, pointer_location, cursor_status, cursors, .. } = comp;
+    let renderer = graphics_renderer(graphics);
+    let mut elements = Vec::new();
+    if paint_cursor {
+        crate::renderer::push_cursor_elements(
+            &mut elements,
+            renderer,
+            wm.backend(),
+            *pointer_location,
+            cursor_status,
+            cursors,
+            viewport,
+        );
+    }
+    let surface_element_start = elements.len();
+    crate::renderer::push_surface_tree(
+        &mut elements,
+        renderer,
+        &surface,
+        SPoint::<i32, Physical>::from((0, 0)),
+        factor,
+        1.0,
+        Kind::Unspecified,
+    );
+    if elements.len() == surface_element_start {
+        return None;
+    }
+    render_offscreen(
+        renderer,
+        &elements,
+        viewport.size,
+        1.0,
+        Color32F::new(0.0, 0.0, 0.0, 0.0),
+    )
+}
+
 /// Draws `elements` into a fresh offscreen texture and downloads the
 /// result. `scale` must be the scale the elements were built at - the
 /// damage tracker re-derives each element's on-target geometry from

--- a/crates/wm-wayland/src/gamma.rs
+++ b/crates/wm-wayland/src/gamma.rs
@@ -596,6 +596,38 @@ pub(crate) fn note_session_resumed(gamma: &mut GammaControl) {
     }
 }
 
+/// Rebuilds the index-aligned hardware slots after connector hotplug.
+/// Existing controls become inert (their recorded object id owns no
+/// new slot), preventing a stale handle from programming a different
+/// CRTC that happened to inherit its old index.
+pub(crate) fn outputs_changed(
+    gamma: &mut GammaControl,
+    graphics: &crate::state::Graphics,
+    display_handle: &DisplayHandle,
+) {
+    let sizes = crate::session::gamma_ramp_sizes(graphics);
+    gamma.outputs = sizes
+        .into_iter()
+        .map(|size| OutputGamma {
+            size: size as usize,
+            owner: None,
+            original: None,
+            live: None,
+            pending: None,
+        })
+        .collect();
+    gamma.ctm_manager = None;
+    gamma.reprogram_after_vt_switch = false;
+    if gamma._global.is_none() && gamma.outputs.iter().any(|output| output.size > 0) {
+        gamma._global = Some(
+            display_handle.create_global::<Compositor, ZwlrGammaControlManagerV1, ()>(
+                GAMMA_CONTROL_VERSION,
+                (),
+            ),
+        );
+    }
+}
+
 /// Which entry of `Compositor::outputs` a `wl_output` names, or `None`
 /// for a resource that is not one of ours. Same derivation as
 /// `lock.rs` and `protocols.rs` use — the client named a specific

--- a/crates/wm-wayland/src/image_capture.rs
+++ b/crates/wm-wayland/src/image_capture.rs
@@ -1,0 +1,613 @@
+//! ext-image-copy-capture-v1 and its output/toplevel source factories.
+//!
+//! The protocol is deliberately shm-first: the four 32-bit formats the
+//! existing screencopy writer already understands are advertised, while
+//! dmabuf is omitted until the compositor can prove a zero-copy path. Both
+//! outputs and toplevels use the same GLES readback and shm conversion as
+//! `zwlr_screencopy_v1`; the long-lived session adds constraint updates and
+//! source lifetime tracking around that pixel path.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols::ext::image_capture_source::v1::server::{
+    ext_foreign_toplevel_image_capture_source_manager_v1::{
+        self, ExtForeignToplevelImageCaptureSourceManagerV1,
+    },
+    ext_image_capture_source_v1::{self, ExtImageCaptureSourceV1},
+    ext_output_image_capture_source_manager_v1::{self, ExtOutputImageCaptureSourceManagerV1},
+};
+use smithay::reexports::wayland_protocols::ext::image_copy_capture::v1::server::{
+    ext_image_copy_capture_cursor_session_v1::{self, ExtImageCopyCaptureCursorSessionV1},
+    ext_image_copy_capture_frame_v1::{self, ExtImageCopyCaptureFrameV1, FailureReason},
+    ext_image_copy_capture_manager_v1::{self, ExtImageCopyCaptureManagerV1},
+    ext_image_copy_capture_session_v1::{self, ExtImageCopyCaptureSessionV1},
+};
+use smithay::reexports::wayland_server::protocol::{wl_buffer::WlBuffer, wl_output, wl_shm};
+use smithay::reexports::wayland_server::{
+    backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+    WEnum,
+};
+use smithay::utils::{Clock, Monotonic, Transform};
+use smithay::wayland::foreign_toplevel_list::ForeignToplevelHandle;
+
+use wm_theme_api::{Rect, Size};
+
+use crate::state::{Compositor, WlWindowId};
+
+const VERSION: u32 = 1;
+
+#[derive(Clone, Debug)]
+enum CaptureTarget {
+    Output(String),
+    Toplevel(WlWindowId),
+}
+
+#[derive(Clone)]
+struct CaptureSourceData(Option<CaptureTarget>);
+
+struct SessionShared {
+    target: Option<CaptureTarget>,
+    paint_cursors: bool,
+    latest_constraints: Mutex<Option<Constraints>>,
+    frame_live: AtomicBool,
+    stopped: AtomicBool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Constraints {
+    size: Size,
+    /// Re-advertise even where the pixel dimensions happen to stay the
+    /// same: scale changes alter the source-to-buffer relationship.
+    scale_bits: u64,
+}
+
+struct SessionInstance {
+    resource: ExtImageCopyCaptureSessionV1,
+    shared: Arc<SessionShared>,
+}
+
+struct FrameState {
+    buffer: Option<WlBuffer>,
+    captured: bool,
+}
+
+struct FrameData {
+    shared: Arc<SessionShared>,
+    state: Mutex<FrameState>,
+}
+
+struct PendingCapture {
+    frame: ExtImageCopyCaptureFrameV1,
+    buffer: WlBuffer,
+    shared: Arc<SessionShared>,
+}
+
+struct CursorSessionData {
+    capture_session_created: AtomicBool,
+}
+
+pub(crate) struct ImageCapture {
+    sessions: Vec<SessionInstance>,
+    captures: Vec<PendingCapture>,
+}
+
+pub(crate) fn init(display: &DisplayHandle) -> ImageCapture {
+    let _copy = display.create_global::<Compositor, ExtImageCopyCaptureManagerV1, ()>(VERSION, ());
+    let _output =
+        display.create_global::<Compositor, ExtOutputImageCaptureSourceManagerV1, ()>(VERSION, ());
+    let _toplevel = display
+        .create_global::<Compositor, ExtForeignToplevelImageCaptureSourceManagerV1, ()>(
+            VERSION,
+            (),
+        );
+    tracing::info!(
+        version = VERSION,
+        "ext image-copy-capture and source managers advertised"
+    );
+    ImageCapture {
+        sessions: Vec::new(),
+        captures: Vec::new(),
+    }
+}
+
+/// Re-advertises constraints after resize/modeset, stops dead targets,
+/// then answers capture requests parked during protocol dispatch.
+pub(crate) fn refresh(comp: &mut Compositor) {
+    comp.image_capture
+        .sessions
+        .retain(|session| session.resource.is_alive());
+    let sessions: Vec<_> = comp
+        .image_capture
+        .sessions
+        .iter()
+        .map(|session| (session.resource.clone(), Arc::clone(&session.shared)))
+        .collect();
+    for (resource, shared) in sessions {
+        update_constraints(comp, &resource, &shared);
+    }
+
+    let pending = std::mem::take(&mut comp.image_capture.captures);
+    for capture in pending {
+        if !capture.frame.is_alive() {
+            continue;
+        }
+        if capture.shared.stopped.load(Ordering::Relaxed) {
+            capture.frame.failed(FailureReason::Stopped);
+            continue;
+        }
+        let Some(constraints) = target_constraints(comp, capture.shared.target.as_ref()) else {
+            stop_session(&capture.shared, None);
+            capture.frame.failed(FailureReason::Stopped);
+            continue;
+        };
+        if capture.shared.latest_constraints.lock().unwrap().as_ref() != Some(&constraints) {
+            capture.frame.failed(FailureReason::BufferConstraints);
+            continue;
+        }
+
+        // Never bypass the lock screen to read a toplevel's private surface
+        // tree. Output capture remains allowed and sees the ordinary locked
+        // scene through build_scene.
+        if matches!(capture.shared.target, Some(CaptureTarget::Toplevel(_)))
+            && comp.wm.backend().locked
+        {
+            capture.frame.failed(FailureReason::Unknown);
+            continue;
+        }
+        let pixels = match capture.shared.target.as_ref() {
+            Some(CaptureTarget::Output(name)) => comp
+                .outputs
+                .iter()
+                .find(|entry| entry.output.name() == *name)
+                .map(|entry| Rect::new(entry.position, entry.size))
+                .and_then(|region| {
+                    crate::protocols::capture_region(
+                        comp,
+                        region,
+                        Transform::Normal,
+                        capture.shared.paint_cursors,
+                    )
+                }),
+            Some(CaptureTarget::Toplevel(window)) => {
+                crate::capture::capture_window_full(comp, *window, capture.shared.paint_cursors)
+            }
+            None => None,
+        };
+        let Some(pixels) = pixels else {
+            capture.frame.failed(FailureReason::Unknown);
+            continue;
+        };
+        if let Err(error) = crate::protocols::write_capture(&capture.buffer, &pixels) {
+            tracing::warn!(%error, "ext image-copy-capture could not write the client buffer");
+            capture.frame.failed(FailureReason::BufferConstraints);
+            continue;
+        }
+
+        capture.frame.transform(wl_output::Transform::Normal);
+        capture
+            .frame
+            .damage(0, 0, pixels.width as i32, pixels.height as i32);
+        let stamp = Duration::from(Clock::<Monotonic>::new().now());
+        capture.frame.presentation_time(
+            (stamp.as_secs() >> 32) as u32,
+            stamp.as_secs() as u32,
+            stamp.subsec_nanos(),
+        );
+        capture.frame.ready();
+    }
+}
+
+fn target_constraints(comp: &Compositor, target: Option<&CaptureTarget>) -> Option<Constraints> {
+    match target? {
+        CaptureTarget::Output(name) => comp
+            .outputs
+            .iter()
+            .find(|entry| entry.output.name() == *name)
+            .filter(|entry| entry.size.w > 0 && entry.size.h > 0)
+            .map(|entry| Constraints {
+                size: entry.size,
+                scale_bits: entry.scale.to_bits(),
+            }),
+        CaptureTarget::Toplevel(window) => {
+            let backend = comp.wm.backend();
+            let record = backend
+                .windows
+                .get(window)
+                .filter(|record| record.mapped && record.surface.alive())?;
+            (record.content.size.w > 0 && record.content.size.h > 0).then(|| Constraints {
+                size: record.content.size,
+                scale_bits: backend.window_surface_scale(record).to_bits(),
+            })
+        }
+    }
+}
+
+fn update_constraints(
+    comp: &Compositor,
+    resource: &ExtImageCopyCaptureSessionV1,
+    shared: &Arc<SessionShared>,
+) {
+    if shared.stopped.load(Ordering::Relaxed) {
+        return;
+    }
+    let Some(constraints) = target_constraints(comp, shared.target.as_ref()) else {
+        stop_session(shared, Some(resource));
+        return;
+    };
+    let mut latest = shared.latest_constraints.lock().unwrap();
+    if latest.as_ref() == Some(&constraints) {
+        return;
+    }
+    *latest = Some(constraints);
+    drop(latest);
+    for format in [
+        wl_shm::Format::Argb8888,
+        wl_shm::Format::Xrgb8888,
+        wl_shm::Format::Abgr8888,
+        wl_shm::Format::Xbgr8888,
+    ] {
+        resource.shm_format(format);
+    }
+    resource.buffer_size(constraints.size.w, constraints.size.h);
+    resource.done();
+}
+
+fn stop_session(shared: &Arc<SessionShared>, resource: Option<&ExtImageCopyCaptureSessionV1>) {
+    if !shared.stopped.swap(true, Ordering::Relaxed) {
+        if let Some(resource) = resource {
+            resource.stopped();
+        }
+    }
+}
+
+fn create_session(
+    state: &mut Compositor,
+    data_init: &mut DataInit<'_, Compositor>,
+    id: New<ExtImageCopyCaptureSessionV1>,
+    target: Option<CaptureTarget>,
+    paint_cursors: bool,
+) {
+    let shared = Arc::new(SessionShared {
+        target,
+        paint_cursors,
+        latest_constraints: Mutex::new(None),
+        frame_live: AtomicBool::new(false),
+        stopped: AtomicBool::new(false),
+    });
+    let resource = data_init.init(id, Arc::clone(&shared));
+    state
+        .image_capture
+        .sessions
+        .push(SessionInstance { resource, shared });
+}
+
+impl GlobalDispatch<ExtOutputImageCaptureSourceManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ExtOutputImageCaptureSourceManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl Dispatch<ExtOutputImageCaptureSourceManagerV1, ()> for Compositor {
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        _resource: &ExtOutputImageCaptureSourceManagerV1,
+        request: ext_output_image_capture_source_manager_v1::Request,
+        _data: &(),
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_output_image_capture_source_manager_v1::Request::CreateSource {
+                source,
+                output,
+            } => {
+                let target = Output::from_resource(&output)
+                    .map(|output| CaptureTarget::Output(output.name()));
+                data_init.init(source, CaptureSourceData(target));
+            }
+            ext_output_image_capture_source_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl GlobalDispatch<ExtForeignToplevelImageCaptureSourceManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ExtForeignToplevelImageCaptureSourceManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl Dispatch<ExtForeignToplevelImageCaptureSourceManagerV1, ()> for Compositor {
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        _resource: &ExtForeignToplevelImageCaptureSourceManagerV1,
+        request: ext_foreign_toplevel_image_capture_source_manager_v1::Request,
+        _data: &(),
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_foreign_toplevel_image_capture_source_manager_v1::Request::CreateSource {
+                source,
+                toplevel_handle,
+            } => {
+                let target = ForeignToplevelHandle::from_resource(&toplevel_handle)
+                    .and_then(|handle| handle.user_data().get::<WlWindowId>().copied())
+                    .map(CaptureTarget::Toplevel);
+                data_init.init(source, CaptureSourceData(target));
+            }
+            ext_foreign_toplevel_image_capture_source_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtImageCaptureSourceV1, CaptureSourceData> for Compositor {
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        _resource: &ExtImageCaptureSourceV1,
+        request: ext_image_capture_source_v1::Request,
+        _data: &CaptureSourceData,
+        _handle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        let _ = request;
+    }
+}
+
+impl GlobalDispatch<ExtImageCopyCaptureManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ExtImageCopyCaptureManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureManagerV1, ()> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ExtImageCopyCaptureManagerV1,
+        request: ext_image_copy_capture_manager_v1::Request,
+        _data: &(),
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_image_copy_capture_manager_v1::Request::CreateSession {
+                session,
+                source,
+                options,
+            } => {
+                let (paint_cursors, valid) = match options {
+                    WEnum::Value(options) => (
+                        options.contains(ext_image_copy_capture_manager_v1::Options::PaintCursors),
+                        true,
+                    ),
+                    WEnum::Unknown(_) => (false, false),
+                };
+                let target = source
+                    .data::<CaptureSourceData>()
+                    .and_then(|data| data.0.clone());
+                create_session(state, data_init, session, target, paint_cursors);
+                if !valid {
+                    resource.post_error(
+                        ext_image_copy_capture_manager_v1::Error::InvalidOption,
+                        "unknown image-copy-capture option",
+                    );
+                }
+            }
+            ext_image_copy_capture_manager_v1::Request::CreatePointerCursorSession {
+                session,
+                ..
+            } => {
+                data_init.init(
+                    session,
+                    CursorSessionData {
+                        capture_session_created: AtomicBool::new(false),
+                    },
+                );
+            }
+            ext_image_copy_capture_manager_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureSessionV1, Arc<SessionShared>> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ExtImageCopyCaptureSessionV1,
+        request: ext_image_copy_capture_session_v1::Request,
+        data: &Arc<SessionShared>,
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_image_copy_capture_session_v1::Request::CreateFrame { frame } => {
+                if data.frame_live.swap(true, Ordering::Relaxed) {
+                    resource.post_error(
+                        ext_image_copy_capture_session_v1::Error::DuplicateFrame,
+                        "the previous capture frame is still alive",
+                    );
+                    return;
+                }
+                data_init.init(
+                    frame,
+                    FrameData {
+                        shared: Arc::clone(data),
+                        state: Mutex::new(FrameState {
+                            buffer: None,
+                            captured: false,
+                        }),
+                    },
+                );
+            }
+            ext_image_copy_capture_session_v1::Request::Destroy => {
+                state
+                    .image_capture
+                    .sessions
+                    .retain(|session| &session.resource != resource);
+            }
+            _ => {}
+        }
+    }
+
+    fn destroyed(
+        state: &mut Self,
+        _client: ClientId,
+        resource: &ExtImageCopyCaptureSessionV1,
+        _data: &Arc<SessionShared>,
+    ) {
+        state
+            .image_capture
+            .sessions
+            .retain(|session| &session.resource != resource);
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureFrameV1, FrameData> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ExtImageCopyCaptureFrameV1,
+        request: ext_image_copy_capture_frame_v1::Request,
+        data: &FrameData,
+        _handle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        let mut frame = data.state.lock().unwrap();
+        match request {
+            ext_image_copy_capture_frame_v1::Request::Destroy => {
+                state
+                    .image_capture
+                    .captures
+                    .retain(|capture| &capture.frame != resource);
+                data.shared.frame_live.store(false, Ordering::Relaxed);
+            }
+            ext_image_copy_capture_frame_v1::Request::AttachBuffer { buffer } => {
+                if frame.captured {
+                    resource.post_error(
+                        ext_image_copy_capture_frame_v1::Error::AlreadyCaptured,
+                        "capture has already been requested for this frame",
+                    );
+                } else {
+                    frame.buffer = Some(buffer);
+                }
+            }
+            ext_image_copy_capture_frame_v1::Request::DamageBuffer {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                if frame.captured {
+                    resource.post_error(
+                        ext_image_copy_capture_frame_v1::Error::AlreadyCaptured,
+                        "capture has already been requested for this frame",
+                    );
+                } else if x < 0 || y < 0 || width <= 0 || height <= 0 {
+                    resource.post_error(
+                        ext_image_copy_capture_frame_v1::Error::InvalidBufferDamage,
+                        "buffer damage must have non-negative origin and positive size",
+                    );
+                }
+                // Full-frame readback is intentional, so valid client damage
+                // is accepted but needs no retained region.
+            }
+            ext_image_copy_capture_frame_v1::Request::Capture => {
+                if frame.captured {
+                    resource.post_error(
+                        ext_image_copy_capture_frame_v1::Error::AlreadyCaptured,
+                        "capture has already been requested for this frame",
+                    );
+                    return;
+                }
+                let Some(buffer) = frame.buffer.clone() else {
+                    resource.post_error(
+                        ext_image_copy_capture_frame_v1::Error::NoBuffer,
+                        "capture requires an attached buffer",
+                    );
+                    return;
+                };
+                frame.captured = true;
+                state.image_capture.captures.push(PendingCapture {
+                    frame: resource.clone(),
+                    buffer,
+                    shared: Arc::clone(&data.shared),
+                });
+                state.wm.backend_mut().mark_damaged();
+            }
+            _ => {}
+        }
+    }
+
+    fn destroyed(
+        state: &mut Self,
+        _client: ClientId,
+        resource: &ExtImageCopyCaptureFrameV1,
+        data: &FrameData,
+    ) {
+        state
+            .image_capture
+            .captures
+            .retain(|capture| &capture.frame != resource);
+        data.shared.frame_live.store(false, Ordering::Relaxed);
+    }
+}
+
+impl Dispatch<ExtImageCopyCaptureCursorSessionV1, CursorSessionData> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ExtImageCopyCaptureCursorSessionV1,
+        request: ext_image_copy_capture_cursor_session_v1::Request,
+        data: &CursorSessionData,
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            ext_image_copy_capture_cursor_session_v1::Request::GetCaptureSession { session } => {
+                if data.capture_session_created.swap(true, Ordering::Relaxed) {
+                    resource.post_error(
+                        ext_image_copy_capture_cursor_session_v1::Error::DuplicateSession,
+                        "cursor capture session already created",
+                    );
+                    return;
+                }
+                // Separate cursor-image streams are optional. Create an
+                // immediately stopped base session so clients get a complete
+                // lifecycle instead of an uninitialised object.
+                create_session(state, data_init, session, None, false);
+            }
+            ext_image_copy_capture_cursor_session_v1::Request::Destroy => {}
+            _ => {}
+        }
+    }
+}

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -58,15 +58,15 @@
 //! it.
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use smithay::backend::input::{
     AbsolutePositionEvent, Axis, AxisSource, ButtonState, Event, GestureBeginEvent, GestureEndEvent,
     GesturePinchUpdateEvent as BackendPinchUpdateEvent, GestureSwipeUpdateEvent as BackendSwipeUpdateEvent,
-    Device, DeviceCapability, InputBackend, InputEvent, KeyState, KeyboardKeyEvent, MouseButton as InputMouseButton, PointerAxisEvent,
-    PointerButtonEvent, PointerMotionEvent, ProximityState, TabletToolButtonEvent,
-    TabletToolDescriptor, TabletToolEvent, TabletToolProximityEvent, TabletToolTipEvent,
-    TabletToolTipState,
+    Device, DeviceCapability, InputBackend, InputEvent, KeyState, KeyboardKeyEvent, MouseButton as InputMouseButton,
+    PointerAxisEvent, PointerButtonEvent, PointerMotionEvent, ProximityState, SwitchToggleEvent,
+    TabletToolButtonEvent, TabletToolDescriptor, TabletToolEvent, TabletToolProximityEvent,
+    TabletToolTipEvent, TabletToolTipState, TouchEvent,
 };
 use smithay::desktop::utils::under_from_surface_tree;
 use smithay::desktop::WindowSurfaceType;
@@ -76,6 +76,7 @@ use smithay::input::pointer::{
     GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent, MotionEvent,
     RelativeMotionEvent,
 };
+use smithay::input::touch::{DownEvent as TouchDown, MotionEvent as TouchMotion, UpEvent as TouchUp};
 use smithay::input::{Seat, SeatHandler};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point as LogicalPoint, SERIAL_COUNTER};
@@ -151,6 +152,18 @@ struct InputState {
     /// domain underneath it. Entries leave on the matching physical
     /// proximity-out and the whole set is drained on lock/unlock.
     active_tablet_tools: HashSet<TabletToolDescriptor>,
+    /// Compositor-owned touch targets, latched per slot from down until
+    /// up just like wl_touch's implicit grab. Client surfaces are
+    /// latched by Smithay itself; this parallel map exists only so a
+    /// finger dragging titlebar or shell chrome keeps reaching the
+    /// object it landed on after it moves outside that object's rect.
+    active_touches: HashMap<smithay::backend::input::TouchSlot, TouchRoute>,
+}
+
+#[derive(Clone, Copy)]
+struct TouchRoute {
+    target: PressTarget,
+    position: Point,
 }
 
 #[derive(Clone, Copy)]
@@ -343,6 +356,7 @@ pub(crate) fn clear_implicit_grab(seat: &Seat<Compositor>) {
 /// interrupted it.
 pub(crate) fn resynchronise_input_after_resume(state: &mut Compositor) {
     let seat = state.seat.clone();
+    cancel_active_touches(state);
     let suppressed_keys = with_input(&seat, reset_resume_bookkeeping);
 
     if let Some(keyboard) = seat.get_keyboard() {
@@ -436,6 +450,7 @@ fn release_stale_pressed_keys<D: SeatHandler + 'static>(
 pub(crate) fn reset_client_input_focus(state: &mut Compositor) {
     let seat = state.seat.clone();
     let time = state.start_time.elapsed().as_millis() as u32;
+    cancel_active_touches(state);
     let tools = with_input(&seat, |input| std::mem::take(&mut input.active_tablet_tools));
     let tablet_seat = seat.tablet_seat();
     for descriptor in tools {
@@ -634,6 +649,9 @@ enum LockedInputRoute {
     /// Tablet motion resolves through the lock-aware scene hit-test;
     /// buttons use the tool focus that motion established or no focus.
     TabletHitTest,
+    /// Touch down resolves through the same lock-aware scene hit-test;
+    /// Smithay then latches that surface for the life of the slot.
+    TouchHitTest,
 }
 
 impl InputFamily {
@@ -678,21 +696,21 @@ impl InputFamily {
                 | Self::PointerButton
                 | Self::PointerAxis
                 | Self::Gesture
+                | Self::Touch
                 | Self::TabletTool
         )
     }
 
     fn locked_route(self) -> LockedInputRoute {
         match self {
-            Self::DeviceLifecycle | Self::Touch | Self::Switch | Self::Special => {
-                LockedInputRoute::NoClientDelivery
-            }
+            Self::DeviceLifecycle | Self::Switch | Self::Special => LockedInputRoute::NoClientDelivery,
             Self::Keyboard => LockedInputRoute::KeyboardFilter,
             Self::PointerMotion => LockedInputRoute::PointerMotionHandler,
             Self::PointerButton | Self::PointerAxis | Self::Gesture => {
                 LockedInputRoute::PointerFocus
             }
             Self::TabletTool => LockedInputRoute::TabletHitTest,
+            Self::Touch => LockedInputRoute::TouchHitTest,
         }
     }
 }
@@ -849,15 +867,198 @@ pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event
         InputEvent::TabletToolProximity { event } => on_tablet_proximity::<I>(state, event),
         InputEvent::TabletToolTip { event } => on_tablet_tip::<I>(state, event),
         InputEvent::TabletToolButton { event } => on_tablet_button::<I>(state, event),
-        // Touch and switch devices remain represented in the device
-        // registry above; their protocol/event policy is independent.
-        InputEvent::TouchDown { .. }
-        | InputEvent::TouchMotion { .. }
-        | InputEvent::TouchUp { .. }
-        | InputEvent::TouchCancel { .. }
-        | InputEvent::TouchFrame { .. }
-        | InputEvent::SwitchToggle { .. }
-        | InputEvent::Special(_) => {}
+        InputEvent::TouchDown { event } => on_touch_down::<I>(state, event),
+        InputEvent::TouchMotion { event } => on_touch_motion::<I>(state, event),
+        InputEvent::TouchUp { event } => on_touch_up::<I>(state, event),
+        InputEvent::TouchCancel { event: _ } => on_touch_cancel(state),
+        InputEvent::TouchFrame { event: _ } => on_touch_frame(state),
+        InputEvent::SwitchToggle { event } => {
+            tracing::info!(switch = ?event.switch(), state = ?event.state(), "input switch toggled");
+        }
+        InputEvent::Special(_) => {}
+    }
+}
+
+// -- touch --------------------------------------------------------------
+
+fn touch_position<I: InputBackend, E: AbsolutePositionEvent<I>>(
+    state: &Compositor,
+    event: &E,
+) -> LogicalPoint<f64, Logical> {
+    let size = state.wm.backend().output_size;
+    event.position_transformed((size.w as i32, size.h as i32).into())
+}
+
+fn on_touch_down<I: InputBackend>(state: &mut Compositor, event: I::TouchDownEvent) {
+    let Some(touch) = state.seat.get_touch() else {
+        return;
+    };
+    let position = touch_position::<I, _>(state, &event);
+    let at = Point::new(position.x.floor() as i32, position.y.floor() as i32);
+    let hit = hit_at(state.wm.backend(), at, position);
+    let focus = client_focus(&hit);
+    let serial = SERIAL_COUNTER.next_serial();
+    let slot = event.slot();
+    touch.down(
+        state,
+        focus,
+        &TouchDown { slot, location: position, serial, time: event.time_msec() },
+    );
+
+    if !state.wm.backend().locked {
+        let target = press_target(&hit);
+        with_input(&state.seat.clone(), |input| {
+            input.active_touches.insert(slot, TouchRoute { target, position: at });
+        });
+        route_touch_button(state, target, at, event.time_msec(), serial, true);
+    }
+    state.wm.backend_mut().mark_damaged();
+}
+
+fn on_touch_motion<I: InputBackend>(state: &mut Compositor, event: I::TouchMotionEvent) {
+    let Some(touch) = state.seat.get_touch() else {
+        return;
+    };
+    let position = touch_position::<I, _>(state, &event);
+    let at = Point::new(position.x.floor() as i32, position.y.floor() as i32);
+    let focus = client_focus(&hit_at(state.wm.backend(), at, position));
+    let slot = event.slot();
+    touch.motion(state, focus, &TouchMotion { slot, location: position, time: event.time_msec() });
+
+    let route = with_input(&state.seat.clone(), |input| {
+        input.active_touches.get_mut(&slot).map(|route| {
+            route.position = at;
+            *route
+        })
+    });
+    if let Some(route) = route {
+        route_touch_motion(state, route.target, at);
+    }
+    state.wm.backend_mut().mark_damaged();
+}
+
+fn on_touch_up<I: InputBackend>(state: &mut Compositor, event: I::TouchUpEvent) {
+    let Some(touch) = state.seat.get_touch() else {
+        return;
+    };
+    let serial = SERIAL_COUNTER.next_serial();
+    let slot = event.slot();
+    touch.up(state, &TouchUp { slot, serial, time: event.time_msec() });
+    let route = with_input(&state.seat.clone(), |input| input.active_touches.remove(&slot));
+    if let Some(route) = route {
+        route_touch_button(state, route.target, route.position, event.time_msec(), serial, false);
+    }
+    state.wm.backend_mut().mark_damaged();
+}
+
+fn on_touch_cancel(state: &mut Compositor) {
+    cancel_active_touches(state);
+}
+
+fn on_touch_frame(state: &mut Compositor) {
+    if let Some(touch) = state.seat.get_touch() {
+        touch.frame(state);
+    }
+}
+
+fn cancel_active_touches(state: &mut Compositor) {
+    if let Some(touch) = state.seat.get_touch() {
+        touch.cancel(state);
+    }
+    let routes = with_input(&state.seat.clone(), |input| {
+        std::mem::take(&mut input.active_touches).into_values().collect::<Vec<_>>()
+    });
+    let time = state.start_time.elapsed().as_millis() as u32;
+    for route in routes {
+        route_touch_button(
+            state,
+            route.target,
+            route.position,
+            time,
+            SERIAL_COUNTER.next_serial(),
+            false,
+        );
+    }
+}
+
+/// Mirrors the compositor-owned half of a left pointer button without
+/// synthesising wl_pointer events. Native clients receive the real
+/// wl_touch stream above; wm-core still needs the press to focus a
+/// managed client, and frame/shell/root chrome needs its ordinary click
+/// machinery to keep buttons and titlebar drags usable by touch.
+fn route_touch_button(
+    state: &mut Compositor,
+    target: PressTarget,
+    at: Point,
+    time_ms: u32,
+    serial: smithay::utils::Serial,
+    pressed: bool,
+) {
+    let mods = state
+        .seat
+        .get_keyboard()
+        .map(|keyboard| combo_modifiers(&keyboard.modifier_state()))
+        .unwrap_or_else(Modifiers::empty);
+    let backend = state.wm.backend_mut();
+    match target {
+        PressTarget::Shell(shell) => {
+            if let Some(record) = backend.shells.get(&shell) {
+                backend.shell_clicks.push_back((shell, local_to(at, record.geometry.pos), MouseButton::Left, pressed));
+            }
+        }
+        PressTarget::Frame(frame) => {
+            if let Some(record) = backend.frames.get(&frame) {
+                backend.queue(WmEvent::PointerButton {
+                    surface: SurfaceRef::Frame(frame),
+                    local: local_to(at, record.geometry.pos),
+                    button: MouseButton::Left,
+                    pressed,
+                    time_ms,
+                    mods,
+                });
+            }
+        }
+        PressTarget::Content(window) => {
+            let local = backend.windows.get(&window).map(|record| local_to(at, record.content.pos)).unwrap_or(at);
+            backend.queue(WmEvent::PointerButton {
+                surface: SurfaceRef::Client(window),
+                local,
+                button: MouseButton::Left,
+                pressed,
+                time_ms,
+                mods,
+            });
+        }
+        PressTarget::Layer(_) | PressTarget::Ime => {}
+        PressTarget::Root => backend.shell_clicks.push_back((ROOT_SHELL, at, MouseButton::Left, pressed)),
+    }
+    if pressed && !state.focus_grab.is_active() {
+        match target {
+            PressTarget::Layer(layer) => claim_on_demand_focus(state, layer, serial),
+            PressTarget::Ime => {}
+            _ => release_on_demand_focus(state, serial),
+        }
+    }
+}
+
+fn route_touch_motion(state: &mut Compositor, target: PressTarget, at: Point) {
+    let backend = state.wm.backend_mut();
+    match target {
+        PressTarget::Shell(shell) => {
+            if let Some(record) = backend.shells.get(&shell) {
+                backend.shell_motions.push_back((shell, local_to(at, record.geometry.pos)));
+            }
+            backend.queue(WmEvent::PointerMotion { root: at, surface_local: None });
+        }
+        PressTarget::Frame(frame) => {
+            let local = backend.frames.get(&frame).map(|record| local_to(at, record.geometry.pos));
+            backend.queue(WmEvent::PointerMotion {
+                root: at,
+                surface_local: local.map(|point| (SurfaceRef::Frame(frame), point)),
+            });
+        }
+        PressTarget::Root => backend.queue(WmEvent::PointerMotion { root: at, surface_local: None }),
+        PressTarget::Content(_) | PressTarget::Layer(_) | PressTarget::Ime => {}
     }
 }
 
@@ -1338,6 +1539,22 @@ fn confine_to_outputs(monitors: &[MonitorInfo], position: LogicalPoint<f64, Logi
     // `Compositor::outputs`); leaving the position untouched is still
     // better than snapping it to the origin.
     best.map(|(_, point)| point).unwrap_or(position)
+}
+
+/// Moves a saved pointer off a departed monitor before the next input
+/// event. Without this, keyboard-driven actions continue targeting a
+/// coordinate that no output can display until the mouse is moved.
+pub(crate) fn reconcile_pointer_after_output_change(state: &mut Compositor) {
+    if state.wm.backend().monitors.is_empty() {
+        return;
+    }
+    let position = confine_to_outputs(&state.wm.backend().monitors, state.pointer_location);
+    if position != state.pointer_location {
+        let time = state.start_time.elapsed().as_millis() as u32;
+        pointer_moved(state, position, time, None);
+    } else {
+        sync_pointer_focus(state);
+    }
 }
 
 /// The shared motion path: hover/crossing bookkeeping, WM/shell queue
@@ -2954,7 +3171,7 @@ mod tests {
             (PointerButton, true, PointerFocus),
             (PointerAxis, true, PointerFocus),
             (Gesture, true, PointerFocus),
-            (Touch, false, NoClientDelivery),
+            (Touch, true, TouchHitTest),
             (TabletTool, true, TabletHitTest),
             (Switch, false, NoClientDelivery),
             (Special, false, NoClientDelivery),

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -41,6 +41,7 @@ mod hyprland_ipc;
 // the honest nested answer.
 mod gamma;
 mod idle;
+mod image_capture;
 mod inhibit_bus;
 mod input;
 mod layers;

--- a/crates/wm-wayland/src/output_mgmt.rs
+++ b/crates/wm-wayland/src/output_mgmt.rs
@@ -116,8 +116,9 @@ struct Manager {
 }
 
 /// One `zwlr_output_head_v1` belonging to one manager, for one entry of
-/// `Compositor::outputs` (same index — outputs are never removed, so
-/// the index is stable for the life of the session).
+/// `Compositor::outputs`. A connector-set change retires every existing
+/// head before rebuilding this index-aligned list, so an index is stable
+/// only until the next structural update.
 struct HeadInstance {
     index: usize,
     resource: ZwlrOutputHeadV1,
@@ -128,6 +129,7 @@ struct HeadInstance {
 /// The publishable state of one output, for change detection.
 #[derive(Clone, PartialEq)]
 struct HeadSnapshot {
+    name: String,
     position: Point,
     scale: f64,
     current_mode: usize,
@@ -233,8 +235,15 @@ fn publish(comp: &mut Compositor) {
     // Vec here made a persistent `kanshi`/`wlr-randr` connection pay
     // one allocation and free for every unrelated client commit. The
     // baseline is rewritten in place only on the rare changed path.
-    let changed = comp.output_mgmt.dirty
+    let structural = comp.output_mgmt.dirty
         && (comp.outputs.len() != comp.output_mgmt.published.len()
+            || comp
+                .outputs
+                .iter()
+                .zip(&comp.output_mgmt.published)
+                .any(|(entry, previous)| entry.output.name() != previous.name));
+    let changed = comp.output_mgmt.dirty
+        && (structural
             || comp
                 .outputs
                 .iter()
@@ -261,7 +270,23 @@ fn publish(comp: &mut Compositor) {
             manager.resource.done(serial);
             continue;
         }
-        if changed {
+        if structural {
+            // Head resource data carries the output index. Once a connector
+            // disappears, all later indices shift, so retire the complete
+            // advertised set and mint a fresh, correctly indexed one. The
+            // serial bump above cancels configurations made against the old
+            // set.
+            for head in manager.heads.drain(..) {
+                for mode in head.modes {
+                    mode.finished();
+                }
+                head.resource.finished();
+            }
+            for (index, entry) in outputs.iter().enumerate() {
+                announce_head(&display_handle, manager, index, entry);
+            }
+            manager.resource.done(serial);
+        } else if changed {
             for head in &manager.heads {
                 let Some(entry) = outputs.get(head.index) else { continue };
                 let Some(previous) = output_mgmt.published.get(head.index) else { continue };
@@ -278,6 +303,7 @@ fn publish(comp: &mut Compositor) {
 
 fn head_snapshot(entry: &crate::state::OutputEntry) -> HeadSnapshot {
     HeadSnapshot {
+        name: entry.output.name(),
         position: entry.position,
         scale: entry.scale,
         current_mode: current_mode_index(entry),

--- a/crates/wm-wayland/src/protocols.rs
+++ b/crates/wm-wayland/src/protocols.rs
@@ -150,6 +150,9 @@ use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_scre
 use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::{
     self, ZwlrScreencopyManagerV1,
 };
+use smithay::wayland::foreign_toplevel_list::{
+    ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
+};
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_shm;
@@ -206,6 +209,11 @@ const BYTES_PER_PIXEL: usize = 4;
 /// login session's protocol dispatch has no unreachable panic in it —
 /// the same call `dmabuf.rs` makes for the same reason.
 pub(crate) struct ProtocolState {
+    /// Standard, read-only toplevel list used by the ext capture-source
+    /// factory. The wlr management protocol below remains available for
+    /// taskbars which also need window-control requests.
+    ext_list: ForeignToplevelListState,
+    ext_toplevels: HashMap<WlWindowId, ForeignToplevelHandle>,
     /// Live `zwlr_foreign_toplevel_manager_v1` instances. A manager that
     /// sent `stop` is dropped from here (it wants no further *new*
     /// toplevels) while the handles it already owns keep updating,
@@ -375,6 +383,8 @@ pub(crate) fn init(display_handle: &DisplayHandle) -> ProtocolState {
         "wlr protocols advertised"
     );
     ProtocolState {
+        ext_list: ForeignToplevelListState::new::<Compositor>(display_handle),
+        ext_toplevels: HashMap::new(),
         managers: Vec::new(),
         toplevels: HashMap::new(),
         minimize_requests: Vec::new(),
@@ -392,11 +402,67 @@ pub(crate) fn refresh(comp: &mut Compositor) {
     comp.notice_wm_protocol_changes();
     let new_manager = comp.protocols.managers.iter().any(|manager| !manager.announced);
     if comp.foreign_toplevel_dirty || new_manager {
+        sync_ext_toplevels(comp);
         sync_toplevels(comp);
         comp.foreign_toplevel_dirty = false;
     }
     service_captures(comp);
 }
+
+/// Keeps ext-foreign-toplevel-list in step with the same authoritative
+/// window ledger as the older wlr management protocol. Capture-source
+/// objects recover the compositor window id from each handle's user data.
+fn sync_ext_toplevels(comp: &mut Compositor) {
+    let snapshots: Vec<(WlWindowId, String, String)> = comp
+        .wm
+        .clients()
+        .map(|(_, client)| {
+            let app_id = comp
+                .wm
+                .backend()
+                .windows
+                .get(&client.window)
+                .and_then(|record| record.app_id.clone())
+                .unwrap_or_else(|| client.class.clone());
+            (client.window, client.title.clone(), app_id)
+        })
+        .collect();
+    let live: HashSet<WlWindowId> = snapshots.iter().map(|(window, _, _)| *window).collect();
+
+    let ProtocolState { ext_list, ext_toplevels, .. } = &mut comp.protocols;
+    ext_toplevels.retain(|window, handle| {
+        if live.contains(window) {
+            true
+        } else {
+            handle.send_closed();
+            false
+        }
+    });
+    ext_list.cleanup_closed_handles();
+
+    for (window, title, app_id) in snapshots {
+        if let Some(handle) = ext_toplevels.get(&window) {
+            let changed = handle.title() != title || handle.app_id() != app_id;
+            handle.send_title(&title);
+            handle.send_app_id(&app_id);
+            if changed {
+                handle.send_done();
+            }
+            continue;
+        }
+        let handle = ext_list.new_toplevel::<Compositor>(title, app_id);
+        handle.user_data().insert_if_missing(|| window);
+        ext_toplevels.insert(window, handle);
+    }
+}
+
+impl ForeignToplevelListHandler for Compositor {
+    fn foreign_toplevel_list_state(&mut self) -> &mut ForeignToplevelListState {
+        &mut self.protocols.ext_list
+    }
+}
+
+smithay::delegate_foreign_toplevel_list!(Compositor);
 
 // ---------------------------------------------------------------------
 // wlr-foreign-toplevel-management
@@ -1248,7 +1314,7 @@ fn intersection(a: Rect, b: Rect) -> Option<Rect> {
 /// wrong in the preview" failure mode `capture.rs` warns about, arrived
 /// at from the other direction, and it was observed before it was
 /// argued: `grim` against a nested session came back upside down.
-fn capture_region(
+pub(crate) fn capture_region(
     comp: &mut Compositor,
     region: Rect,
     transform: Transform,
@@ -1396,7 +1462,7 @@ fn pixel_layout(format: wl_shm::Format) -> Option<(bool, bool)> {
 /// `ONE, ONE_MINUS_SRC_ALPHA` over a cleared buffer, and `wl_shm`'s
 /// `argb8888` is defined premultiplied — so nothing but the channel
 /// order changes.
-fn write_capture(buffer: &WlBuffer, capture: &DecorationBuffer) -> Result<(), String> {
+pub(crate) fn write_capture(buffer: &WlBuffer, capture: &DecorationBuffer) -> Result<(), String> {
     let data = shm_layout(buffer, Size::new(capture.width, capture.height))?;
     let (swap_rb, opaque) = pixel_layout(data.format).ok_or("unsupported buffer format")?;
     let width = capture.width as usize;

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -634,31 +634,43 @@ pub(crate) fn note_frame_success() {
 /// on. The submission halves differ (a winit swap versus a DRM page
 /// flip) and live with their backends; everything visible above them
 /// is [`build_scene`].
-pub(crate) fn render_frame(comp: &mut Compositor) {
-    // Window previews for the switcher and icon tiles, refreshed off
-    // the same cadence as drawing and throttled internally.
-    crate::capture::refresh_snapshots(comp);
+pub(crate) fn render_frame(comp: &mut Compositor) -> bool {
     match comp.graphics {
-        Graphics::Session(_) => crate::session::render_frame_session(comp),
-        Graphics::Winit(_) => render_frame_winit(comp),
+        Graphics::Session(_) => {
+            // Snapshot readback is deliberately outside the deadline
+            // path. It is synchronous on some drivers; doing it after
+            // the flip is queued spends post-submit slack rather than
+            // making fresh input miss the vblank we just scheduled for.
+            let drew = crate::session::render_frame_session(comp);
+            if drew {
+                crate::capture::refresh_snapshots(comp);
+            }
+            drew
+        }
+        Graphics::Winit(_) => {
+            // The nested backend has no vblank clock of its own; keep
+            // its existing immediate ordering under the host compositor.
+            crate::capture::refresh_snapshots(comp);
+            render_frame_winit(comp)
+        }
     }
 }
 
-fn render_frame_winit(comp: &mut Compositor) {
+fn render_frame_winit(comp: &mut Compositor) -> bool {
     // Disjoint field borrows: the winit backend (renderer +
     // framebuffer) mutates while the ledger is read — both live on
     // `Compositor`, so destructure instead of going through `&mut
     // self` methods.
     let Compositor { wm, graphics, outputs, pointer_location, cursor_status, cursors, start_time, .. } = comp;
     let Graphics::Winit(winit_backend) = graphics else {
-        return;
+        return false;
     };
     // The host window is the one and only output (see `state.rs`'s
     // `run`), so there is nothing to iterate and no viewport to offset
     // by — this arm is the multi-output path's degenerate case, not a
     // second implementation of it.
     let Some(entry) = outputs.first_mut() else {
-        return;
+        return false;
     };
     let output = &entry.output;
     let damage_tracker = &mut entry.damage_tracker;
@@ -674,7 +686,7 @@ fn render_frame_winit(comp: &mut Compositor) {
         if note_frame_failure() {
             tracing::warn!(?error, "could not bind the winit framebuffer; skipping frame");
         }
-        return;
+        return false;
     }
     // Real buffer age — the whole point of damage tracking. The age
     // says how many frames old this buffer's contents are, and the
@@ -691,7 +703,7 @@ fn render_frame_winit(comp: &mut Compositor) {
                 if note_frame_failure() {
                     tracing::warn!(?error, "could not bind the winit framebuffer; skipping frame");
                 }
-                return;
+                return false;
             }
         };
 
@@ -718,7 +730,7 @@ fn render_frame_winit(comp: &mut Compositor) {
                 // boundary the former temporary vector did, while
                 // retaining only its allocation for the retry.
                 scene_scratch.clear();
-                return;
+                return false;
             }
         }
     };
@@ -743,7 +755,7 @@ fn render_frame_winit(comp: &mut Compositor) {
             if note_frame_failure() {
                 tracing::warn!(?error, "swap failed; keeping damage for a retry");
             }
-            return;
+            return false;
         }
     }
 
@@ -757,6 +769,7 @@ fn render_frame_winit(comp: &mut Compositor) {
     );
     send_frame_callbacks(wm.backend(), output, cursor_status, start_time.elapsed());
     wm.backend_mut().damage = false;
+    true
 }
 
 /// Damage-rect telemetry, on when `CHONKSTEP_DAMAGE_LOG` is set: one
@@ -1258,7 +1271,7 @@ fn return_walk_stack(mut stack: Vec<TreeStep>) {
 /// fall back to the arrow — shipping an Xcursor theme loader is not
 /// worth it for a nested dev backend, and clients that care set
 /// surface cursors.
-fn push_cursor_elements(
+pub(crate) fn push_cursor_elements(
     elements: &mut Vec<SceneElement<GlesRenderer>>,
     renderer: &mut GlesRenderer,
     backend: &WaylandBackend,

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -42,13 +42,10 @@
 //!   means re-running every step of [`init`] against it while the old
 //!   one is still scanning out; a laptop being docked is a session
 //!   restart today.
-//! - **No connector hot-plug.** Connectors are enumerated once, at
-//!   startup. Plugging a monitor in mid-session logs a udev `Changed`
-//!   event and nothing else: adopting it means minting an `Output` and
-//!   a `wl_output` global after clients have already bound the ones
-//!   they know about, re-laying out every existing output, and telling
-//!   `wm-core` its screen just changed shape — a session restart picks
-//!   the new monitor up today.
+//! - **Connector hot-plug on the active GPU.** Udev changes are
+//!   debounced, the connector set is re-probed, and outputs, protocol
+//!   globals, layout state, gamma slots, and stranded windows are
+//!   reconciled together. GPU hot-plug remains separate and unsupported.
 //! - The pointer uses the hardware cursor plane when the driver offers
 //!   one (see [`FRAME_FLAGS`]); the nested backend composites it
 //!   instead, because a window on someone else's desktop has no planes
@@ -80,12 +77,13 @@ use smithay::backend::udev::{all_gpus, primary_gpu, UdevBackend, UdevEvent};
 use smithay::output::{Mode as OutputMode, Output, OutputModeSource, PhysicalProperties};
 use smithay::reexports::calloop::LoopHandle;
 use smithay::reexports::drm::control::{
-    connector, crtc, plane, Device as ControlDevice, Mode as DrmMode, ModeTypeFlags, PlaneType, ResourceHandles,
+    connector, crtc, plane, Device as ControlDevice, Mode as DrmMode, ModeFlags, ModeTypeFlags,
+    PlaneType, ResourceHandles,
 };
 use smithay::reexports::input::Libinput;
 use smithay::reexports::rustix::fs::OFlags;
 use smithay::reexports::wayland_server::DisplayHandle;
-use smithay::utils::{DeviceFd, Transform};
+use smithay::utils::{Clock, DeviceFd, Monotonic, Transform};
 use smithay::wayland::presentation::Refresh;
 use smithay::desktop::utils::OutputPresentationFeedback;
 
@@ -480,6 +478,11 @@ pub(crate) struct SessionGraphics {
     /// publishing that primary node as a render device crashes clients
     /// such as xdg-desktop-portal-wlr. See [`render_node_for_fd`].
     render_node: Option<DrmNode>,
+    /// Retained because a connector appearing after startup needs the
+    /// same allocator and renderer-format intersection as the outputs
+    /// built during `init`.
+    gbm: GbmDevice<DrmDeviceFd>,
+    render_formats: Vec<Format>,
     /// One per connected connector, in the order [`init`] enumerated
     /// them. That order is load-bearing: it is the order
     /// `Compositor::outputs` holds the matching `Output`s in, which is
@@ -498,6 +501,10 @@ pub(crate) struct SessionGraphics {
     /// them completes — see [`strict_release_configured`] for the
     /// mechanism and the NVIDIA-shaped reason it exists.
     strict_release: bool,
+    /// Debounced connector rescan deadline. A physical plug produces a
+    /// burst of udev changes and every forced connector probe may block;
+    /// one absolute deadline coalesces that burst into one walk.
+    hotplug_due: Option<Instant>,
 }
 
 /// One output being scanned out: its crtc, its place in the global
@@ -514,6 +521,9 @@ struct SessionOutput {
     /// Connector name (`eDP-1`, `HDMI-A-2`), for log lines that have to
     /// name which screen is misbehaving.
     name: String,
+    /// Stable KMS identity used to diff a fresh connector enumeration
+    /// without relying on vector positions that change on unplug.
+    connector: connector::Handle,
     /// The scanout engine driving it. Always equal to
     /// `drm_compositor.crtc()`; kept alongside so the page-flip handler
     /// can find the right output without reaching into the compositor.
@@ -584,6 +594,193 @@ struct SessionOutput {
     /// merely when rendering finished.
     presentation: Option<OutputPresentationFeedback>,
     refresh: Refresh,
+    /// Predicts the next vblank and learns how much of the interval
+    /// composition actually consumes. Rendering is armed late enough
+    /// to sample fresh input while retaining a measured safety budget.
+    frame_clock: FrameClock,
+}
+
+const INITIAL_RENDER_MEAN: Duration = Duration::from_millis(2);
+const INITIAL_RENDER_DEVIATION: Duration = Duration::from_millis(1);
+const BASE_RENDER_MARGIN: Duration = Duration::from_micros(1_500);
+const MAX_RENDER_MARGIN: Duration = Duration::from_millis(8);
+
+/// Per-output deadline estimator. All filtering is elapsed-time based,
+/// so it behaves the same at 60 Hz and 144 Hz and naturally forgets a
+/// stale sample after an idle gap.
+#[derive(Clone, Copy, Debug)]
+struct FrameClock {
+    last_vblank: Option<Instant>,
+    period: Option<Duration>,
+    vblank_duration: Duration,
+    mean: Duration,
+    deviation: Duration,
+    margin: Duration,
+    last_sample: Option<Instant>,
+    deadline: Option<Instant>,
+    target_vblank: Option<Instant>,
+}
+
+impl FrameClock {
+    fn new(mode: DrmMode) -> Self {
+        Self {
+            last_vblank: None,
+            period: mode_period(mode),
+            vblank_duration: mode_vblank_duration(mode),
+            mean: INITIAL_RENDER_MEAN,
+            deviation: INITIAL_RENDER_DEVIATION,
+            margin: BASE_RENDER_MARGIN,
+            last_sample: None,
+            deadline: None,
+            target_vblank: None,
+        }
+    }
+
+    #[cfg(test)]
+    fn for_period(period: Duration) -> Self {
+        Self {
+            last_vblank: None,
+            period: Some(period),
+            vblank_duration: Duration::ZERO,
+            mean: INITIAL_RENDER_MEAN,
+            deviation: INITIAL_RENDER_DEVIATION,
+            margin: BASE_RENDER_MARGIN,
+            last_sample: None,
+            deadline: None,
+            target_vblank: None,
+        }
+    }
+
+    fn update_mode(&mut self, mode: DrmMode) {
+        self.period = mode_period(mode);
+        self.vblank_duration = mode_vblank_duration(mode);
+        self.last_vblank = None;
+        self.deadline = None;
+        self.target_vblank = None;
+    }
+
+    fn note_vblank(&mut self, at: Instant) {
+        self.last_vblank = Some(at);
+        self.deadline = None;
+        self.target_vblank = None;
+    }
+
+    fn disarm(&mut self) {
+        self.last_vblank = None;
+        self.deadline = None;
+        self.target_vblank = None;
+    }
+
+    fn pessimistic_budget(&self) -> Duration {
+        self.mean
+            .saturating_add(self.deviation.saturating_mul(2))
+            .saturating_add(self.margin)
+            .saturating_add(self.vblank_duration)
+    }
+
+    fn optimistic_budget(&self) -> Duration {
+        self.mean.saturating_add(self.margin).saturating_add(self.vblank_duration)
+    }
+
+    /// Arms this frame once and returns its absolute deadline. The
+    /// first frame and the first frame after an idle gap remain
+    /// immediate; deadline scheduling is only useful on a live cadence.
+    fn arm(&mut self, now: Instant) -> Instant {
+        if let Some(deadline) = self.deadline {
+            return deadline;
+        }
+        let Some(period) = self.period.filter(|period| !period.is_zero()) else {
+            self.deadline = Some(now);
+            return now;
+        };
+        let Some(last) = self.last_vblank else {
+            self.deadline = Some(now);
+            return now;
+        };
+        if now.saturating_duration_since(last) > period.saturating_mul(3) {
+            self.deadline = Some(now);
+            return now;
+        }
+
+        let mut target = last + period;
+        while target <= now {
+            target += period;
+        }
+        let pessimistic = target.checked_sub(self.pessimistic_budget()).unwrap_or(now);
+        let optimistic = target.checked_sub(self.optimistic_budget()).unwrap_or(now);
+        let deadline = if pessimistic > now {
+            pessimistic
+        } else if optimistic > now {
+            optimistic
+        } else {
+            target += period;
+            target.checked_sub(self.pessimistic_budget()).unwrap_or(now)
+        };
+        self.target_vblank = Some(target);
+        self.deadline = Some(deadline);
+        deadline
+    }
+
+    fn observe_render(&mut self, sample: Duration, finished: Instant) {
+        let elapsed = self
+            .last_sample
+            .map(|previous| finished.saturating_duration_since(previous))
+            .unwrap_or(Duration::from_millis(250));
+        self.last_sample = Some(finished);
+
+        let seconds = elapsed.as_secs_f64();
+        let mean_alpha = 1.0 - (-seconds / 0.35).exp();
+        let decay_alpha = 1.0 - (-seconds / 3.0).exp();
+        let mean = self.mean.as_secs_f64();
+        let sample_secs = sample.as_secs_f64();
+        self.mean = Duration::from_secs_f64((mean + (sample_secs - mean) * mean_alpha).max(0.000_001));
+        let overshoot = sample.saturating_sub(self.mean);
+        if !overshoot.is_zero() {
+            self.deviation = self.deviation.max(overshoot);
+        } else {
+            self.deviation = Duration::from_secs_f64(
+                self.deviation.as_secs_f64() * (1.0 - decay_alpha),
+            );
+        }
+
+        if self.target_vblank.is_some_and(|target| finished > target) {
+            let overrun = self.target_vblank.map(|target| finished.duration_since(target)).unwrap_or_default();
+            self.margin = self.margin.saturating_add(overrun.max(Duration::from_micros(250))).min(MAX_RENDER_MARGIN);
+        } else {
+            let margin = self.margin.as_secs_f64();
+            let base = BASE_RENDER_MARGIN.as_secs_f64();
+            self.margin = Duration::from_secs_f64((margin + (base - margin) * decay_alpha).max(base));
+        }
+        self.deadline = None;
+        self.target_vblank = None;
+    }
+}
+
+fn mode_period(mode: DrmMode) -> Option<Duration> {
+    let millihertz = OutputMode::from(mode).refresh;
+    (millihertz > 0).then(|| Duration::from_nanos(1_000_000_000_000 / millihertz as u64))
+}
+
+fn mode_vblank_duration(mode: DrmMode) -> Duration {
+    let (_, vdisplay) = mode.size();
+    let (_, _, htotal) = mode.hsync();
+    let (_, _, vtotal) = mode.vsync();
+    let clock_khz = u64::from(mode.clock());
+    if clock_khz == 0 || vtotal <= vdisplay || htotal == 0 {
+        return Duration::ZERO;
+    }
+    let mut micros = (u64::from(vtotal - vdisplay) * u64::from(htotal) * 1_000)
+        .div_ceil(clock_khz);
+    if mode.flags().contains(ModeFlags::DBLSCAN) {
+        micros = micros.saturating_mul(2);
+    }
+    Duration::from_micros(micros)
+}
+
+fn drm_monotonic_instant(timestamp: Duration) -> Instant {
+    let now = Instant::now();
+    let clock_now = Duration::from_micros(Clock::<Monotonic>::new().now().as_micros());
+    now.checked_sub(clock_now.saturating_sub(timestamp)).unwrap_or(now)
 }
 
 /// A page flip the kernel has accepted and not yet reported back.
@@ -858,6 +1055,11 @@ pub(crate) fn init(
                         tracing::debug!(?crtc, "page flip completed on a crtc we do not drive");
                         return;
                     };
+                    let vblank_at = match metadata.map(|meta| meta.time) {
+                        Some(DrmEventTime::Monotonic(time)) => drm_monotonic_instant(time),
+                        _ => Instant::now(),
+                    };
+                    output.frame_clock.note_vblank(vblank_at);
                     let pending = output.frame_pending.take();
                     if let Some(mut feedback) = output.presentation.take() {
                         let flags = smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync
@@ -911,19 +1113,21 @@ pub(crate) fn init(
         })
         .map_err(|error| format!("failed to register the DRM event source: {error}"))?;
 
-    // udev. Watched but not acted on: see the module docs on GPU and
-    // connector hot-plug. Logging it is still worth the source, because
-    // "the screen went black" and "the kernel took your GPU away" look
-    // identical over SSH otherwise.
+    // udev. Connector changes on the device we own arm one debounced
+    // rescan; GPU add/remove remains outside this single-device backend.
     let udev_backend =
         UdevBackend::new(&seat_name).map_err(|error| format!("could not watch udev for seat {seat_name}: {error}"))?;
     loop_handle
-        .insert_source(udev_backend, |event, _, _comp: &mut Compositor| match event {
+        .insert_source(udev_backend, |event, _, comp: &mut Compositor| match event {
             UdevEvent::Added { device_id, path } => {
                 tracing::info!(?device_id, path = %path.display(), "a DRM device appeared; chonkstep drives a single GPU and will not adopt it");
             }
             UdevEvent::Changed { device_id } => {
-                tracing::info!(?device_id, "a DRM device changed (connector hot-plug?); the session keeps the outputs it started with");
+                let Graphics::Session(session) = &mut comp.graphics else { return };
+                if session.drm.device_id() == device_id {
+                    session.hotplug_due = Some(Instant::now() + Duration::from_millis(120));
+                    tracing::debug!(?device_id, "connector change noticed; debounced rescan armed");
+                }
             }
             UdevEvent::Removed { device_id } => {
                 tracing::warn!(?device_id, "a DRM device went away; if it is ours the session will stop painting");
@@ -970,6 +1174,7 @@ pub(crate) fn init(
                     // preempted whatever sampling was still queued.
                     for output in session.outputs.iter_mut() {
                         output.frame_pending = None;
+                        output.frame_clock.disarm();
                         clear_scene_holds(
                             &mut output.pending_scene,
                             &mut output.scanout_scene,
@@ -1004,6 +1209,10 @@ pub(crate) fn init(
                     if let Err(error) = session.drm.activate(true) {
                         tracing::error!(?error, "could not reactivate the DRM device; the screen will stay dark");
                     }
+                    // The connector set may have changed while udev and the
+                    // DRM fd were suspended. Reconcile once the fd is usable
+                    // again even if no hotplug event survived the VT switch.
+                    session.hotplug_due = Some(Instant::now() + Duration::from_millis(120));
                     for output in session.outputs.iter_mut() {
                         if let Err(error) = output.drm_compositor.reset_state() {
                             tracing::error!(
@@ -1061,10 +1270,13 @@ pub(crate) fn init(
             drm,
             renderer,
             render_node,
+            gbm,
+            render_formats,
             outputs: session_outputs,
             libinput,
             last_service: Instant::now(),
             strict_release,
+            hotplug_due: None,
         })),
         outputs: setups,
     })
@@ -1235,6 +1447,7 @@ fn attach_output(
     Ok((
         SessionOutput {
             name,
+            connector: info.handle(),
             crtc: *crtc,
             position,
             drm_compositor,
@@ -1252,6 +1465,7 @@ fn attach_output(
             } else {
                 Refresh::Unknown
             },
+            frame_clock: FrameClock::new(*mode),
         },
         OutputSetup { output, position, size, modes },
     ))
@@ -1287,6 +1501,136 @@ pub(crate) fn redraw_pending(graphics: &Graphics) -> bool {
             session.outputs.iter().any(|output| output.dirty || output.frame_pending.is_some())
         }
     }
+}
+
+/// Earliest armed render deadline, folded into the event loop's wait.
+/// An output first acquires a deadline when `render_frame_session`
+/// consumes damage; after that this wakes calloop at the exact absolute
+/// instant instead of depending on the shell's housekeeping cadence.
+pub(crate) fn next_render_deadline(graphics: &Graphics) -> Option<Instant> {
+    let Graphics::Session(session) = graphics else {
+        return None;
+    };
+    if !session.drm.is_active() {
+        return None;
+    }
+    session
+        .outputs
+        .iter()
+        .filter(|output| output.dirty && output.frame_pending.is_none())
+        .filter_map(|output| output.frame_clock.deadline)
+        .min()
+}
+
+/// Deadline of a pending connector rescan, for the event-loop wait.
+pub(crate) fn next_hotplug_deadline(graphics: &Graphics) -> Option<Instant> {
+    let Graphics::Session(session) = graphics else {
+        return None;
+    };
+    session.hotplug_due
+}
+
+/// Performs one due connector rescan and hands the structural delta to
+/// the compositor ledger. The forced KMS probes stay off the udev
+/// callback itself, so a burst is coalesced before any potentially slow
+/// connector query runs.
+pub(crate) fn service_connector_hotplug(comp: &mut Compositor) {
+    let now = Instant::now();
+    let Graphics::Session(session) = &mut comp.graphics else {
+        return;
+    };
+    if !session.hotplug_due.is_some_and(|deadline| deadline <= now) {
+        return;
+    }
+    session.hotplug_due = None;
+    if !session.drm.is_active() {
+        // Resume re-arms a scan below; probing a revoked fd only creates
+        // noise and can block in the session implementation.
+        session.hotplug_due = Some(now + Duration::from_millis(120));
+        return;
+    }
+
+    match rescan_session_outputs(session) {
+        Ok((removed, added)) if removed.is_empty() && added.is_empty() => {
+            tracing::debug!("connector rescan found no output changes");
+        }
+        Ok((removed, added)) => crate::state::apply_connector_hotplug(comp, &removed, added),
+        Err(error) => tracing::warn!(%error, "connector rescan failed; keeping the current output set"),
+    }
+}
+
+fn rescan_session_outputs(session: &mut SessionGraphics) -> Result<(Vec<usize>, Vec<OutputSetup>), String> {
+    let resources = session
+        .drm
+        .resource_handles()
+        .map_err(|error| format!("could not enumerate KMS resources: {error}"))?;
+    let mut connected = Vec::new();
+    for handle in resources.connectors() {
+        match session.drm.get_connector(*handle, true) {
+            Ok(info) if info.state() == connector::State::Connected && !info.modes().is_empty() => {
+                connected.push(info);
+            }
+            Ok(_) => {}
+            Err(error) => tracing::debug!(?handle, ?error, "connector probe failed during hotplug rescan"),
+        }
+    }
+
+    let connected_handles: Vec<connector::Handle> = connected.iter().map(connector::Info::handle).collect();
+    let mut removed: Vec<usize> = session
+        .outputs
+        .iter()
+        .enumerate()
+        .filter_map(|(index, output)| (!connected_handles.contains(&output.connector)).then_some(index))
+        .collect();
+    removed.sort_unstable_by(|a, b| b.cmp(a));
+    for index in &removed {
+        let mut output = session.outputs.remove(*index);
+        if let Some(mut feedback) = output.presentation.take() {
+            feedback.discarded();
+        }
+        tracing::info!(output = %output.name, "connector unplugged; output removed from scanout");
+    }
+
+    let mut next_x = session
+        .outputs
+        .iter()
+        .map(|output| {
+            let width = output.drm_modes.first().map(|mode| mode.size().0 as i32).unwrap_or(0);
+            output.position.x.saturating_add(width)
+        })
+        .max()
+        .unwrap_or(0);
+    let mut added = Vec::new();
+    for info in connected {
+        if session.outputs.iter().any(|output| output.connector == info.handle()) {
+            continue;
+        }
+        let Some(mode) = preferred_mode(&info) else { continue };
+        let taken: Vec<crtc::Handle> = session.outputs.iter().map(|output| output.crtc).collect();
+        let Some(crtc) = crtc_for(&session.drm, &resources, &info, &taken) else {
+            tracing::warn!(output = %connector_name(&info), "hot-plugged connector has no free crtc");
+            continue;
+        };
+        let target = ConnectorTarget { info, crtc, mode };
+        let position = Point::new(next_x, 0);
+        match attach_output(
+            &mut session.drm,
+            &session.gbm,
+            session.render_node,
+            &session.render_formats,
+            &target,
+            position,
+        ) {
+            Ok((output, setup)) => {
+                next_x = next_x.saturating_add(setup.size.w as i32);
+                tracing::info!(output = %output.name, x = position.x, "hot-plugged connector adopted");
+                session.outputs.push(output);
+                added.push(setup);
+            }
+            Err(error) => tracing::warn!(output = %connector_name(&target.info), %error, "could not adopt hot-plugged connector"),
+        }
+    }
+    Ok((removed, added))
 }
 
 /// Services every page flip in flight: names the ones that have overrun
@@ -1462,6 +1806,7 @@ pub(crate) fn apply_mode(graphics: &mut Graphics, index: usize, mode_index: usiz
             } else {
                 Refresh::Unknown
             };
+            output.frame_clock.update_mode(mode);
             output.dirty = true;
             Ok(())
         }
@@ -1627,7 +1972,8 @@ pub(crate) fn change_vt(comp: &mut Compositor, vt: i32) -> bool {
 /// single output the two collapse into exactly the old behavior: damage
 /// sets dirty, dirty clears on a successful submit, and a blocked or
 /// failed frame is retried on the next wakeup.
-pub(crate) fn render_frame_session(comp: &mut Compositor) {
+#[cfg_attr(feature = "profile", profiling::function)]
+pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
     // Disjoint field borrows: the graphics stack mutates while the
     // ledger is read. Both live on `Compositor`, so destructure rather
     // than going through `&mut self` methods.
@@ -1642,7 +1988,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
         ..
     } = comp;
     let Graphics::Session(session) = graphics else {
-        return;
+        return false;
     };
 
     if wm.backend().damage {
@@ -1685,6 +2031,12 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
         if !device_active {
             continue;
         }
+        let now = Instant::now();
+        if output.frame_clock.arm(now) > now {
+            continue;
+        }
+
+        let render_started = Instant::now();
 
         // Resetting every buffer age makes the internal damage tracker
         // treat the whole output as stale, forcing a full-frame submit —
@@ -1768,6 +2120,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
                 if crate::renderer::note_frame_failure() {
                     tracing::warn!(?error, output = %output.name, "DRM render failed; keeping this output dirty for a retry");
                 }
+                output.frame_clock.observe_render(render_started.elapsed(), Instant::now());
                 output.scene_scratch.clear();
                 continue;
             }
@@ -1826,6 +2179,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
                     // retry a full-frame render and a real flip.
                     output.drm_compositor.reset_buffer_ages();
                     tracing::warn!(?error, output = %output.name, "queueing the page flip failed; keeping this output dirty for a retry");
+                    output.frame_clock.observe_render(render_started.elapsed(), Instant::now());
                     output.scene_scratch.clear();
                     continue;
                 }
@@ -1852,6 +2206,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
         // they were appended above this is an empty, allocation-
         // preserving no-op.
         output.scene_scratch.clear();
+        output.frame_clock.observe_render(render_started.elapsed(), Instant::now());
         output.dirty = false;
         drew_any = true;
     }
@@ -1872,6 +2227,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) {
             crate::renderer::send_frame_callbacks(wm.backend(), &primary.output, cursor_status, start_time.elapsed());
         }
     }
+    drew_any
 }
 
 /// One opened, mode-set-capable DRM device together with every output
@@ -2250,5 +2606,57 @@ mod tests {
         );
         assert!(mismatched.indexset().is_empty());
         assert!(common_scanout_formats(std::iter::empty()).indexset().is_empty());
+    }
+
+    #[test]
+    fn first_and_post_idle_frames_are_never_delayed() {
+        let period = Duration::from_millis(16);
+        let now = Instant::now();
+        let mut clock = FrameClock::for_period(period);
+        assert_eq!(clock.arm(now), now);
+
+        clock.deadline = None;
+        clock.last_vblank = Some(now - period.saturating_mul(4));
+        assert_eq!(clock.arm(now), now);
+    }
+
+    #[test]
+    fn active_cadence_arms_before_the_predicted_vblank() {
+        let period = Duration::from_millis(16);
+        let vblank = Instant::now();
+        let now = vblank + Duration::from_millis(1);
+        let mut clock = FrameClock::for_period(period);
+        clock.note_vblank(vblank);
+        let deadline = clock.arm(now);
+        assert!(deadline > now);
+        assert!(deadline < vblank + period);
+        assert_eq!(clock.target_vblank, Some(vblank + period));
+    }
+
+    #[test]
+    fn pausing_disarms_the_deadline_and_forgets_the_old_cadence() {
+        let period = Duration::from_millis(16);
+        let vblank = Instant::now();
+        let mut clock = FrameClock::for_period(period);
+        clock.note_vblank(vblank);
+        assert!(clock.arm(vblank + Duration::from_millis(1)) > vblank);
+
+        clock.disarm();
+        let resumed = vblank + Duration::from_secs(1);
+        assert_eq!(clock.arm(resumed), resumed);
+        assert!(clock.target_vblank.is_none());
+    }
+
+    #[test]
+    fn render_estimate_rises_fast_and_decays_slowly() {
+        let mut clock = FrameClock::for_period(Duration::from_millis(16));
+        let start = Instant::now();
+        clock.observe_render(Duration::from_millis(9), start);
+        let raised = clock.pessimistic_budget();
+        assert!(raised > Duration::from_millis(6));
+
+        clock.observe_render(Duration::from_millis(1), start + Duration::from_millis(16));
+        assert!(clock.pessimistic_budget() > Duration::from_millis(5));
+        assert!(clock.pessimistic_budget() <= raised);
     }
 }

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::os::fd::{BorrowedFd, RawFd};
 use std::process::Stdio;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use calloop::signals::{Signal, Signals};
 use smithay::backend::allocator::Fourcc;
@@ -129,6 +129,64 @@ pub(crate) struct ProtocolPublishMetrics {
     pub hyprland_event_snapshots: u64,
     pub foreign_toplevel_full_syncs: u64,
     pub foreign_toplevel_drag_syncs: u64,
+}
+
+/// Aggregated cost of a named section of the compositor's event-loop
+/// pass. Durations are cumulative so the test door can bracket any
+/// interaction; `max` keeps a single hitch visible instead of averaging
+/// it into a long quiet sample.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PhaseTiming {
+    pub calls: u64,
+    pub total: Duration,
+    pub max: Duration,
+}
+
+impl PhaseTiming {
+    fn record(&mut self, elapsed: Duration) {
+        self.calls = self.calls.saturating_add(1);
+        self.total = self.total.saturating_add(elapsed);
+        self.max = self.max.max(elapsed);
+    }
+}
+
+/// Live frame/pass instrumentation. It is always cheap and available:
+/// a handful of monotonic clock reads and fixed-size counters, with no
+/// allocation or logging in the frame path. The optional `profile`
+/// Cargo feature complements these counters by enabling the profiling
+/// spans already embedded throughout Smithay.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct FrameStats {
+    pub dispatch: PhaseTiming,
+    pub input: PhaseTiming,
+    pub shell: PhaseTiming,
+    pub protocols: PhaseTiming,
+    pub layout: PhaseTiming,
+    pub render: PhaseTiming,
+    pub flush: PhaseTiming,
+    pub ipc: PhaseTiming,
+    /// Power-of-two microsecond ceilings, from <=1 us through >16384 us.
+    pub dispatch_histogram: [u64; 16],
+    pub render_histogram: [u64; 16],
+}
+
+impl FrameStats {
+    fn histogram_bucket(elapsed: Duration) -> usize {
+        let micros = elapsed.as_micros().max(1);
+        (u128::BITS - (micros - 1).leading_zeros()).min(15) as usize
+    }
+
+    fn record_dispatch(&mut self, elapsed: Duration) {
+        self.dispatch.record(elapsed);
+        let bucket = Self::histogram_bucket(elapsed);
+        self.dispatch_histogram[bucket] = self.dispatch_histogram[bucket].saturating_add(1);
+    }
+
+    fn record_render(&mut self, elapsed: Duration) {
+        self.render.record(elapsed);
+        let bucket = Self::histogram_bucket(elapsed);
+        self.render_histogram[bucket] = self.render_histogram[bucket].saturating_add(1);
+    }
 }
 
 /// One entry in the bottom-to-top managed-window stacking order.
@@ -1311,16 +1369,16 @@ pub(crate) struct OutputEntry {
     pub scene_scratch: Vec<crate::renderer::SceneElement<GlesRenderer>>,
     /// The `wl_output` global clients bind to. Dropping the id does not
     /// take the global down — that needs
-    /// `DisplayHandle::remove_global` — so this is held for the one
-    /// caller that would ever pass it there: a connector-hot-unplug
-    /// path taking an output back off the wire.
-    _global: GlobalId,
+    /// `DisplayHandle::disable_global` — so this is held for the one
+    /// caller that passes it there: connector hot-unplug taking an
+    /// output safely back off the wire.
+    pub(crate) global: GlobalId,
 }
 
 impl OutputEntry {
     /// Advertises one output to clients and prepares it for rendering.
-    fn new(setup: OutputSetup, display_handle: &DisplayHandle) -> Self {
-        let _global = setup.output.create_global::<Compositor>(display_handle);
+    pub(crate) fn new(setup: OutputSetup, display_handle: &DisplayHandle) -> Self {
+        let global = setup.output.create_global::<Compositor>(display_handle);
         let damage_tracker = physical_damage_tracker(&setup.output, setup.size);
         Self {
             output: setup.output,
@@ -1330,7 +1388,7 @@ impl OutputEntry {
             modes: setup.modes,
             damage_tracker,
             scene_scratch: Vec::new(),
-            _global,
+            global,
         }
     }
 }
@@ -1438,7 +1496,7 @@ fn advertise_scales(outputs: &mut [OutputEntry], scales: &[f64]) {
 /// and their EDID facts are available. Unsupported fields refuse their
 /// entire line so a rotated/disabled/mirrored request is never partly
 /// honored as only a scale or position change.
-fn apply_monitor_rules(
+pub(crate) fn apply_monitor_rules(
     setups: &mut [OutputSetup],
     rules: &[wm_config::hyprland::directive::Monitor],
     fallback_scale: f64,
@@ -1537,6 +1595,108 @@ fn apply_monitor_rules(
         }
     }
     scales
+}
+
+/// Mirrors a DRM connector delta into every positional output ledger.
+/// Session outputs have already been inserted/removed when this is
+/// called; this half owns protocol globals, monitor policy, shell
+/// resize, and the index-bearing layer/lock records.
+pub(crate) fn apply_connector_hotplug(
+    comp: &mut Compositor,
+    removed: &[usize],
+    added: Vec<OutputSetup>,
+) {
+    let mut departed = Vec::new();
+    for &index in removed {
+        if index >= comp.outputs.len() {
+            continue;
+        }
+        let entry = comp.outputs.remove(index);
+        departed.push(Rect::new(entry.position, entry.size));
+        // Registry clients see global_remove immediately. Keep the disabled
+        // server-side record rather than freeing it in the same dispatch,
+        // which avoids the bind-vs-removal race documented by wayland-server.
+        comp.display_handle.disable_global::<Compositor>(entry.global);
+
+        let backend = comp.wm.backend_mut();
+        backend.layers.iter_mut().for_each(|layer| {
+            if layer.output == index {
+                layer.output = 0;
+            } else if layer.output > index {
+                layer.output -= 1;
+            }
+        });
+        backend.lock_surfaces.retain(|surface| surface.output != index);
+        for surface in &mut backend.lock_surfaces {
+            if surface.output > index {
+                surface.output -= 1;
+            }
+        }
+    }
+
+    for setup in added {
+        comp.outputs.push(OutputEntry::new(setup, &comp.display_handle));
+    }
+
+    // Re-read monitor rules on the rare structural change so a docked
+    // connector lands at its configured position/scale immediately.
+    let session = chonk_shell::startup::SessionState::resolve(&wm_config::load());
+    let mut setups: Vec<OutputSetup> = comp
+        .outputs
+        .iter()
+        .map(|entry| OutputSetup {
+            output: entry.output.clone(),
+            position: entry.position,
+            size: entry.size,
+            modes: entry.modes.clone(),
+        })
+        .collect();
+    let scales = apply_monitor_rules(&mut setups, &session.monitor_rules, comp.ui_scale as f64);
+    for ((entry, setup), scale) in comp.outputs.iter_mut().zip(setups).zip(scales) {
+        entry.position = setup.position;
+        entry.scale = scale;
+        entry.output.change_current_state(
+            None,
+            None,
+            Some(advertised_output_scale(scale as f32)),
+            Some((entry.position.x, entry.position.y).into()),
+        );
+    }
+
+    let layout: Vec<(Point, Size)> = comp.outputs.iter().map(|entry| (entry.position, entry.size)).collect();
+    crate::session::sync_positions(&mut comp.graphics, &layout);
+    let monitors: Vec<MonitorInfo> = comp
+        .outputs
+        .iter()
+        .enumerate()
+        .map(|(index, entry)| MonitorInfo {
+            geometry: Rect::new(entry.position, entry.size),
+            name: entry.output.name(),
+            primary: index == 0,
+        })
+        .collect();
+    let monitor_scales: Vec<f64> = comp.outputs.iter().map(|entry| entry.scale).collect();
+    {
+        let backend = comp.wm.backend_mut();
+        backend.monitors = monitors;
+        backend.monitor_scales = monitor_scales;
+        backend.output_size = union_size(&backend.monitors);
+        backend.pending_resize = Some(backend.output_size);
+        backend.damage = true;
+        backend.layer_layout_dirty = true;
+        backend.idle_policy_dirty = true;
+    }
+    for rect in departed {
+        comp.wm.rescue_clients_from_removed_monitor(rect);
+    }
+    crate::input::reconcile_pointer_after_output_change(comp);
+    crate::gamma::outputs_changed(&mut comp.gamma, &comp.graphics, &comp.display_handle);
+    comp.output_mgmt.mark_dirty();
+    comp.session_lock.mark_dirty();
+    comp.layer_shell.needs_arrange = true;
+    comp.hyprland_state_dirty = true;
+    comp.foreign_toplevel_dirty = true;
+    tracing::info!(outputs = comp.outputs.len(), "connector hotplug reconciled across the desktop");
 }
 
 fn parse_monitor_position(value: &str) -> Option<Point> {
@@ -1658,6 +1818,10 @@ pub struct Compositor {
     /// events allocation-free when they changed no published state.
     observed_wm_protocol_revision: u64,
     pub(crate) protocol_publish_metrics: ProtocolPublishMetrics,
+    /// Fixed-size timing counters exposed through the opt-in test door.
+    /// Reading them resets the bracket, so a harness can measure one
+    /// interaction without parsing tracing output or wall-clock sleeps.
+    pub(crate) frame_stats: FrameStats,
 
     // Per-protocol smithay state. Constructed once in `run`; the
     // handler impls in `xdg.rs`/`input.rs`/`xwayland.rs` return these
@@ -1713,9 +1877,8 @@ pub struct Compositor {
 
     pub seat: Seat<Compositor>,
     /// Every output, primary first — see [`OutputEntry`] for what that
-    /// order binds together. Never empty: a session with no output
-    /// never gets built (`session::init` fails, and the nested backend
-    /// always has its host window).
+    /// order binds together. Startup requires one, though DRM hot-unplug
+    /// may leave this briefly empty until a connector returns.
     pub(crate) outputs: Vec<OutputEntry>,
 
     /// The X11 window-manager connection into XWayland, once
@@ -1775,6 +1938,10 @@ pub struct Compositor {
     /// foreign-toplevel window list and screencopy capture. The
     /// Wayland counterpart to the X11 session's EWMH properties.
     pub(crate) protocols: crate::protocols::ProtocolState,
+    /// ext-image-copy-capture sessions and their output/toplevel source
+    /// factories. Kept beside the legacy wlr protocol state because both
+    /// intentionally share its shm pixel writer.
+    pub(crate) image_capture: crate::image_capture::ImageCapture,
     pub(crate) _toplevel_mapping: crate::toplevel_mapping::ToplevelMapping,
     /// wlr-output-management: what `wlr-randr` and `kanshi` list and
     /// configure outputs through — see `output_mgmt.rs`.
@@ -1875,7 +2042,11 @@ impl Compositor {
     /// "the desktop behaves identically" a structural property rather
     /// than a porting promise, so change that file first if this order
     /// ever needs to move.
+    #[cfg_attr(feature = "profile", profiling::function)]
     pub(crate) fn dispatch_pending(&mut self) {
+        let dispatch_started = Instant::now();
+        crate::session::service_connector_hotplug(self);
+        let phase_started = Instant::now();
         crate::input::tick_repeating_binding(self);
         // Consecutive `PointerMotion` events coalesce to the most
         // recent one — same rationale as the X11 loop: during a fast
@@ -1930,6 +2101,9 @@ impl Compositor {
         if let Some(motion) = pending_motion.take() {
             self.dispatch_motion(motion);
         }
+
+        self.frame_stats.input.record(phase_started.elapsed());
+        let phase_started = Instant::now();
 
         while let Some(notification) = self.wm.take_notification() {
             self.shell.on_notification(&mut self.wm, notification);
@@ -1986,6 +2160,8 @@ impl Compositor {
         // every coalesced `PointerMotion` above passes through.
 
         self.shell.tick(&mut self.wm);
+        self.frame_stats.shell.record(phase_started.elapsed());
+        let phase_started = Instant::now();
 
         // State, not the shape of the event that reached it, drives
         // protocol invalidation. A press/release inside the already-focused
@@ -2020,6 +2196,10 @@ impl Compositor {
         // reconciliations and before the damage test, so an applied
         // configuration's re-layout renders on this very pass.
         crate::output_mgmt::refresh(self);
+        // Long-lived ext capture sessions observe the settled toplevel and
+        // output geometry above, re-advertise changed constraints, and answer
+        // frame requests through the shared offscreen path.
+        crate::image_capture::refresh(self);
         // Gamma ramps settle beside the other protocol reconciliations
         // and for a reason of their own: this is the only place the
         // blocking legacy-gamma ioctl is called from, so a client
@@ -2051,6 +2231,8 @@ impl Compositor {
         // Idle inhibition follows visibility, which everything above
         // may have changed.
         crate::idle::refresh(self);
+        self.frame_stats.protocols.record(phase_started.elapsed());
+        let phase_started = Instant::now();
 
         // The UI scale moved: rebuild the built-in pointer, the one
         // thing this session draws that is sized from that scale and
@@ -2150,6 +2332,7 @@ impl Compositor {
         // damage. Poll before the render decision so an idle desktop
         // can answer one without waiting for unrelated client pixels.
         crate::capture::poll_screenshot_marker(self);
+        self.frame_stats.layout.record(phase_started.elapsed());
 
         // Damage means the scene changed; `redraw_pending` means a
         // change already accounted for has not reached every screen yet
@@ -2157,7 +2340,10 @@ impl Compositor {
         // The second condition only ever fires on the session backend
         // with more than one output — see `session::redraw_pending`.
         if self.wm.backend().damage || crate::session::redraw_pending(&self.graphics) {
-            crate::renderer::render_frame(self);
+            let render_started = Instant::now();
+            if crate::renderer::render_frame(self) {
+                self.frame_stats.record_render(render_started.elapsed());
+            }
         }
 
         // A locking client is owed its `locked` event only after a
@@ -2168,22 +2354,27 @@ impl Compositor {
         // Protocol replies queued by everything above (configures,
         // frame callbacks, focus enter/leave) only reach clients on a
         // flush.
+        let phase_started = Instant::now();
         let _ = self.display_handle.flush_clients();
+        self.frame_stats.flush.record(phase_started.elapsed());
 
         // Hyprland IPC, before the source reconciliation below so that
         // a connection accepted or dropped in this pass is registered
         // or unregistered in the same one.
+        let phase_started = Instant::now();
         self.service_hyprland_ipc();
 
         // Last, after every socket this pass was going to close has
         // been closed. See `sync_dock_sources` for why that ordering is
         // the safety argument and not a tidiness one.
         self.sync_dock_sources();
+        self.frame_stats.ipc.record(phase_started.elapsed());
 
         // Test-door barriers ack only after the frame above has landed
         // and the flush has gone out — a no-op in a user session (the
         // door never opens without CHONKSTEP_TEST_SOCKET).
         crate::test_door::after_frame(self);
+        self.frame_stats.record_dispatch(dispatch_started.elapsed());
     }
 
     /// Dismiss popup trees whose native parent changed size.
@@ -3080,6 +3271,10 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
             .map_err(|fallback| format!("failed to initialize even the default seat keyboard: {fallback}"))?;
     }
     seat.add_pointer();
+    // wl_touch is a seat capability, not a per-device global. Keeping
+    // it present lets hot-plugged touchscreens work without changing
+    // the wl_seat capability set underneath already-bound clients.
+    seat.add_touch();
 
     // Which kind of session this process is. Owning the hardware and
     // living in a window on somebody else's desktop are the same
@@ -3203,6 +3398,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let syncobj = crate::dmabuf::init_syncobj(&display_handle, &graphics);
     // Same timing rule as dmabuf: bound before any client can connect.
     let protocols = crate::protocols::init(&display_handle);
+    let image_capture = crate::image_capture::init(&display_handle);
     let toplevel_mapping = crate::toplevel_mapping::init(&display_handle);
     let output_mgmt = crate::output_mgmt::init(&display_handle);
     // Gamma control rides the same timing rule and additionally asks
@@ -3501,6 +3697,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         foreign_toplevel_dirty: true,
         observed_wm_protocol_revision: wm.protocol_state_revision(),
         protocol_publish_metrics: ProtocolPublishMetrics::default(),
+        frame_stats: FrameStats::default(),
         wm,
         shell,
         display_handle,
@@ -3536,6 +3733,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         dmabuf,
         syncobj,
         protocols,
+        image_capture,
         _toplevel_mapping: toplevel_mapping,
         output_mgmt,
         gamma,
@@ -3639,6 +3837,12 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         wait = wait.min(request_poller.next_deadline().saturating_duration_since(now));
         wait = wait.min(comp.screenshot_poller.next_deadline().saturating_duration_since(now));
         if let Some(deadline) = crate::input::repeating_binding_deadline(&comp) {
+            wait = wait.min(deadline.saturating_duration_since(now));
+        }
+        if let Some(deadline) = crate::session::next_render_deadline(&comp.graphics) {
+            wait = wait.min(deadline.saturating_duration_since(now));
+        }
+        if let Some(deadline) = crate::session::next_hotplug_deadline(&comp.graphics) {
             wait = wait.min(deadline.saturating_duration_since(now));
         }
         event_loop.dispatch(Some(wait), &mut comp)?;
@@ -4035,6 +4239,21 @@ fn resize_cursor_pixels(scale: f32, angle_rad: f32) -> (Vec<u8>, i32, i32, (i32,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn frame_stats_use_bounded_power_of_two_buckets_and_saturating_counts() {
+        let mut stats = FrameStats::default();
+        stats.record_dispatch(Duration::from_micros(1));
+        stats.record_dispatch(Duration::from_micros(8));
+        stats.record_render(Duration::from_millis(40));
+
+        assert_eq!(stats.dispatch.calls, 2);
+        assert_eq!(stats.dispatch_histogram[0], 1);
+        assert_eq!(stats.dispatch_histogram[3], 1);
+        assert_eq!(stats.render.calls, 1);
+        assert_eq!(stats.render_histogram[15], 1, "large frames stay in the final bucket");
+        assert_eq!(stats.dispatch.max, Duration::from_micros(8));
+    }
 
     #[test]
     fn omarchys_recovery_locker_waits_for_its_relaunched_shell() {

--- a/crates/wm-wayland/src/test_door.rs
+++ b/crates/wm-wayland/src/test_door.rs
@@ -511,6 +511,33 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                 .as_bytes(),
             );
         }
+        Some("frame-stats") => {
+            let stats = std::mem::take(&mut comp.frame_stats);
+            let micros = |duration: std::time::Duration| duration.as_micros();
+            let buckets = |values: &[u64; 16]| {
+                values.iter().map(u64::to_string).collect::<Vec<_>>().join(",")
+            };
+            let _ = stream.write_all(
+                format!(
+                    "frame-stats dispatch_calls={} dispatch_us={} dispatch_max_us={} input_us={} shell_us={} protocol_us={} layout_us={} render_calls={} render_us={} render_max_us={} flush_us={} ipc_us={} dispatch_hist={} render_hist={}\n",
+                    stats.dispatch.calls,
+                    micros(stats.dispatch.total),
+                    micros(stats.dispatch.max),
+                    micros(stats.input.total),
+                    micros(stats.shell.total),
+                    micros(stats.protocols.total),
+                    micros(stats.layout.total),
+                    stats.render.calls,
+                    micros(stats.render.total),
+                    micros(stats.render.max),
+                    micros(stats.flush.total),
+                    micros(stats.ipc.total),
+                    buckets(&stats.dispatch_histogram),
+                    buckets(&stats.render_histogram),
+                )
+                .as_bytes(),
+            );
+        }
         Some("hyprland-sources") => {
             let (desired, registered) = comp.hyprland_ipc_source_counts();
             let _ = stream.write_all(

--- a/docs/screen-sharing.md
+++ b/docs/screen-sharing.md
@@ -20,7 +20,9 @@ windows. What it talks to instead is a chain of brokers:
     browser (WebRTC getDisplayMedia)
       → xdg-desktop-portal            org.freedesktop.portal.ScreenCast, D-Bus
         → xdg-desktop-portal-wlr      the backend chonkstep-portals.conf selects
-          → chonkstep-wayland         zwlr_screencopy_manager_v1 (v3)
+          → chonkstep-wayland         ext_image_copy_capture_manager_v1
+                                      + output/toplevel capture sources
+                                      (zwlr_screencopy_manager_v1 v3 fallback)
             → PipeWire                the video stream the browser consumes
 
 `xdg-desktop-portal` is the frontend every sandboxed-or-not app talks
@@ -28,19 +30,26 @@ to. It picks a *backend* per portal interface, and
 `xdg-desktop-portal-wlr` is the one that captures wlroots-style
 compositors. It never checks whether the compositor actually is
 wlroots — it speaks protocols, and the ones it needs for capture are
-ones chonkstep-wayland advertises: `zwlr_screencopy_manager_v1`
-version 3, `zxdg_output_manager_v1` version 3, and a feedback-capable
-`zwp_linux_dmabuf_v1` global (see
-`crates/wm-wayland/src/protocols.rs` and `dmabuf.rs`). Frames captured
-over screencopy are pushed into a PipeWire stream, and the node id of
-that stream is what the portal hands back to the browser.
+ones chonkstep-wayland advertises. Its preferred path is
+`ext_image_copy_capture_manager_v1`, with
+`ext_output_image_capture_source_manager_v1` for monitors and
+`ext_foreign_toplevel_image_capture_source_manager_v1` plus
+`ext_foreign_toplevel_list_v1` for individual windows. The legacy
+`zwlr_screencopy_manager_v1` version 3 remains advertised as a fallback,
+alongside `zxdg_output_manager_v1` version 3 and a feedback-capable
+`zwp_linux_dmabuf_v1` global (see `crates/wm-wayland/src/image_capture.rs`,
+`protocols.rs`, and `dmabuf.rs`). Captured frames are pushed into a
+PipeWire stream, and the node id of that stream is what the portal hands
+back to the browser.
 
 ### linux-dmabuf feedback
 
-Screen capture itself uses `zwlr_screencopy`; `zwp_linux_dmabuf_v1`
-is the separate path GPU clients use to submit their own buffers.
-xdg-desktop-portal-wlr 0.8.2 nevertheless requires both globals and
-installs linux-dmabuf feedback listeners before capture starts.
+The preferred ext capture path currently negotiates writable `wl_shm`
+buffers; the retained `zwlr_screencopy` fallback does the same.
+`zwp_linux_dmabuf_v1` is the separate path GPU clients use to submit
+their own buffers. xdg-desktop-portal-wlr 0.8.2 nevertheless requires
+the dmabuf global and installs linux-dmabuf feedback listeners before
+capture starts.
 
 For a hardware login, ChonkStep asks EGL for the node of the GPU that
 actually renders. That distinction matters on split hardware such as
@@ -140,17 +149,17 @@ Checked against the frontend with the chonkstep config active:
 | Screenshot | wlr | **Works** — `Screenshot()` returned a real PNG of the session (xdg-desktop-portal-wlr shells out to `grim`, which is also installed) |
 | Inhibit | chonkstep | Idle requests feed the compositor's own timers and are released on request close or caller disconnect |
 | FileChooser, Notification, Settings, and the rest | gtk | **Backend activates and answers** (D-Bus ping + interface version 4 confirmed); the dialogs themselves are ordinary windows and were not driven headlessly |
-| Window/toplevel capture (`types=2` in SelectSources) | wlr | **Not available** — xdg-desktop-portal-wlr only captures outputs (`AvailableSourceTypes=1`); this is an upstream backend limitation, not a chonkstep gap. "Share entire screen" works; "share a single window" is not offered |
+| Window/toplevel capture (`types=2` in SelectSources) | wlr | **Supported** — ext image-copy-capture advertises both output and foreign-toplevel sources; compatible portal backends expose `AvailableSourceTypes=3` |
 
 Backend matrix:
 
-| Chonkstep graphics path | Screencopy | linux-dmabuf | ScreenCast |
+| Chonkstep graphics path | Capture globals | linux-dmabuf | ScreenCast |
 | --- | --- | --- | --- |
-| DRM login (physical or virtual GPU) | v3 | v5 with default feedback | **Supported; clean Omarchy VM verified** |
-| DRM login with separate KMS/render devices | v3 | v5 when EGL identifies the actual render node; otherwise absent | Supported when the driver exposes its renderer identity; otherwise fails cleanly |
-| Nested GPU with EGL render-node discovery | v3 | v5 with default feedback | Supported |
-| Nested EGL with formats but no discoverable node | v3 | absent | Unsupported, but the portal fails cleanly instead of crashing |
-| Renderer without dmabuf import formats | v3 | absent | Unsupported by the current wlr portal backend |
+| DRM login (physical or virtual GPU) | ext v1 + wlr v3 fallback | v5 with default feedback | **Supported; clean Omarchy VM verified** |
+| DRM login with separate KMS/render devices | ext v1 + wlr v3 fallback | v5 when EGL identifies the actual render node; otherwise absent | Supported when the driver exposes its renderer identity; otherwise fails cleanly |
+| Nested GPU with EGL render-node discovery | ext v1 + wlr v3 fallback | v5 with default feedback | Supported |
+| Nested EGL with formats but no discoverable node | ext v1 + wlr v3 fallback | absent | Unsupported, but the portal fails cleanly instead of crashing |
+| Renderer without dmabuf import formats | ext v1 + wlr v3 fallback | absent | Unsupported by the current wlr portal backend |
 
 ## Troubleshooting
 
@@ -213,7 +222,8 @@ restart the frontend, and run it from the ChonkStep session:
 It does `CreateSession`, `SelectSources` (one monitor), `Start`, and
 `OpenPipeWireRemote` through `org.freedesktop.portal.ScreenCast`, then
 uses `pipewiresrc` to consume the returned node. The clean Omarchy VM
-run reported:
+run below predates ext image-copy-capture support and records the former
+monitor-only baseline:
 
     ScreenCast portal version=4 AvailableSourceTypes=1
     <- Response(CreateSession): code=0


### PR DESCRIPTION
## Summary

- schedule DRM composition against predicted vblank deadlines with adaptive render-cost margins
- debounce connector rescans, add and remove outputs live, and rescue windows from unplugged monitors
- expose wl_touch, route latched touch gestures, cancel stale contacts safely, and account for switch events
- record bounded per-phase frame timings and histograms, with an optional profiling feature and test-door coverage
- advertise ext image-copy capture for outputs and foreign toplevels while retaining legacy screencopy support

## Validation

- cargo test --workspace
- cargo test -p wm-wayland --lib (post-rebase)
- cargo clippy -p wm-wayland --all-targets --features profile -- -D warnings
- cargo clippy -p chonk-testkit --all-targets -- -D warnings
- scripts/e2e.sh --headless ordinary_desktop_globals_bind_successfully
- scripts/e2e.sh --headless a_self_timed_client_on_a_parked_workspace_schedules_no_frames

Closes #46
Closes #47
Closes #48
Closes #49
Closes #51