### PR TITLE
Answer the toplevel-mapping protocol's ext arm (#77)

### DIFF
--- a/crates/chonk-testkit/src/bin/chonk-toplevel-mapping-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-toplevel-mapping-probe.rs
@@ -1,10 +1,22 @@
-//! Correlates a live wlr foreign-toplevel handle through
-//! `hyprland-toplevel-mapping-v1` and prints the returned address.
+//! Correlates a live foreign-toplevel handle through
+//! `hyprland-toplevel-mapping-v1` and prints the returned address —
+//! once for the wlr manager's handle and once for the frozen
+//! `ext_foreign_toplevel_list_v1` handle naming the same window.
+//!
+//! The protocol has two requests and both are a *join*: whichever kind
+//! of handle a caller holds, the address that comes back has to be the
+//! one `hyprctl clients -j` prints. The ext arm answered `failed`
+//! unconditionally until the list was served, so the probe labels each
+//! answer with the arm that produced it.
 
 use std::io::Write;
 
 use wayland_client::protocol::wl_registry;
 use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_protocols::ext::foreign_toplevel_list::v1::client::{
+    ext_foreign_toplevel_handle_v1::{self, ExtForeignToplevelHandleV1},
+    ext_foreign_toplevel_list_v1::{self, ExtForeignToplevelListV1},
+};
 use wayland_protocols_wlr::foreign_toplevel::v1::client::{
     zwlr_foreign_toplevel_handle_v1::{self, ZwlrForeignToplevelHandleV1},
     zwlr_foreign_toplevel_manager_v1::{self, ZwlrForeignToplevelManagerV1},
@@ -38,9 +50,31 @@ use mapping_bindings::hyprland_toplevel_window_mapping_handle_v1::{
     self, HyprlandToplevelWindowMappingHandleV1,
 };
 
+/// Which of the mapping protocol's two requests a pending answer came
+/// from. Carried as the response object's user data, because the two
+/// arms are only interesting when compared.
+#[derive(Clone, Copy)]
+enum Origin {
+    Wlr,
+    Ext,
+}
+
+impl Origin {
+    fn name(self) -> &'static str {
+        match self {
+            Origin::Wlr => "wlr",
+            Origin::Ext => "ext",
+        }
+    }
+}
+
 #[derive(Default)]
 struct Probe {
     foreign: Option<ZwlrForeignToplevelManagerV1>,
+    /// The frozen list beside the wlr manager. Both name the same
+    /// windows; the point of the probe is that both resolve to one
+    /// address through `hyprland-toplevel-mapping-v1`.
+    ext_list: Option<ExtForeignToplevelListV1>,
     mapping: Option<HyprlandToplevelMappingManagerV1>,
 }
 
@@ -63,6 +97,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
                 "zwlr_foreign_toplevel_manager_v1" => {
                     probe.foreign = Some(registry.bind(name, version.min(3), qh, ()))
                 }
+                "ext_foreign_toplevel_list_v1" => {
+                    probe.ext_list = Some(registry.bind(name, version.min(1), qh, ()))
+                }
                 "hyprland_toplevel_mapping_manager_v1" => {
                     probe.mapping = Some(registry.bind(name, version.min(1), qh, ()))
                 }
@@ -83,7 +120,7 @@ impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for Probe {
     ) {
         if let zwlr_foreign_toplevel_manager_v1::Event::Toplevel { toplevel } = event {
             if let Some(mapping) = &probe.mapping {
-                mapping.get_window_for_toplevel_wlr(&toplevel, qh, ());
+                mapping.get_window_for_toplevel_wlr(&toplevel, qh, Origin::Wlr);
             }
         }
     }
@@ -109,6 +146,43 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for Probe {
     }
 }
 
