### PR TITLE
Report measured monitor facts and a truthful keyword refusal (#100)

### DIFF
--- a/crates/chonk-hyprland-ipc/src/lib.rs
+++ b/crates/chonk-hyprland-ipc/src/lib.rs
@@ -70,4 +70,4 @@ pub use dispatch::{Action, Direction, Outcome};
 pub use event::{Differ, Event};
 pub use request::Request;
 pub use server::{Server, MAX_EVENT_CLIENTS, MAX_REQUEST_CLIENTS, REQUEST_IDLE_PASSES};
-pub use state::{Monitor, Snapshot, Window, Workspace};
+pub use state::{Monitor, MonitorMode, Snapshot, Window, Workspace};

--- a/crates/chonk-hyprland-ipc/src/server.rs
+++ b/crates/chonk-hyprland-ipc/src/server.rs
@@ -252,9 +252,22 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
             },
             None,
         ),
-        "keyword" => {
-            ("Invalid dispatcher: chonkstep does not read a Hyprland config; keyword changes nothing".to_string(), None)
-        }
+        // A refusal, and it stays one: `keyword` is Hyprland's whole
+        // configuration namespace, and answering `ok` for all of it
+        // would be worse than saying no. But the refusal has to be
+        // *true* — chonkstep does read a Hyprland config, and the old
+        // sentence pointed a user reading it away from the one route
+        // that works. `hyprctl` exits zero either way (see the module
+        // docs), so this string is the only diagnostic there is.
+        "keyword" => (
+            "Invalid dispatcher: keyword does not mutate chonkstep's configuration. \
+             chonkstep reads ~/.config/hypr and re-reads it within a second of an edit, \
+             so edit the file instead, or use `hyprctl eval hl.monitor({...})` for a live \
+             scale change. `keyword monitor NAME,disable` cannot work at all: chonkstep \
+             drives every connected output and has no disable path."
+                .to_string(),
+            None,
+        ),
         "reload" => ("ok".to_string(), Some(Action::ReloadConfig)),
         "binds" => (if json { json_bindings(snapshot) } else { plain_bindings(snapshot) }, None),
         "devices" => (json_devices(snapshot), None),

--- a/crates/chonk-hyprland-ipc/src/state.rs
+++ b/crates/chonk-hyprland-ipc/src/state.rs
@@ -54,7 +54,44 @@ pub struct Monitor {
     pub focused: bool,
     /// The 0-based chonkstep workspace index active on this output.
     pub active_workspace: usize,
+    /// EDID make and model as the matching `wl_output` advertises them,
+    /// so the two protocols cannot describe the same panel differently.
+    /// `serial` has no source on this compositor and stays empty rather
+    /// than being invented.
+    pub make: String,
+    pub model: String,
+    pub serial: String,
+    /// The current mode's refresh rate in millihertz, or 0 when the
+    /// backend drives no real mode. Millihertz because that is what the
+    /// mode carries and what the session already divides into a frame
+    /// period; the conversion to Hyprland's float belongs at the wire,
+    /// not here.
+    pub refresh_millihertz: u32,
+    /// Every mode this output can drive, current first — the same list
+    /// `zwlr_output_management` enumerates for the same head.
+    pub modes: Vec<MonitorMode>,
 }
+
+/// One mode an output can drive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MonitorMode {
+    pub width: i32,
+    pub height: i32,
+    pub refresh_millihertz: u32,
+}
+
+impl MonitorMode {
+    /// Hyprland's `availableModes` spelling: `WIDTHxHEIGHT@RATEHz`.
+    fn to_hyprland(self) -> String {
+        format!("{}x{}@{:.2}Hz", self.width, self.height, f64::from(self.refresh_millihertz) / 1000.0)
+    }
+}
+
+/// The rate reported when an output drives no mode with a real refresh.
+///
+/// A bar divides by this to pace an animation, so 0 is not an option —
+/// this is the number to fall back to, not a number anybody measured.
+const FALLBACK_REFRESH_HZ: f64 = 60.0;
 
 /// One workspace.
 #[derive(Debug, Clone, PartialEq)]
