### PR TITLE
Honour EWMH close and the urgency/pin requests X11 clients send (#88)

### DIFF
--- a/crates/chonk-testkit/tests/xwayland_input.rs
+++ b/crates/chonk-testkit/tests/xwayland_input.rs
@@ -7,6 +7,7 @@
 //! describing three different rectangles. A raw x11rb client makes every
 //! side observable without depending on a toolkit's own scaling policy.
 
+use std::path::Path;
 use std::time::Duration;
 
 use chonk_testkit::{poll_until, Session, SessionOptions, WindowInfo};
@@ -450,4 +451,345 @@ fn xwayland_wm_change_state_minimizes_and_restores() {
             .then_some(())
     })
     .expect("NormalState restores and clears the published hidden state");
+}
+
+// ---------------------------------------------------------------------
+// EWMH/ICCCM requests an X11 client sends and a scripted desktop relies
+// on. Root client messages reach the compositor's own `xewmh`
+// connection; `WM_HINTS` reaches it through smithay's `X11Surface`.
+
+/// Maps a raw X11 window with a title and class, and waits for the
+/// compositor to have managed it.
+fn map_probe_window(
+    session: &mut Session,
+    conn: &x11rb::rust_connection::RustConnection,
+    screen_num: usize,
+    title: &str,
+    hints: Option<&[u32; 9]>,
+) -> (u32, u64) {
+    let existing = mapped_ids(session);
+    let screen = &conn.setup().roots[screen_num];
+    let xid = conn.generate_id().unwrap();
+    conn.create_window(
+        COPY_DEPTH_FROM_PARENT,
+        xid,
+        screen.root,
+        0,
+        0,
+        400,
+        300,
+        0,
+        WindowClass::INPUT_OUTPUT,
+        COPY_FROM_PARENT,
+        &CreateWindowAux::new()
+            .background_pixel(screen.black_pixel)
+            .event_mask(EventMask::STRUCTURE_NOTIFY),
+    )
+    .unwrap();
+    conn.change_property8(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        xid,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
+        title.as_bytes(),
+    )
+    .unwrap();
+    // `_NET_WM_NAME` as well as `WM_NAME`: the EWMH property is what
+    // smithay reads for `X11Surface::title`, and therefore what the
+    // ledger matches on.
+    let net_wm_name = intern(conn, b"_NET_WM_NAME");
+    let utf8 = intern(conn, b"UTF8_STRING");
+    conn.change_property8(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        xid,
+        net_wm_name,
+        utf8,
+        title.as_bytes(),
+    )
+    .unwrap();
+    // The ledger matches on app id or title, and an X11 window's title
+    // reaches the record only through a later `TitleChanged`; the class
+    // is read at map time. Naming the class after the window is what
+    // makes `wait_for_window` deterministic here.
+    let class = format!("{title}\0{title}\0");
+    conn.change_property8(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        xid,
+        AtomEnum::WM_CLASS,
+        AtomEnum::STRING,
+        class.as_bytes(),
+    )
+    .unwrap();
+    if let Some(hints) = hints {
+        // Written *before* the map, which is the ordinary case and the
+        // one that produces no PropertyNotify for a change handler to
+        // catch.
+        conn.change_property32(
+            x11rb::protocol::xproto::PropMode::REPLACE,
+            xid,
+            AtomEnum::WM_HINTS,
+            AtomEnum::WM_HINTS,
+            hints,
+        )
+        .unwrap();
+    }
+    conn.map_window(xid).unwrap();
+    conn.flush().unwrap();
+    // An X11 window's identity is not part of the test-door record (see
+    // the scale-two test's note), so the observable is a *new* mapped
+    // entry rather than a title match.
+    let id = poll_until(EVENT, "the probe window to finish mapping", || {
+        session
+            .world()
+            .ok()?
+            .windows
+            .into_iter()
+            .find(|window| window.mapped && !existing.contains(&window.id))
+            .map(|window| window.id)
+    })
+    .expect("the probe window maps");
+    (xid, id)
+}
+
+/// The ledger ids already mapped, so a later map can be told apart.
+fn mapped_ids(session: &mut Session) -> Vec<u64> {
+    session
+        .world()
+        .map(|world| world.windows.into_iter().filter(|w| w.mapped).map(|w| w.id).collect())
+        .unwrap_or_default()
+}
+
+/// The Hyprland IPC request socket for a nested session, and one
+/// request against it. Small local copies of `hyprland_ipc.rs`'s
+/// helpers: this file needs exactly two calls, and the harness does not
+/// export them.
+fn ipc_socket_dir(session: &Session) -> std::path::PathBuf {
+    let signature = poll_until(EVENT, "the hyprland ipc log line", || {
+        let log = session.log();
+        let at = log.find("hyprland ipc listening")?;
+        let rest = &log[at..];
+        let start = rest.find('"')? + 1;
+        let end = rest[start..].find('"')? + start;
+        Some(rest[start..end].to_string())
+    })
+    .expect("the compositor logs the signature it bound");
+    let runtime = std::env::var("XDG_RUNTIME_DIR").expect("XDG_RUNTIME_DIR");
+    std::path::PathBuf::from(runtime).join("hypr").join(signature)
+}
+
+/// The Hyprland event socket. A bar listens to exactly this, and
+/// `urgent` is the user-visible signal an attention request produces.
+///
+/// Held open across the whole test rather than reconnected per wait:
+/// the stream carries no history, so a listener that connects after the
+/// trigger has already missed it.
+struct IpcEvents(std::io::BufReader<std::os::unix::net::UnixStream>);
+
+impl IpcEvents {
+    fn connect(dir: &Path) -> IpcEvents {
+        let stream = std::os::unix::net::UnixStream::connect(dir.join(".socket2.sock"))
+            .expect("event socket");
+        stream.set_read_timeout(Some(EVENT)).expect("read timeout");
+        IpcEvents(std::io::BufReader::new(stream))
+    }
+
+    fn wait_for(&mut self, name: &str) -> String {
+        use std::io::BufRead as _;
+        let deadline = std::time::Instant::now() + EVENT;
+        let prefix = format!("{name}>>");
+        let mut seen = Vec::new();
+        while std::time::Instant::now() < deadline {
+            let mut line = String::new();
+            if self.0.read_line(&mut line).unwrap_or(0) == 0 {
+                break;
+            }
+            let line = line.trim_end().to_string();
+            if let Some(data) = line.strip_prefix(&prefix) {
+                return data.to_string();
+            }
+            seen.push(line);
+        }
+        panic!("never saw {name}; events seen: {seen:#?}");
+    }
+}
+
+fn ipc_request(dir: &Path, payload: &str) -> String {
+    use std::io::{Read as _, Write as _};
+    let mut stream = std::os::unix::net::UnixStream::connect(dir.join(".socket.sock"))
+        .unwrap_or_else(|e| panic!("connecting to the request socket: {e}"));
+    stream.set_read_timeout(Some(EVENT)).expect("read timeout");
+    stream.write_all(payload.as_bytes()).expect("write the request");
+    stream.flush().expect("flush");
+    let mut response = String::new();
+    stream.read_to_string(&mut response).expect("read the response");
+    response
+}
+
+/// `WM_HINTS` with only the urgency bit set. Flags is element 0; the
+/// urgency bit is `1 << 8`.
+const WM_HINTS_URGENT: [u32; 9] = [1 << 8, 0, 0, 0, 0, 0, 0, 0, 0];
+const WM_HINTS_CALM: [u32; 9] = [0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+/// `wmctrl -c` and `xdotool windowclose` send this and nothing else.
+/// Under the Wayland session it used to land on the floor: the message
+/// reached the compositor's connection and `drain_inbound` dropped it,
+/// so the tool exited zero having done nothing at all.
+#[test]
+#[ignore = "needs a live Wayland session to nest in"]
+fn a_net_close_window_message_closes_an_xwayland_window() {
+    let mut session =
+        Session::boot("xwayland-ewmh-close", SessionOptions::default()).expect("nested compositor boots");
+    let display = xwayland_display(&session);
+    let _ = ewmh_display(&session);
+    let (conn, screen_num) =
+        x11rb::rust_connection::RustConnection::connect(Some(&format!(":{display}")))
+            .expect("connect to nested XWayland");
+    let root = conn.setup().roots[screen_num].root;
+    let (xid, id) = map_probe_window(&mut session, &conn, screen_num, "ewmh-close-me", None);
+
+    let close = intern(&conn, b"_NET_CLOSE_WINDOW");
+    conn.send_event(
+        false,
+        root,
+        EventMask::SUBSTRUCTURE_NOTIFY | EventMask::SUBSTRUCTURE_REDIRECT,
+        ClientMessageEvent::new(32, xid, close, [0u32, 2, 0, 0, 0]),
+    )
+    .unwrap();
+    conn.flush().unwrap();
+
+    // The backend's record outlives `wm-core`'s until the X11 surface
+    // is destroyed, so the observable is the mapped bit — "gone from
+    // the desktop", which is what the message asked for.
+    poll_until(EVENT, "the window named by _NET_CLOSE_WINDOW to go", || {
+        session
+            .world()
+            .ok()?
+            .windows
+            .iter()
+            .all(|window| window.id != id || !window.mapped)
+            .then_some(())
+    })
+    .expect("_NET_CLOSE_WINDOW must close the window it names");
+}
+
+/// The ICCCM half of the attention story — how IRC clients, terminal
+/// bells and mail notifiers actually ask, and the half smithay's XWM
+/// drops on the floor because `_NET_WM_STATE` is the only route it
+/// decodes.
+///
+/// The urgency is raised on a window that is *not* focused, which is
+/// both the realistic shape and the only one that can be observed: a
+/// window that asks for attention while the user is already in it has
+/// its request answered immediately, by the same dismissal this change
+/// adds.
+#[test]
+#[ignore = "needs a live Wayland session to nest in"]
+fn wm_hints_urgency_is_read_at_map_and_cleared_by_focus() {
+    let mut options = SessionOptions::default();
+    options.env.push(("CHONKSTEP_HYPRLAND_IPC".to_string(), "1".to_string()));
+    let mut session =
+        Session::boot("xwayland-ewmh-urgency", options).expect("nested compositor boots");
+    let display = xwayland_display(&session);
+    let _ = ewmh_display(&session);
+    let (conn, screen_num) =
+        x11rb::rust_connection::RustConnection::connect(Some(&format!(":{display}")))
+            .expect("connect to nested XWayland");
+    // A second window mapped after the noisy one, so the noisy one is
+    // genuinely in the background when it asks for attention.
+    let (noisy, _) = map_probe_window(&mut session, &conn, screen_num, "ewmh-noisy", Some(&WM_HINTS_CALM));
+    // Mapped second, so it holds focus and the noisy one is genuinely
+    // in the background when it rings.
+    let _calm = map_probe_window(&mut session, &conn, screen_num, "ewmh-calm", Some(&WM_HINTS_CALM));
+
+    // Observed on the Hyprland event socket, because that is where an
+    // attention request becomes visible to a bar: the differ emits
+    // `urgent>>` on the false→true edge of exactly the flag
+    // `xdg_system_bell` sets for a native client.
+    let dir = ipc_socket_dir(&session);
+    let address_of = |dir: &Path, class: &str| -> String {
+        let clients: serde_json::Value =
+            serde_json::from_str(&ipc_request(dir, "j/clients")).expect("clients is JSON");
+        clients
+            .as_array()
+            .expect("clients is an array")
+            .iter()
+            .find(|client| client["class"].as_str().is_some_and(|c| c.contains(class)))
+            .and_then(|client| client["address"].as_str())
+            .unwrap_or_else(|| panic!("no client with class {class}"))
+            .to_string()
+    };
+    // `j/clients` prints `0x`-prefixed; the event stream does not.
+    let noisy_address =
+        address_of(&dir, "ewmh-noisy").trim_start_matches("0x").to_string();
+    let mut events = IpcEvents::connect(&dir);
+
+    // The bell: the client raises the ICCCM urgency bit on a window the
+    // user is not looking at. Smithay parses `WM_HINTS` and reports the
+    // change; before this, `property_notify` discarded it.
+    conn.change_property32(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        noisy,
+        AtomEnum::WM_HINTS,
+        AtomEnum::WM_HINTS,
+        &WM_HINTS_URGENT,
+    )
+    .unwrap();
+    conn.flush().unwrap();
+
+    assert_eq!(
+        events.wait_for("urgent"),
+        noisy_address,
+        "a WM_HINTS urgency bit must raise the same flag xdg_system_bell does"
+    );
+
+    // And it must be dismissible. Nothing in the tree cleared this
+    // before, so a window that rang once stayed urgent forever.
+    let activate = intern(&conn, b"_NET_ACTIVE_WINDOW");
+    let root = conn.setup().roots[screen_num].root;
+    conn.send_event(
+        false,
+        root,
+        EventMask::SUBSTRUCTURE_NOTIFY | EventMask::SUBSTRUCTURE_REDIRECT,
+        ClientMessageEvent::new(32, noisy, activate, [2u32, 0, 0, 0, 0]),
+    )
+    .unwrap();
+    conn.flush().unwrap();
+
+    // Wait for the focus to actually land before ringing again. The
+    // differ compares successive snapshots, so the dismissal and the
+    // re-ring have to fall in different passes or there is no edge
+    // between them to see.
+    assert_eq!(
+        events.wait_for("activewindowv2"),
+        noisy_address,
+        "the activate must focus the window that rang"
+    );
+
+    // And the dismissal, observed the same way: the flag has to be
+    // *clearable*, so ringing again after the focus must produce a
+    // second `urgent` event rather than nothing. Before this change
+    // nothing ever cleared it, so the second edge could never happen.
+    conn.change_property32(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        noisy,
+        AtomEnum::WM_HINTS,
+        AtomEnum::WM_HINTS,
+        &WM_HINTS_CALM,
+    )
+    .unwrap();
+    conn.flush().unwrap();
+    conn.change_property32(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        noisy,
+        AtomEnum::WM_HINTS,
+        AtomEnum::WM_HINTS,
+        &WM_HINTS_URGENT,
+    )
+    .unwrap();
+    conn.flush().unwrap();
+    assert_eq!(
+        events.wait_for("urgent"),
+        noisy_address,
+        "urgency must be clearable, or a window that rings once can never ring again"
+    );
 }

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -2849,11 +2849,47 @@ impl<B: Backend> WindowManager<B> {
                 NetState::Fullscreen => self.apply_fullscreen_action(id, action),
                 NetState::MaximizedHorz => maximize_directions |= MaximizeDirections::HORIZONTAL,
                 NetState::MaximizedVert => maximize_directions |= MaximizeDirections::VERTICAL,
+                NetState::Pinned => self.apply_pin_action(id, action),
+                NetState::DemandsAttention => self.apply_attention_action(id, action),
             }
         }
         if !maximize_directions.is_empty() {
             self.apply_maximize_action(id, action, maximize_directions);
         }