+impl Dispatch<ExtForeignToplevelListV1, ()> for Probe {
+    fn event(
+        probe: &mut Self,
+        _: &ExtForeignToplevelListV1,
+        event: ext_foreign_toplevel_list_v1::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let ext_foreign_toplevel_list_v1::Event::Toplevel { toplevel } = event {
+            if let Some(mapping) = &probe.mapping {
+                mapping.get_window_for_toplevel(&toplevel, qh, Origin::Ext);
+            }
+        }
+    }
+
+    wayland_client::event_created_child!(Probe, ExtForeignToplevelListV1, [
+        ext_foreign_toplevel_list_v1::EVT_TOPLEVEL_OPCODE => (ExtForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<ExtForeignToplevelHandleV1, ()> for Probe {
+    fn event(
+        _: &mut Self,
+        _: &ExtForeignToplevelHandleV1,
+        event: ext_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if matches!(event, ext_foreign_toplevel_handle_v1::Event::Done) {
+            println!("**ext done**");
+            let _ = std::io::stdout().flush();
+        }
+    }
+}
+
 impl Dispatch<HyprlandToplevelMappingManagerV1, ()> for Probe {
     fn event(
         _: &mut Self,
@@ -121,12 +195,12 @@ impl Dispatch<HyprlandToplevelMappingManagerV1, ()> for Probe {
     }
 }
 
-impl Dispatch<HyprlandToplevelWindowMappingHandleV1, ()> for Probe {
+impl Dispatch<HyprlandToplevelWindowMappingHandleV1, Origin> for Probe {
     fn event(
         _: &mut Self,
         _: &HyprlandToplevelWindowMappingHandleV1,
         event: hyprland_toplevel_window_mapping_handle_v1::Event,
-        _: &(),
+        origin: &Origin,
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
@@ -135,13 +209,19 @@ impl Dispatch<HyprlandToplevelWindowMappingHandleV1, ()> for Probe {
                 address_hi,
                 address,
             } => {
-                println!(
-                    "**mapped address 0x{:x}**",
-                    (u64::from(address_hi) << 32) | u64::from(address)
-                );
+                let address = (u64::from(address_hi) << 32) | u64::from(address);
+                // The unlabelled line is kept verbatim: an older test
+                // matches on it, and the wlr arm is what it watches.
+                if matches!(origin, Origin::Wlr) {
+                    println!("**mapped address 0x{address:x}**");
+                }
+                println!("**{} address 0x{address:x}**", origin.name());
             }
             hyprland_toplevel_window_mapping_handle_v1::Event::Failed => {
-                println!("**mapping failed**")
+                println!("**{} mapping failed**", origin.name());
+                if matches!(origin, Origin::Wlr) {
+                    println!("**mapping failed**");
+                }
             }
         }
         let _ = std::io::stdout().flush();
@@ -158,6 +238,12 @@ fn main() {
     queue.roundtrip(&mut probe).expect("registry roundtrip");
     if probe.foreign.is_none() || probe.mapping.is_none() {
         println!("**required global missing**");
+        return;
+    }
+    if probe.ext_list.is_none() {
+        // Named separately so "the compositor does not serve the frozen
+        // list" and "the probe could not start" are different failures.
+        println!("**ext list missing**");
         return;
     }
     println!("**mapping ready**");

--- a/crates/chonk-testkit/tests/hyprland_ipc.rs
+++ b/crates/chonk-testkit/tests/hyprland_ipc.rs
@@ -313,6 +313,60 @@ fn the_live_keyword_refusal_does_not_deny_reading_a_hyprland_config() {
     assert!(answer.contains("~/.config/hypr"), "point at the route that works: {answer}");
 }
 
+/// The mapping protocol has two requests, and both are a join: whether
+/// a caller holds the wlr manager's handle or the frozen
+/// `ext_foreign_toplevel_list_v1` handle, the address that comes back
+/// must be the one `hyprctl clients -j` prints for that window.
+///
+/// The ext arm answered `failed` unconditionally while the list went
+/// unadvertised, so half of a protocol this compositor chose to serve
+/// was inert. Deliberately driven with the harness's own probe rather
+/// than `zenity`, so it runs wherever the harness builds.
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn both_mapping_arms_resolve_one_window_to_one_address() {
+    let mut session = boot("hypr-toplevel-mapping-ext");
+    let dir = socket_dir(&session);
+    let mapper = profile_binary("chonk-toplevel-mapping-probe").expect("mapping probe built");
+    session.launch(mapper.to_str().unwrap(), &[]).expect("mapping probe launches");
+    poll_until(EVENT, "the mapping probe to bind every global", || {
+        session.client_log("chonk-toplevel-mapping-probe").contains("**mapping ready**").then_some(())
+    })
+    .expect("the mapping probe binds the wlr manager, the ext list and the mapping manager");
+
+    let window = profile_binary("chonk-fullscreen-probe").expect("fullscreen probe built");
+    session
+        .launch(window.to_str().unwrap(), &["ext-mapping", "ext-mapping"])
+        .expect("the window under test launches");
+    session.wait_for_window("ext-mapping").expect("the window maps");
+
+    fn address_from(session: &Session, arm: &str) -> Option<String> {
+        let report = session.client_log("chonk-toplevel-mapping-probe");
+        let marker = format!("**{arm} address ");
+        Some(report.split(&marker).nth(1)?.split("**").next()?.to_string())
+    }
+
+    let wlr = poll_until(EVENT, "the wlr arm to answer", || address_from(&session, "wlr"))
+        .expect("the wlr arm answers with an address");
+    let ext = poll_until(EVENT, "the ext arm to answer", || address_from(&session, "ext"))
+        .expect("the ext arm must answer with an address, not `failed`");
+    assert_eq!(wlr, ext, "one window has one address whichever handle names it");
+
+    let clients = json(&dir, "j/clients");
+    let ipc = clients
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|client| client["title"].as_str().is_some_and(|title| title.contains("ext-mapping")))
+        .and_then(|client| client["address"].as_str())
+        .expect("the same window appears in IPC");
+    assert_eq!(ext, ipc, "the ext arm must join to the address hyprctl prints");
+    assert!(
+        !session.client_log("chonk-toplevel-mapping-probe").contains("**ext mapping failed**"),
+        "the ext arm answered `failed`, which is the defect this covers"
+    );
+}
+
 /// The four requests Quickshell makes on connect, in the shapes it
 /// parses. `j/status` is first because Quickshell will not even connect
 /// to the event socket until it is answered.

--- a/crates/wm-wayland/src/protocols.rs
+++ b/crates/wm-wayland/src/protocols.rs
@@ -150,6 +150,7 @@ use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_scre
 use smithay::reexports::wayland_protocols_wlr::screencopy::v1::server::zwlr_screencopy_manager_v1::{
     self, ZwlrScreencopyManagerV1,
 };
+use smithay::reexports::wayland_protocols::ext::foreign_toplevel_list::v1::server::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1;
 use smithay::wayland::foreign_toplevel_list::{
     ForeignToplevelHandle, ForeignToplevelListHandler, ForeignToplevelListState,
 };
@@ -230,6 +231,26 @@ pub(crate) struct ProtocolState {
     minimize_requests: Vec<(WlWindowId, bool)>,
     /// Capture requests waiting for a frame to answer them.
     captures: Vec<PendingCapture>,
+}
+
+/// Resolve an ext foreign-toplevel resource back to its managed window.
+///
+/// The mirror of [`window_for_wlr_toplevel`] for the frozen protocol,
+/// and the join key `hyprland-toplevel-mapping-v1` hangs its ext
+/// request off. The window id rides in the handle's own user data,
+/// planted where the handle is minted ([`sync_ext_toplevels`]), so this
+/// is a map lookup rather than a scan — but the answer is still gated
+/// on the window being *currently* listed. A handle whose window has
+/// closed keeps its inner state alive for as long as a client holds the
+/// resource, and resolving one of those would hand out an address for a
+/// window that is gone; the wlr arm refuses that case by construction
+/// and this one refuses it explicitly.
+pub(crate) fn window_for_ext_toplevel(
+    state: &ProtocolState,
+    handle: &ExtForeignToplevelHandleV1,
+) -> Option<WlWindowId> {
+    let window = *ForeignToplevelHandle::from_resource(handle)?.user_data().get::<WlWindowId>()?;
+    state.ext_toplevels.contains_key(&window).then_some(window)
 }
 
 /// Resolve a wlr foreign-toplevel resource back to its managed window.

--- a/crates/wm-wayland/src/toplevel_mapping.rs
+++ b/crates/wm-wayland/src/toplevel_mapping.rs
@@ -66,13 +66,18 @@ impl Dispatch<HyprlandToplevelMappingManagerV1, ()> for Compositor {
                     .map(wm_core::ClientId::as_u64);
                 send_address(&response, address);
             }
-            // Chonkstep currently advertises the stateful wlr manager,
-            // not ext-foreign-toplevel-list. The request remains in the
-            // upstream protocol and is answered honestly if a client
-            // imports such an object through another future global.
-            hyprland_toplevel_mapping_manager_v1::Request::GetWindowForToplevel { handle, .. } => {
+            // The same join through the frozen protocol. Both arms
+            // resolve to one `ClientId`, so a caller holding either
+            // kind of handle gets the address `hyprctl clients -j`
+            // prints for that window — which is the whole contract of
+            // this protocol, and was half-inert while the ext list went
+            // unadvertised.
+            hyprland_toplevel_mapping_manager_v1::Request::GetWindowForToplevel { handle, toplevel } => {
                 let response = data_init.init(handle, ());
-                response.failed();
+                let address = crate::protocols::window_for_ext_toplevel(&state.protocols, &toplevel)
+                    .and_then(|window| state.wm.client_for_window(window))
+                    .map(wm_core::ClientId::as_u64);
+                send_address(&response, address);
             }
             hyprland_toplevel_mapping_manager_v1::Request::Destroy => {}
         }


### PR DESCRIPTION
Fixes #77

## What changed under this issue while it was open

PR #118 (Codex, issues 46–51) landed `ext_foreign_toplevel_list_v1` on `main` at `626c65a`, as a prerequisite for the window-capture work in #51. So the first half of this issue — "the frozen protocol is not advertised at all" — is already fixed, and this PR does **not** re-do it. `ProtocolState` carries `ext_list`/`ext_toplevels`, `sync_ext_toplevels` maintains them, and `wayland_globals.rs` already asserts the global is advertised.

What #118 did not touch is the half this issue names as its visible symptom: `hyprland-toplevel-mapping-v1`'s ext request. On `main` today it is still

```rust
hyprland_toplevel_mapping_manager_v1::Request::GetWindowForToplevel { handle, .. } => {
    let response = data_init.init(handle, ());
    response.failed();
}
```

with a comment explaining the refusal by the very condition that no longer holds — "Chonkstep currently advertises the stateful wlr manager, not ext-foreign-toplevel-list". The compositor now advertises both and still refuses to join one of them. That is what this PR fixes.

## Root cause

The mapping protocol has two requests and both are the same join: whichever kind of handle a caller holds, the address that comes back should be the one `hyprctl clients -j` prints. Only `GetWindowForToplevelWlr` resolved, through `protocols::window_for_wlr_toplevel`. The ext arm had no counterpart to resolve through, so it answered `failed` unconditionally — including to callers holding a handle the compositor had just minted itself.

## Behavioral change

- New `protocols::window_for_ext_toplevel`, the mirror of `window_for_wlr_toplevel`. The window id already rides in the handle's own user data — `sync_ext_toplevels` plants it where the handle is minted — so this is a map lookup rather than a scan.
- The ext arm resolves through it and calls the same `send_address` the wlr arm does, so both requests share one code path to one `ClientId`.
- The stale comment goes with the behaviour it described.

## Invariants and edge cases

- **A closed window must not resolve.** A `ForeignToplevelHandle`'s inner state stays alive as long as a client holds the resource, so `from_resource` + user-data alone would happily hand out an address for a window that is gone. The lookup is gated on the window still being in `ext_toplevels`, which `sync_ext_toplevels` prunes on close — matching the wlr arm, which gets that refusal for free because its handles are dropped from the entry. This is the identifier-stability invariant the issue calls out, enforced at the one place that can violate it.
- The existing `foreign_toplevel_dirty` gate is untouched: nothing here adds a publication path or a per-pass cost.
- The probe keeps emitting its original unlabelled `**mapped address …**` line for the wlr arm, so the pre-existing `foreign_toplevel_mapping_returns_the_same_live_ipc_address` test is unaffected by the new labelling.

## Tests added

`both_mapping_arms_resolve_one_window_to_one_address` in `crates/chonk-testkit/tests/hyprland_ipc.rs`, against a live nested session. `chonk-toplevel-mapping-probe` now binds the ext list as well and labels each answer with the arm that produced it (`Origin::Wlr` / `Origin::Ext` as the response object's user data). The test asserts three things that were not all true before: the ext arm answers with an address rather than `failed`, both arms return the *same* address, and that address is the one `j/clients` reports.

Driven with the harness's own `chonk-fullscreen-probe` as the window rather than `zenity`, deliberately — the existing mapping test uses `zenity` and is therefore one of the three that cannot run on a machine without it. This one runs anywhere the harness builds.

### Fails without the fix

Restoring the `response.failed()` arm, rebuilding, re-running:

```
test both_mapping_arms_resolve_one_window_to_one_address ... FAILED
the ext arm must answer with an address, not `failed`: "timed out after 10s waiting for the ext arm to answer"
```

## Commands run

```
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
cargo test -p chonk-testkit --test hyprland_ipc \
  --test wayland_globals -- --ignored --test-threads=1       12 passed, 3 failed
```

The three failures are `could not launch zenity: No such file or directory` and pre-exist this branch on `origin/main` (`a_real_window_appears_in_the_stream_and_the_client_list`, `foreign_toplevel_mapping_returns_the_same_live_ipc_address`, `window_geometry_plain_fields_and_monitor_eval_are_applied_before_ok`). `scripts/e2e.sh --headless` cannot run on this machine at all: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. CI's `wayland` job has the full client set.

## Known limitations / follow-up

- The external consumers this unblocks (`xdg-desktop-portal-wlr`'s window picker, tools written against the frozen protocol) are not exercised here; that is the separate window-screencast work, which #118 moved forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