@@ -382,17 +419,22 @@ impl Snapshot {
                     id: monitor.id,
                     name: monitor.name.clone(),
                     description: monitor.description.clone(),
-                    make: String::new(),
-                    model: String::new(),
-                    serial: String::new(),
+                    make: monitor.make.clone(),
+                    model: monitor.model.clone(),
+                    serial: monitor.serial.clone(),
                     width: monitor.width,
                     height: monitor.height,
-                    // Hyprland reports the mode's refresh rate. chonkstep
-                    // does not model modes, and a bar that divides by it
-                    // would divide by zero, so report the conventional
-                    // 60 rather than 0 and say so here rather than let a
-                    // reader infer we measured it.
-                    refresh_rate: 60.0,
+                    // Hyprland reports the mode's refresh rate, and so
+                    // does this: the session picks a mode per connector
+                    // and already divides its millihertz into a frame
+                    // period. Only a backend driving no real mode falls
+                    // back to [`FALLBACK_REFRESH_HZ`], which exists so a
+                    // bar pacing an animation never divides by zero.
+                    refresh_rate: if monitor.refresh_millihertz == 0 {
+                        FALLBACK_REFRESH_HZ
+                    } else {
+                        f64::from(monitor.refresh_millihertz) / 1000.0
+                    },
                     x: monitor.x,
                     y: monitor.y,
                     active_workspace: WorkspaceRef {
@@ -416,7 +458,7 @@ impl Snapshot {
                     disabled: false,
                     current_format: "XRGB8888".to_string(),
                     mirror_of: "none".to_string(),
-                    available_modes: Vec::new(),
+                    available_modes: monitor.modes.iter().map(|mode| mode.to_hyprland()).collect(),
                 }
             })
             .collect()

--- a/crates/chonk-hyprland-ipc/tests/protocol.rs
+++ b/crates/chonk-hyprland-ipc/tests/protocol.rs
@@ -12,7 +12,7 @@
 use chonk_hyprland_ipc::dispatch::{self, Action, Fullscreen};
 use chonk_hyprland_ipc::request::Request;
 use chonk_hyprland_ipc::server::answer_payload;
-use chonk_hyprland_ipc::state::{Devices, Monitor, Snapshot, Window, Workspace};
+use chonk_hyprland_ipc::state::{Devices, Monitor, MonitorMode, Snapshot, Window, Workspace};
 use chonk_hyprland_ipc::{Differ, Outcome};
 
 fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monitor {
@@ -27,6 +27,17 @@ fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monit
         scale: 2.0,
         focused,
         active_workspace,
+        make: "Sharp".to_string(),
+        model: name.to_string(),
+        serial: String::new(),
+        // 120 Hz on purpose: the value this used to report was a
+        // conventional 60 for every panel, so a fixture that is also
+        // 60 would pass either way.
+        refresh_millihertz: 120_000,
+        modes: vec![
+            MonitorMode { width: 2560, height: 1600, refresh_millihertz: 120_000 },
+            MonitorMode { width: 2560, height: 1600, refresh_millihertz: 60_000 },
+        ],
     }
 }
 