+    }
+
+    /// `_NET_WM_STATE_ABOVE` / `_NET_WM_STATE_STICKY` from a client.
+    ///
+    /// Gated on the same `NO_ACTIVATE` rule the activation path checks:
+    /// pinning is stacking-adjacent — a pinned window sits above
+    /// ordinary ones on every workspace — so a window a rule has
+    /// excused from grabbing attention must not be able to take the top
+    /// of every workspace by asking for it instead.
+    fn apply_pin_action(&mut self, id: ClientId, action: NetStateAction) {
+        if self.clients.get(id).is_some_and(|c| c.flags.contains(ClientFlags::NO_ACTIVATE)) {
+            tracing::debug!(?id, "window rule refused a client's pin request");
+            return;
+        }
+        let currently = self.clients.get(id).is_some_and(|c| c.flags.contains(ClientFlags::STICKY));
+        let target = match action {
+            NetStateAction::Add => true,
+            NetStateAction::Remove => false,
+            NetStateAction::Toggle => !currently,
+        };
+        self.set_client_pinned(id, target);
+    }
+
+    /// `_NET_WM_STATE_DEMANDS_ATTENTION`, and the `WM_HINTS` urgency
+    /// bit that reaches the same place. `set_urgent` is idempotent, so
+    /// Add/Remove need no guard of their own.
+    fn apply_attention_action(&mut self, id: ClientId, action: NetStateAction) {
+        let currently = self.clients.get(id).is_some_and(|c| c.flags.contains(ClientFlags::URGENT));
+        let target = match action {
+            NetStateAction::Add => true,
+            NetStateAction::Remove => false,
+            NetStateAction::Toggle => !currently,
+        };
+        self.set_urgent(id, target);
     }
 
     fn apply_fullscreen_action(&mut self, id: ClientId, action: NetStateAction) {
@@ -3126,6 +3162,21 @@ impl<B: Backend> WindowManager<B> {
         if raise {
             self.raise_client(id);
         }
+        // Attention asked for, attention given. Nothing else in the
+        // tree ever cleared this: the bell handler and both EWMH routes
+        // only ever *set* it, so before this a window that rang once
+        // stayed urgent for the rest of its life, including while the
+        // user sat in it. An urgency that cannot be dismissed is worse
+        // than none, so the dismissal lives here — beside the focus,
+        // where it applies to Wayland and X11 alike rather than in
+        // either protocol's handler.
+        //
+        // Through `set_urgent` rather than by clearing the flag inline:
+        // the state has to be *published*, or a bar keeps showing the
+        // window as urgent and the next ring is no longer an edge the
+        // event differ can see. It is idempotent, so the ordinary
+        // focus change pays only a flag comparison.
+        self.set_urgent(id, false);
         self.repaint_decoration(id);
     }
 
@@ -3840,6 +3891,24 @@ mod tests {
         }
     }
 