@@ -795,5 +806,71 @@ fn an_unlocked_session_blocks_nothing_which_is_what_hyprland_reports() {
     assert!(
         parsed[0]["solitaryBlockedBy"] == serde_json::json!([]),
         "nothing is blocking a solitary client on an unlocked desk: {json}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// The monitor object: values a caller acts on, and the refusal a user
+// reads when a control does nothing.
+
+/// A 120 Hz panel used to be reported as 60 Hz, because the rate was a
+/// constant rather than a measurement. A bar divides this into a frame
+/// budget; on the panel in the fixture the old answer was off by half.
+#[test]
+fn a_monitors_refresh_rate_is_the_modes_rate_not_a_convention() {
+    let monitors = ask_json("j/monitors", &desktop());
+    let first = &monitors[0];
+    assert_eq!(
+        first["refreshRate"], 120.0,
+        "the reported rate must come from the mode the session drives: {monitors}"
+    );
+}
+
+/// Zero is the one case a convention is still right for: no consumer
+/// may be handed a rate it will divide by.
+#[test]
+fn a_monitor_with_no_real_mode_falls_back_rather_than_reporting_zero() {
+    let mut desk = desktop();
+    desk.monitors[0].refresh_millihertz = 0;
+    let monitors = ask_json("j/monitors", &desk);
+    assert_eq!(monitors[0]["refreshRate"], 60.0, "0 must never reach a caller that divides by it");
+}
+
+/// `availableModes` was an empty list on a compositor that enumerates
+/// every connector mode for `zwlr_output_management` at the same moment.
+#[test]
+fn a_monitors_mode_list_is_the_connectors_modes_in_hyprlands_spelling() {
+    let monitors = ask_json("j/monitors", &desktop());
+    let modes = monitors[0]["availableModes"].as_array().expect("availableModes is a list").clone();
+    assert_eq!(
+        modes,
+        vec![
+            serde_json::json!("2560x1600@120.00Hz"),
+            serde_json::json!("2560x1600@60.00Hz")
+        ],
+        "current mode first, in WIDTHxHEIGHT@RATEHz"
+    );
+    assert_eq!(monitors[0]["make"], "Sharp", "make comes from the same EDID wl_output advertises");
+    assert_eq!(monitors[0]["model"], "eDP-1");
+    assert_eq!(monitors[0]["serial"], "", "no serial reaches this compositor; empty beats invented");
+}
+
+/// The refusal is the only diagnostic `keyword` has — `hyprctl` exits
+/// zero for it — so it must not be false. It used to claim chonkstep
+/// does not read a Hyprland config, which is this compositor's headline
+/// feature.
+#[test]
+fn the_keyword_refusal_is_true_and_names_the_routes_that_work() {
+    let answer = ask("keyword monitor eDP-1,disable", &desktop());
+    assert!(answer.starts_with("Invalid dispatcher:"), "keyword stays a refusal: {answer}");
+    assert!(
+        !answer.contains("does not read a Hyprland config"),
+        "the compositor does read one; saying otherwise sends a reader the wrong way: {answer}"
+    );
+    assert!(answer.contains("~/.config/hypr"), "name the file that does work: {answer}");
+    assert!(answer.contains("hl.monitor"), "name the live route that does work: {answer}");
+    assert!(
+        answer.contains("disable"),
+        "the one shipped caller toggles a monitor off; say why that cannot work: {answer}"
     );
 }

--- a/crates/chonk-testkit/tests/hyprland_ipc.rs
+++ b/crates/chonk-testkit/tests/hyprland_ipc.rs
@@ -256,6 +256,63 @@ fn a_connection_storm_is_capped_before_it_can_grow_the_source_set() {
     );
 }
 
+/// The monitor object a display panel reads, against a live session.
+///
+/// Three of its fields used to be fabricated while the same session
+/// published the truth on `wl_output` and `zwlr_output_management` at
+/// the same moment: `availableModes` was empty, and `make`/`model` were
+/// empty strings. The nested backend drives one mode, so this cannot
+/// prove the *rate* is measured (its host window is 60 Hz either way —
+/// that is what the unit tests in `chonk-hyprland-ipc` are for), but it
+/// can prove the list and the identity are no longer blank.
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn a_live_monitor_reports_its_real_modes_and_identity() {
+    let session = boot("hypr-ipc-monitor-facts");
+    let dir = socket_dir(&session);
+
+    let monitors = json(&dir, "j/monitors");
+    let monitor = &monitors.as_array().expect("monitors is an array")[0];
+
+    let modes = monitor["availableModes"].as_array().expect("availableModes is a list");
+    assert!(
+        !modes.is_empty(),
+        "the session enumerates this connector's modes for wlr-output-management; \
+         IPC must not report none: {monitor}"
+    );
+    let current = modes[0].as_str().expect("a mode is a string");
+    assert!(
+        current.contains('x') && current.ends_with("Hz"),
+        "Hyprland's spelling is WIDTHxHEIGHT@RATEHz, got {current:?}"
+    );
+    assert!(
+        !monitor["model"].as_str().unwrap_or_default().is_empty(),
+        "model comes from the same properties wl_output advertises: {monitor}"
+    );
+    assert!(
+        monitor["refreshRate"].as_f64().unwrap_or(0.0) > 0.0,
+        "no caller may be handed a rate it will divide by: {monitor}"
+    );
+}
+
+/// `keyword` is refused, and the refusal is the only diagnostic there
+/// is: `hyprctl` exits zero for it. The old sentence denied the
+/// compositor's headline feature.
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn the_live_keyword_refusal_does_not_deny_reading_a_hyprland_config() {
+    let session = boot("hypr-ipc-keyword");
+    let dir = socket_dir(&session);
+
+    let answer = request(&dir, "keyword monitor eDP-1,disable");
+    assert!(answer.starts_with("Invalid dispatcher:"), "still a refusal: {answer}");
+    assert!(
+        !answer.contains("does not read a Hyprland config"),
+        "chonkstep reads one; the refusal must not say otherwise: {answer}"
+    );
+    assert!(answer.contains("~/.config/hypr"), "point at the route that works: {answer}");
+}
+
 /// The four requests Quickshell makes on connect, in the shapes it
 /// parses. `j/status` is first because Quickshell will not even connect
 /// to the event socket until it is answered.

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -147,6 +147,16 @@ fn build_snapshot(
             // instance that no key can change.
             focused: index == focused_monitor_index(wm, &monitors_info),
             active_workspace: current,
+            // The connector's own account of itself, mirrored onto the
+            // backend from the same `Output` that answers `wl_output`
+            // and `zwlr_output_management` (see
+            // `Compositor::sync_monitor_outputs`). An index with no
+            // mirror yet reports nothing rather than a placeholder.
+            make: hardware(wm, index).map(|out| out.make.clone()).unwrap_or_default(),
+            model: hardware(wm, index).map(|out| out.model.clone()).unwrap_or_default(),
+            serial: hardware(wm, index).map(|out| out.serial.clone()).unwrap_or_default(),
+            refresh_millihertz: hardware(wm, index).map_or(0, |out| out.refresh_millihertz),
+            modes: hardware(wm, index).map(|out| out.modes.clone()).unwrap_or_default(),
         })
         .collect();
 
@@ -379,6 +389,12 @@ fn keysym_name(keysym: u32) -> String {
     } else {
         name
     }
+}
+
+/// The display-hardware mirror for the monitor at `index`, if the
+/// output layout has been synced since that monitor appeared.
+fn hardware(wm: &WindowManager<WaylandBackend>, index: usize) -> Option<&crate::state::MonitorOutput> {
+    wm.backend().monitor_outputs.get(index)
 }
 
 fn focused_monitor_index(wm: &WindowManager<WaylandBackend>, monitors: &[wm_core::MonitorInfo]) -> usize {

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -48,6 +48,8 @@ use smithay::input::keyboard::XkbConfig;
 use smithay::input::pointer::CursorImageStatus;
 use smithay::input::{Seat, SeatState};
 use smithay::output::{Mode, Output, PhysicalProperties, Scale as OutputScale, Subpixel};
+
+use chonk_hyprland_ipc::MonitorMode;
 use smithay::reexports::calloop::generic::Generic;
 use smithay::reexports::calloop::{
     EventLoop, Interest, LoopHandle, Mode as TriggerMode, PostAction, RegistrationToken,
@@ -691,6 +693,16 @@ pub struct WaylandBackend {
     /// scale has no meaning (the X session is scaled by rasterizing the
     /// theme larger, not by telling anyone a factor).
     pub(crate) monitor_scales: Vec<f64>,
+    /// Per-monitor display hardware facts, in the same index order as
+    /// `Backend::monitors` — what the connector's EDID and chosen mode
+    /// say, mirrored here for the callers that ask over IPC.
+    ///
+    /// Not on `MonitorInfo` for the same reason `monitor_scales` is
+    /// not (see above): that type is `wm-core`'s and is shared with the
+    /// X11 backend, and nothing in the core wants a mode list. The
+    /// Hyprland IPC snapshot and `zwlr_output_management` are the only
+    /// readers, and both live on this side of the boundary.
+    pub(crate) monitor_outputs: Vec<MonitorOutput>,
     /// Live input devices, maintained from backend hotplug events and
     /// served through Hyprland-compatible IPC.
     pub(crate) input_devices: Vec<InputDeviceRecord>,
@@ -892,6 +904,7 @@ impl WaylandBackend {
     pub(crate) fn new(display_handle: DisplayHandle, monitors: Vec<MonitorInfo>, scale: f32) -> Self {
         let output_size = union_size(&monitors);
         let monitor_scales = vec![scale.max(0.125) as f64; monitors.len()];
+        let monitor_outputs = vec![MonitorOutput::default(); monitors.len()];
         Self {
             next_id: 1,
             windows: HashMap::new(),
@@ -920,6 +933,7 @@ impl WaylandBackend {
             root_background: RootBackground::Color((0, 0, 0)),
             monitors,
             monitor_scales,
+            monitor_outputs,
             input_devices: Vec::new(),
             ime_popups: Vec::new(),
             output_size,
@@ -1331,6 +1345,22 @@ pub(crate) struct OutputSetup {
     /// alternatives instead of pretending the current mode is the only
     /// one.
     pub modes: Vec<Mode>,
+}
+
+/// What one output's connector says about itself: the EDID identity and
+/// the modes it can drive.
+///
+/// Mirrored onto [`WaylandBackend::monitor_outputs`] so the Hyprland IPC
+/// snapshot can report measured values instead of conventional ones.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct MonitorOutput {
+    pub make: String,
+    pub model: String,
+    pub serial: String,
+    /// Current mode's refresh in millihertz; 0 when no real mode is
+    /// driven, which is what the wire layer turns into its fallback.
+    pub refresh_millihertz: u32,
+    pub modes: Vec<MonitorMode>,
 }
 
 /// One output the compositor drives, everything the session needs to
@@ -2950,6 +2980,49 @@ impl Compositor {
     pub(crate) fn sync_monitor_scales(&mut self) {
         let scales: Vec<f64> = self.outputs.iter().map(|entry| entry.scale).collect();
         self.wm.backend_mut().monitor_scales = scales;
+        self.sync_monitor_outputs();
+    }
+
+    /// Mirrors each output's EDID identity and mode list onto the
+    /// backend, where the IPC snapshot can reach them.
+    ///
+    /// Read straight off the `Output` the compositor already drives, so
+    /// what IPC reports and what `wl_output` / `zwlr_output_management`
+    /// advertise for the same head come from one source and cannot
+    /// drift. Rides along with the scale sync because the two change
+    /// together: every event that reshapes the output layout moves both.
+    pub(crate) fn sync_monitor_outputs(&mut self) {
+        let outputs: Vec<MonitorOutput> = self
+            .outputs
+            .iter()
+            .map(|entry| {
+                let properties = entry.output.physical_properties();
+                MonitorOutput {
+                    make: properties.make,
+                    model: properties.model,
+                    // No connector serial reaches this compositor. Left
+                    // empty rather than filled with the model again:
+                    // an empty string is a readable "not known", a
+                    // duplicated model is a wrong answer.
+                    serial: String::new(),
+                    refresh_millihertz: entry
+                        .output
+                        .current_mode()
+                        .and_then(|mode| u32::try_from(mode.refresh).ok())
+                        .unwrap_or(0),
+                    modes: entry
+                        .modes
+                        .iter()
+                        .map(|mode| MonitorMode {
+                            width: mode.size.w,
+                            height: mode.size.h,
+                            refresh_millihertz: u32::try_from(mode.refresh).unwrap_or(0),
+                        })
+                        .collect(),
+                }
+            })
+            .collect();
+        self.wm.backend_mut().monitor_outputs = outputs;
     }
 
     /// Change one live output's advertised scale from IPC. The scale
@@ -3787,6 +3860,21 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
             .into());
         }
     }
+
+    // Seed the hardware mirror from the outputs just created. Every
+    // later reshape re-syncs it, but the first IPC query can arrive
+    // before any reshape does, and a monitor list that reports no modes
+    // until something happens to move a scale is the same fabricated
+    // answer this replaced.
+    //
+    // Deliberately not `sync_monitor_scales`, which would also be
+    // correct-looking here and is not: `OutputEntry::new` starts every
+    // entry at 1.0 and only `advertise_scale` — which no startup path
+    // reaches — writes the session's real factor into it. Syncing
+    // scales from the entries at this point would overwrite the ledger
+    // the backend was *constructed* with and flatten a 2x session to 1x
+    // until something happened to change a scale.
+    comp.sync_monitor_outputs();
 
     // The end-to-end test door: a control socket for injected input,
     // opened only when CHONKSTEP_TEST_SOCKET is set (a user session

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -129,6 +129,32 @@ not reported as unknown syntax. Monitor scaling validates the output
 and range before changing anything, so an Omarchy script cannot record
 a scale that the compositor said it applied but did not.
 
+`keyword` is refused, and the refusal names what does work instead:
+chonkstep re-reads `~/.config/hypr` within a second of an edit, and
+`hyprctl eval hl.monitor({ output=..., scale=... })` changes a live
+scale. The one shipped Omarchy caller is the monitor panel's row toggle
+(`hyprctl keyword monitor NAME,disable` / `NAME,preferred,auto,auto`),
+and that specific form is refused by name for a reason the user can act
+on: chonkstep drives every connected output and has no disable path, so
+its `disabled` field is honestly `false` for every head and the panel's
+checkmark will not move. Growing an output-disable path—routing that
+form into the same validated apply `zwlr_output_management` already
+uses—is a real but separate piece of work; until it exists, saying so
+in the refusal is the honest answer, because `hyprctl` exits zero for a
+refusal and the string is the only diagnostic a user gets.
+
+The monitor object reports measured values, not conventional ones.
+`refreshRate` is the driven mode's rate, `availableModes` is the
+connector's mode list in `WIDTHxHEIGHT@RATEHz` with the current mode
+first, and `make`/`model` come from the same properties the matching
+`wl_output` advertises—so IPC and `zwlr_output_management` cannot
+describe one panel two ways. Two fields stay empty on purpose: `serial`,
+because no connector serial reaches this compositor, and a duplicated
+model would be a wrong answer where an empty string is a readable "not
+known"; and `vrr`, which is covered by the adaptive-sync work. A backend
+driving no real mode reports 60 Hz rather than 0, because a bar divides
+this into a frame budget.
+
 Tiling vocabulary—`layoutmsg`, `togglesplit`, `swapwindow`, `pseudo`,
 groups, special workspaces, tiled workspace options—has no faithful
 meaning on this floating desktop and is refused. The mirrored Omarchy


### PR DESCRIPTION
Fixes #100

## Root cause

Two separate confidently-wrong answers on the same object.

**The refusal was false.** `keyword` answered `"chonkstep does not read a Hyprland config; keyword changes nothing"`. Reading the user's live `~/.config/hypr` tree is this compositor's headline feature — all of `crates/wm-config/src/hyprland/` and 440 lines of `docs/hyprland-config.md`. `hyprctl` exits zero for a refusal, so that string is the *only* diagnostic a user gets, and it pointed them away from the one route that works.

**Four monitor fields were fabricated while the same session held the truth.** `refreshRate` was a hardcoded `60.0`, `availableModes` an empty list, `make`/`model`/`serial` three empty strings — at the same moment `zwlr_output_management` was enumerating that connector's full mode list and `wl_output` was advertising its make and model. The placeholder survived because the type in the middle was never widened, not because the value was unavailable.

## Behavioral change

- **The refusal is true and actionable**, and stays a refusal (`keyword` is Hyprland's whole config namespace; answering `ok` for it would be worse). It now names the two routes that work — edit `~/.config/hypr`, which is re-read within a second, or `hyprctl eval hl.monitor({...})` for a live scale — and calls out `monitor NAME,disable` by name, because that is the one shipped Omarchy caller (the display panel's row toggle) and a user watching it do nothing deserves the actual reason.
- **`refreshRate` is the driven mode's rate.** `0` still falls back to 60.0, because a bar divides this into a frame budget — but that is now the fallback, not the policy, and the comment says so.
- **`availableModes` is the connector's mode list**, current first, in Hyprland's `WIDTHxHEIGHT@RATEHz`.
- **`make`/`model`** come from the same `PhysicalProperties` the matching `wl_output` carries, so the two protocols cannot describe one panel two ways. `serial` stays empty: no connector serial reaches this compositor, and an empty string is a readable "not known" where a duplicated model would be a wrong answer.
- The decision on `monitor NAME,disable` is recorded in `docs/hyprland-ipc.md` beside the tiling refusals, along with why `serial` and `vrr` stay empty.

## One deviation from the issue's proposed fix, deliberately

The issue proposes adding `refresh_millihertz` to `wm_core::MonitorInfo`. I put all four facts in a backend-side mirror (`WaylandBackend::monitor_outputs`) beside `monitor_scales` instead, for two reasons:

1. The comment directly above `monitor_scales` already answers this question for this exact situation — that field is on the backend *and not on `MonitorInfo`* precisely because `MonitorInfo` is `wm-core`'s and is shared with the X11 backend. The same reasoning covers a mode list, which nothing in `wm-core` wants.
2. `refreshRate` is not the only fabricated field. Putting the rate on `MonitorInfo` and the modes/make/model somewhere else would split four facts about one connector across two mechanisms; one mirror keeps them together and keeps the X11 backend untouched.

The values are read straight off the `Output` the compositor already drives, so IPC and `zwlr_output_management` share a source by construction rather than by convention.

## Invariants and edge cases

- **A startup-ordering trap I hit and fixed before pushing:** seeding the mirror by calling `sync_monitor_scales()` at startup looks right and is not. `OutputEntry::new` starts every entry at `scale: 1.0` and only `advertise_scale` — which no startup path reaches — writes the session's real factor. Syncing scales there would have overwritten the ledger the backend was *constructed* with and flattened a 2x session to 1x until something changed a scale. Startup now calls `sync_monitor_outputs()` alone, and the comment records the trap. `chromium_resize_at_scale_2_keeps_its_scale` passes.
- The mirror is index-parallel to `Backend::monitors`, the same contract `monitor_scales` has; an index with no mirror yet reports empty rather than a placeholder.
- `refresh_millihertz` stays in millihertz all the way to the wire; the conversion to Hyprland's float happens once, at the JSON boundary.

## Tests added

`chonk-hyprland-ipc/tests/protocol.rs` — the fixture panel is **120 Hz on purpose**, so a fixture that was also 60 could not pass by accident:

- `a_monitors_refresh_rate_is_the_modes_rate_not_a_convention`
- `a_monitor_with_no_real_mode_falls_back_rather_than_reporting_zero`
- `a_monitors_mode_list_is_the_connectors_modes_in_hyprlands_spelling` (also make/model/serial)
- `the_keyword_refusal_is_true_and_names_the_routes_that_work`

`chonk-testkit/tests/hyprland_ipc.rs`, against a live nested session:

- `a_live_monitor_reports_its_real_modes_and_identity`
- `the_live_keyword_refusal_does_not_deny_reading_a_hyprland_config`

The nested backend drives one 60 Hz mode, so the e2e cannot prove the *rate* is measured — that is what the 120 Hz unit fixture is for. It can and does prove the mode list and identity are no longer blank, which they were.

## Commands run

```
cargo test -p chonk-hyprland-ipc                             49 passed
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
cargo test -p chonk-testkit --test hyprland_ipc -- \
  --ignored --test-threads=1                                 13 passed, 3 failed
```

The three nested failures are `could not launch zenity: No such file or directory` — `zenity` is not installed on the development machine. Verified pre-existing by running the same target on `origin/main`: the same three fail there (`a_real_window_appears_in_the_stream_and_the_client_list`, `foreign_toplevel_mapping_returns_the_same_live_ipc_address`, `window_geometry_plain_fields_and_monitor_eval_are_applied_before_ok`). `scripts/e2e.sh --headless` cannot run here at all: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. CI's `wayland` job has the full client set.

## Known limitations / follow-up

- **`monitor NAME,disable` still does not work** — it is now refused by name with the real reason instead of a false one. Growing an output-disable path (routing that form into the same validated apply `zwlr_output_management` uses in `output_mgmt.rs`) is real, bounded work and is not in this PR; it is also not exercisable on a machine with no DRM backend.
- `serial` and `vrr` stay empty; `vrr` belongs to the adaptive-sync issue, which now has `monitor_outputs` to put a truthful answer in.
- `MonitorJson::reserved` is still `[0,0,0,0]` while its doc comment promises a caller fills it in. Left alone rather than half-done: wiring `Shell::apply_workareas` through is its own change with its own test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