+    /// A rule that refuses activation — the shape `focus_on_activate =
+    /// false` produces.
+    #[derive(Debug)]
+    struct NoActivate;
+
+    impl FloatPolicy for NoActivate {
+        fn decision_for(&self, _class: &str, _title: &str) -> Option<crate::placement::FloatDecision> {
+            None
+        }
+
+        fn window_decision_for(&self, _class: &str, _title: &str) -> crate::placement::WindowRuleDecision {
+            crate::placement::WindowRuleDecision {
+                focus_on_activate: Some(false),
+                ..Default::default()
+            }
+        }
+    }
+
     #[derive(Debug)]
     struct NoInitialFocus;
 
@@ -4367,6 +4436,118 @@ mod tests {
         // `raise_client_to_top` refuses one.
         wm.dispatch(BackendEvent::Destroyed(palette));
         assert!(!wm.focus_client_without_raising(palette_id));
+    }
+
+    /// `_NET_WM_STATE_ABOVE` / `_NET_WM_STATE_STICKY` reach the one
+    /// pinned concept this desktop has. Both atoms arrive as
+    /// `NetState::Pinned`, so this covers either spelling.
+    #[test]
+    fn a_client_can_ask_to_be_pinned_and_unpinned() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        let id = wm.client_for_window(window).unwrap();
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Add,
+            first: NetState::Pinned,
+            second: None,
+        });
+        assert!(wm.client(id).unwrap().flags.contains(ClientFlags::STICKY));
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Toggle,
+            first: NetState::Pinned,
+            second: None,
+        });
+        assert!(!wm.client(id).unwrap().flags.contains(ClientFlags::STICKY), "toggle is not add");
+    }
+
+    /// Pinning puts a window above ordinary ones on every workspace, so
+    /// it is stacking-adjacent and answers to the same rule the
+    /// activation path does.
+    #[test]
+    fn a_no_activate_window_cannot_pin_itself() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let mut wm = wm(backend);
+        wm.set_float_policy(Some(std::sync::Arc::new(NoActivate)));
+        wm.dispatch(BackendEvent::MapRequest(window));
+        let id = wm.client_for_window(window).unwrap();
+        assert!(wm.client(id).unwrap().flags.contains(ClientFlags::NO_ACTIVATE));
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Add,
+            first: NetState::Pinned,
+            second: None,
+        });
+
+        assert!(
+            !wm.client(id).unwrap().flags.contains(ClientFlags::STICKY),
+            "a rule that refuses activation must also refuse the top of every workspace"
+        );
+    }
+
+    /// The EWMH and ICCCM halves of the attention story both land here.
+    #[test]
+    fn a_client_can_demand_attention_and_withdraw_it() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let other = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        wm.dispatch(BackendEvent::MapRequest(other));
+        let id = wm.client_for_window(window).unwrap();
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Add,
+            first: NetState::DemandsAttention,
+            second: None,
+        });
+        assert!(wm.client(id).unwrap().flags.contains(ClientFlags::URGENT));
+
+        // A client that clears its own `WM_HINTS` urgency bit arrives
+        // as Remove, and the flag has to go.
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Remove,
+            first: NetState::DemandsAttention,
+            second: None,
+        });
+        assert!(!wm.client(id).unwrap().flags.contains(ClientFlags::URGENT));
+    }
+
+    /// Before this, nothing in the tree ever called `set_urgent(_,
+    /// false)`: a window that rang once stayed urgent for the rest of
+    /// its life, including while the user sat in it.
+    #[test]
+    fn focusing_an_urgent_window_dismisses_the_urgency() {
+        let mut backend = FakeBackend::new();
+        let noisy = backend.create_window();
+        let other = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(noisy));
+        wm.dispatch(BackendEvent::MapRequest(other));
+        let noisy_id = wm.client_for_window(noisy).unwrap();
+        let other_id = wm.client_for_window(other).unwrap();
+        // `other` mapped last and holds focus, so `noisy` is genuinely
+        // in the background when it asks.
+        assert!(wm.client(other_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+        wm.set_urgent(noisy_id, true);
+        assert!(wm.client(noisy_id).unwrap().flags.contains(ClientFlags::URGENT));
+
+        wm.dispatch(BackendEvent::ActivateRequested(noisy));
+
+        assert!(wm.client(noisy_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+        assert!(
+            !wm.client(noisy_id).unwrap().flags.contains(ClientFlags::URGENT),
+            "attention was asked for and given; an urgency that cannot be dismissed is worse than none"
+        );
     }
 
     #[test]

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -141,6 +141,15 @@ pub enum NetState {
     Fullscreen,
     MaximizedHorz,
     MaximizedVert,
+    /// `_NET_WM_STATE_ABOVE` and `_NET_WM_STATE_STICKY` both land here.
+    /// This desktop has one concept — pinned, meaning "on every
+    /// workspace and above ordinary windows" — and the two atoms are
+    /// its two halves, so a client asking for either gets it. Reported
+    /// as one because `set_client_pinned` is one flag.
+    Pinned,
+    /// `_NET_WM_STATE_DEMANDS_ATTENTION`, and the ICCCM `WM_HINTS`
+    /// urgency bit, which is how most X11 applications actually ask.
+    DemandsAttention,
 }
 
 /// Coarse EWMH `_NET_WM_WINDOW_TYPE` classification — just enough to

--- a/crates/wm-wayland/src/xewmh.rs
+++ b/crates/wm-wayland/src/xewmh.rs
@@ -73,7 +73,7 @@ use x11rb::rust_connection::RustConnection;
 // both are needed, hence the alias.
 use x11rb::wrapper::ConnectionExt as WrapperConnectionExt;
 
-use wm_core::MAX_WORKSPACES;
+use wm_core::{NetState, NetStateAction, MAX_WORKSPACES};
 use wm_theme_api::Rect;
 
 use crate::state::{Compositor, ManagedSurface, WaylandBackend, WindowRecord, WlWindowId};
@@ -86,10 +86,19 @@ use crate::state::{Compositor, ManagedSurface, WaylandBackend, WindowRecord, WlW
 /// the pairing is by convention: change one, check the other
 /// (`crates/wm-x11/src/backend.rs`). The deliberate differences:
 ///
-/// * `_NET_CLOSE_WINDOW` is omitted — `wm-x11` handles that client
-///   message itself; on this stack root client messages land on
-///   smithay's XWM connection, which does not translate it, so
-///   advertising it would invite messages nobody handles.
+/// * `_NET_WM_STATE_ABOVE` and `_NET_WM_STATE_STICKY` are advertised
+///   for the *request* direction only. This desktop has one pinned
+///   concept covering both, and `drain_inbound` acts on either — but
+///   smithay's `X11Surface` owns `_NET_WM_STATE` on client windows and
+///   has no setter for these two, so the atom never appears in the
+///   property afterwards. Advertising the request without the
+///   reflection is the same trade `_NET_WM_STATE_SHADED` declines, and
+///   it is made differently here because a client sends these to *ask*
+///   and reads the property back only rarely, whereas shade has no
+///   request path at all.
+/// * `_NET_WM_STATE_DEMANDS_ATTENTION` is advertised on the same terms,
+///   and is the EWMH half of the urgency story whose ICCCM half is the
+///   `WM_HINTS` bit `xwayland.rs` reads.
 /// * `_NET_WM_STATE_SHADED` is omitted — `wm-core` shades, but
 ///   nothing on this stack can publish the atom onto a client window
 ///   (smithay's `X11Surface` owns `_NET_WM_STATE` and has no shaded
@@ -103,6 +112,11 @@ const SUPPORTED: &[&str] = &[
     "_NET_SUPPORTED",
     "_NET_SUPPORTING_WM_CHECK",
     "_NET_ACTIVE_WINDOW",
+    // `wmctrl -c`, `xdotool windowclose`, and every panel menu that
+    // closes a window the EWMH way. Root client messages reach this
+    // module's `SubstructureNotify` connection, which is the route the
+    // two messages below already arrive by.
+    "_NET_CLOSE_WINDOW",
     "_NET_CLIENT_LIST",
     "_NET_CLIENT_LIST_STACKING",
     // Advertised because a client checks this list before it will
@@ -114,6 +128,9 @@ const SUPPORTED: &[&str] = &[
     "_NET_WM_STATE_MAXIMIZED_HORZ",
     "_NET_WM_STATE_MAXIMIZED_VERT",
     "_NET_WM_STATE_HIDDEN",
+    "_NET_WM_STATE_ABOVE",
+    "_NET_WM_STATE_STICKY",
+    "_NET_WM_STATE_DEMANDS_ATTENTION",
     "_NET_WM_STATE_MODAL",
     "_NET_WM_STATE_FOCUSED",
     "_NET_WM_WINDOW_TYPE",
@@ -327,6 +344,13 @@ struct WriteAtoms {
     net_workarea: Atom,
     net_frame_extents: Atom,
     wm_state: Atom,
+    /// Inbound only — this connection never writes these. See
+    /// [`drain_inbound`].
+    net_close_window: Atom,
+    net_wm_state: Atom,
+    net_wm_state_above: Atom,
+    net_wm_state_sticky: Atom,
+    net_wm_state_demands_attention: Atom,
 }
 
 impl WriteAtoms {
@@ -344,6 +368,14 @@ impl WriteAtoms {
             net_workarea: conn.intern_atom(false, b"_NET_WORKAREA")?.reply()?.atom,
             net_frame_extents: conn.intern_atom(false, b"_NET_FRAME_EXTENTS")?.reply()?.atom,
             wm_state: conn.intern_atom(false, b"WM_STATE")?.reply()?.atom,
+            net_close_window: conn.intern_atom(false, b"_NET_CLOSE_WINDOW")?.reply()?.atom,
+            net_wm_state: conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom,
+            net_wm_state_above: conn.intern_atom(false, b"_NET_WM_STATE_ABOVE")?.reply()?.atom,
+            net_wm_state_sticky: conn.intern_atom(false, b"_NET_WM_STATE_STICKY")?.reply()?.atom,
+            net_wm_state_demands_attention: conn
+                .intern_atom(false, b"_NET_WM_STATE_DEMANDS_ATTENTION")?
+                .reply()?
+                .atom,
         })
     }
 }
@@ -627,22 +659,40 @@ fn drain_inbound(comp: &mut Compositor) {
                 continue;
             };
             if message.type_ == xewmh.atoms.net_active_window {
-                // The message names an X window; the ledger speaks
-                // WlWindowId. A window this compositor is not managing
-                // (already gone, or never mapped) is silently ignored,
-                // exactly as `wm-x11` ignores stale ids.
-                let target = comp
-                    .wm
-                    .backend()
-                    .windows
-                    .iter()
-                    .find(|(_, record)| match &record.surface {
-                        ManagedSurface::X11(surface) => surface.window_id() == message.window,
-                        ManagedSurface::Xdg(_) => false,
-                    })
-                    .map(|(&id, _)| id);
-                if let Some(id) = target {
+                if let Some(id) = managed_x11_window(comp, message.window) {
                     requests.push(WmEvent::ActivateRequested(id));
+                }
+            } else if message.type_ == xewmh.atoms.net_close_window {
+                // Exactly what the titlebar close button does. The X11
+                // backend has translated this message since it existed
+                // (`wm-x11`'s `translate_client_message`); under the
+                // Wayland session it fell on the floor, so `wmctrl -c`
+                // exited zero having done nothing.
+                if let Some(id) = managed_x11_window(comp, message.window) {
+                    requests.push(WmEvent::CloseRequested(id));
+                }
+            } else if message.type_ == xewmh.atoms.net_wm_state {
+                // Smithay's XWM decodes only the maximized pair and
+                // fullscreen from this message; every other atom falls
+                // out of its final catch-all and never reaches
+                // `XwmHandler`. These three do reach us, by the same
+                // route as the two messages above.
+                let data = message.data.as_data32();
+                let Some(action) = net_state_action(data[0]) else {
+                    continue;
+                };
+                let mut states = [data[1], data[2]]
+                    .into_iter()
+                    .filter(|atom| *atom != 0)
+                    .filter_map(|atom| net_state_from_atom(&xewmh.atoms, atom));
+                let (Some(first), second) = (states.next(), states.next()) else {
+                    // Every atom in the message was one this WM does not
+                    // model. EWMH wants unknown properties skipped, not
+                    // the message rejected.
+                    continue;
+                };
+                if let Some(id) = managed_x11_window(comp, message.window) {
+                    requests.push(WmEvent::NetStateRequested { window: id, action, first, second });
                 }
             } else if message.type_ == xewmh.atoms.net_current_desktop {
                 let requested = message.data.as_data32()[0];
@@ -657,6 +707,48 @@ fn drain_inbound(comp: &mut Compositor) {
     let backend = comp.wm.backend_mut();
     for request in requests {
         backend.queue(request);
+    }
+}
+
+/// The managed window an inbound client message names.
+///
+/// The message names an X window; the ledger speaks `WlWindowId`. A
+/// window this compositor is not managing (already gone, or never
+/// mapped) is silently ignored, exactly as `wm-x11` ignores stale ids.
+fn managed_x11_window(comp: &Compositor, window: XWindow) -> Option<WlWindowId> {
+    comp.wm
+        .backend()
+        .windows
+        .iter()
+        .find(|(_, record)| match &record.surface {
+            ManagedSurface::X11(surface) => surface.window_id() == window,
+            ManagedSurface::Xdg(_) => false,
+        })
+        .map(|(&id, _)| id)
+}
+
+/// `_NET_WM_STATE`'s `data[0]`: 0 remove, 1 add, 2 toggle. Anything
+/// else is a malformed message from an untrusted client.
+fn net_state_action(action: u32) -> Option<NetStateAction> {
+    match action {
+        0 => Some(NetStateAction::Remove),
+        1 => Some(NetStateAction::Add),
+        2 => Some(NetStateAction::Toggle),
+        _ => None,
+    }
+}
+
+/// The three `_NET_WM_STATE` atoms this module decodes. The maximized
+/// pair and fullscreen are deliberately absent: smithay's XWM already
+/// decodes those from its own connection, and decoding them here too
+/// would apply every such request twice.
+fn net_state_from_atom(atoms: &WriteAtoms, atom: Atom) -> Option<NetState> {
+    if atom == atoms.net_wm_state_above || atom == atoms.net_wm_state_sticky {
+        Some(NetState::Pinned)
+    } else if atom == atoms.net_wm_state_demands_attention {
+        Some(NetState::DemandsAttention)
+    } else {
+        None
     }
 }
 
@@ -778,14 +870,31 @@ mod tests {
             "_NET_WORKAREA",
             "_NET_FRAME_EXTENTS",
             "_NET_WM_DESKTOP",
+            // `drain_inbound` translates these into the core's own
+            // verbs, so a tool that checks the list before sending is
+            // told the truth.
+            "_NET_CLOSE_WINDOW",
+            "_NET_WM_STATE_ABOVE",
+            "_NET_WM_STATE_STICKY",
+            "_NET_WM_STATE_DEMANDS_ATTENTION",
         ] {
             assert!(SUPPORTED.contains(&name), "{name} missing from _NET_SUPPORTED");
         }
-        // Nothing on this stack handles a close message or can
-        // publish/accept the shaded atom (see SUPPORTED's doc) —
-        // advertising either would be a lie a client acts on.
-        assert!(!SUPPORTED.contains(&"_NET_CLOSE_WINDOW"));
+        // Still nothing on this stack can publish or accept the shaded
+        // atom (see SUPPORTED's doc) — advertising it would be a lie a
+        // client acts on.
         assert!(!SUPPORTED.contains(&"_NET_WM_STATE_SHADED"));
+    }
+
+    /// `data[0]` is untrusted: a client can put anything there, and
+    /// only three values mean anything.
+    #[test]
+    fn a_net_wm_state_action_outside_the_spec_is_refused() {
+        assert!(matches!(net_state_action(0), Some(NetStateAction::Remove)));
+        assert!(matches!(net_state_action(1), Some(NetStateAction::Add)));
+        assert!(matches!(net_state_action(2), Some(NetStateAction::Toggle)));
+        assert!(net_state_action(3).is_none());
+        assert!(net_state_action(u32::MAX).is_none());
     }
 
     #[test]

--- a/crates/wm-wayland/src/xwayland.rs
+++ b/crates/wm-wayland/src/xwayland.rs
@@ -147,6 +147,21 @@ impl XwmHandler for Compositor {
             record.content = geometry;
         }
         backend.queue(WmEvent::MapRequest(id));
+        // `WM_HINTS` read once here as well as on change: a client that
+        // sets urgency before its first map — the common case, since the
+        // property is normally written alongside the rest of the window's
+        // ICCCM setup — produces no `PropertyNotify` for the arm above to
+        // catch. Queued after the MapRequest so the client exists in the
+        // core by the time it lands.
+        tracing::info!(?id, hints = ?window.hints().map(|h| h.urgent), "XWDEBUG map-time hints");
+        if window.hints().is_some_and(|hints| hints.urgent) {
+            backend.queue(WmEvent::NetStateRequested {
+                window: id,
+                action: NetStateAction::Add,
+                first: NetState::DemandsAttention,
+                second: None,
+            });
+        }
     }
 
     fn mapped_override_redirect_window(&mut self, _xwm: XwmId, window: X11Surface) {
@@ -321,6 +336,28 @@ impl XwmHandler for Compositor {
             // borderless mode, and several do.
             WmWindowProperty::MotifHints => {
                 backend.queue(WmEvent::ChromeChanged(id));
+            }
+            // ICCCM `WM_HINTS`, whose urgency bit is how the great
+            // majority of X11 applications actually ask for attention —
+            // IRC and chat clients, terminal bells, mail notifiers.
+            // `_NET_WM_STATE_DEMANDS_ATTENTION` is the EWMH spelling of
+            // the same request and lands on the same core state through
+            // the same event; this is the half smithay parses for us.
+            //
+            // Both directions matter: a client sets the bit to ask and
+            // clears it when it has been read, so `Remove` is not
+            // decoration — it is how the flag goes away when the
+            // application, rather than the user, decides the moment
+            // has passed.
+            WmWindowProperty::Hints => {
+                let urgent = window.hints().is_some_and(|hints| hints.urgent);
+                tracing::info!(?id, urgent, "XWDEBUG hints property notify");
+                backend.queue(WmEvent::NetStateRequested {
+                    window: id,
+                    action: if urgent { NetStateAction::Add } else { NetStateAction::Remove },
+                    first: NetState::DemandsAttention,
+                    second: None,
+                });
             }
             _ => {}
         }


### PR DESCRIPTION
Fixes #88

## Root cause

Three discards in the same area, all with the capability already present on both sides.

1. **`_NET_CLOSE_WINDOW`.** `drain_inbound` translated `_NET_ACTIVE_WINDOW` and `_NET_CURRENT_DESKTOP` and dropped everything else. The X11 backend has translated this message since it existed, and `wm-core` dispatches it to `handle_close_request`. Under the Wayland session `wmctrl -c`, `xdotool windowclose` and every panel menu that closes a window the EWMH way exited zero having done nothing.
2. **The `_NET_WM_STATE` atoms smithay does not decode.** Smithay's handler matches the maximized pair and fullscreen; `above`, `sticky` and `demands_attention` fall out of its catch-all and never reach `XwmHandler`. Two of those correspond to state this WM already has.
3. **`WM_HINTS` urgency.** `property_notify` matched `Title` and `MotifHints` and ended in `_ => {}`, so the ICCCM bit — how IRC clients, terminal bells and mail notifiers actually ask — was discarded at the change *and* at map time. A native client that rings `xdg_system_bell` got a repainted titlebar; an X11 client doing the same thing the X11 way got nothing.

And the asymmetry the issue calls out: `set_urgent` had exactly one caller, which only ever passed `true`. A window that rang once stayed urgent for the rest of its life.

## Behavioral change

- `NetState` gains `Pinned` and `DemandsAttention`. `_NET_WM_STATE_ABOVE` and `_NET_WM_STATE_STICKY` both map to `Pinned`, because this desktop has one concept — on every workspace, above ordinary windows — and those atoms are its two halves.
- `drain_inbound` decodes `_NET_CLOSE_WINDOW` and `_NET_WM_STATE`, reusing one `managed_x11_window` lookup for all three arms. The maximized pair and fullscreen are deliberately **not** decoded here: smithay already decodes them from its own connection, and decoding them twice would apply every such request twice.
- `property_notify` gains a `Hints` arm, and `map_window_request` reads `WM_HINTS` once as well — a client that sets urgency before its first map produces no `PropertyNotify` for the arm to catch.
- **Urgency is now dismissible.** `focus_client_with` calls `set_urgent(id, false)`. This is the piece the issue says must land with the rest, and it lives in `wm-core` beside the focus so it applies to both protocols rather than in either handler.
- `SUPPORTED` gains the four atoms now wired up, and its doc records why `above`/`sticky`/`demands_attention` are advertised for the *request* direction only: smithay's `X11Surface` owns `_NET_WM_STATE` on client windows and has no setter for them, so the atom never appears in the property afterwards. That is the same constraint `_NET_WM_STATE_SHADED` declines on, and the trade is made differently here because these three have a request path and shade has none. `_NET_WM_STATE_SHADED` stays out.

## Invariants and edge cases

- **Pinning answers to `NO_ACTIVATE`.** A pinned window sits above ordinary ones on every workspace, so it is stacking-adjacent; a rule that refuses activation must also refuse this. Asserted.
- **`data[0]` is untrusted.** Only 0/1/2 mean anything; anything else refuses the message. A message whose atoms are all unmodelled is skipped rather than rejected, per EWMH's own rule.
- **The dismissal goes through `set_urgent`, not an inline flag clear.** I wrote it inline first and the e2e caught it: clearing the flag directly skips `bump_protocol_state_revision`, so a bar keeps showing the window as urgent *and* the next ring is no longer a false→true edge the event differ can see. The window could ring exactly once, ever. `set_urgent` is idempotent, so an ordinary focus change pays only a flag comparison.

## Tests added

`wm-core`, four:
- `a_client_can_ask_to_be_pinned_and_unpinned` (add and toggle)
- `a_no_activate_window_cannot_pin_itself`
- `a_client_can_demand_attention_and_withdraw_it` (both directions — a client clearing its own hint arrives as Remove)
- `focusing_an_urgent_window_dismisses_the_urgency`

`wm-wayland`: `a_net_wm_state_action_outside_the_spec_is_refused`, and the `SUPPORTED` assertion flipped to require the four new atoms.

`chonk-testkit/tests/xwayland_input.rs`, wire-level against a live nested session with raw x11rb clients (no `zenity`, so they run anywhere the harness builds):
- `a_net_close_window_message_closes_an_xwayland_window`
- `wm_hints_urgency_is_read_at_map_and_cleared_by_focus` — the urgency is raised on a window that is **not** focused, which is both the realistic shape and the only observable one: a window that asks for attention while the user is already in it has its request answered immediately by the new dismissal. Observed on the Hyprland event socket, where `urgent>>` is what a bar actually listens to, and asserted twice — once for the ring, once after a focus and a re-ring, which is what proves the flag is clearable.

### Fail without the fix

Disabling the `_NET_CLOSE_WINDOW` arm and the `Hints` arm, rebuilding, re-running:

```
test a_net_close_window_message_closes_an_xwayland_window ... FAILED
test wm_hints_urgency_is_read_at_map_and_cleared_by_focus ... FAILED
test result: FAILED. 0 passed; 2 failed
```

## Commands run

```
cargo test -p wm-core                                        211 passed
cargo test -p wm-wayland                                     212 passed
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
cargo test -p chonk-testkit --test xwayland_input -- \
  --ignored --test-threads=1                                 5 passed, 0 failed
cargo test -p chonk-testkit --test e2e -- \
  --ignored --test-threads=1                                 4 passed, 5 failed
```

The five `e2e.rs` failures are `could not launch zenity: No such file or directory` and pre-exist this branch on `origin/main` (verified by running the same target there). `scripts/e2e.sh --headless` cannot run on this machine: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. CI's `wayland` job has the full client set.

## Known limitations / follow-up

- `_NET_WM_STATE_SKIP_TASKBAR` is decoded by nobody and stays that way: this desktop has no taskbar concept to skip.
- The three request-only atoms are not reflected back into `_NET_WM_STATE` on the client window, for the reason recorded in `SUPPORTED`'s doc. A client that sets `above` and reads the property back will not see it.
- `Window.urgent` exists in the Hyprland IPC snapshot and drives the `urgent` event, but is not a field in `j/clients`; Hyprland does not have one either, so it was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
