### PR TITLE
Keep the X server's stacking order in step with the desktop's (#87)

### DIFF
--- a/crates/chonk-testkit/tests/xwayland_input.rs
+++ b/crates/chonk-testkit/tests/xwayland_input.rs
@@ -793,3 +793,78 @@ fn wm_hints_urgency_is_read_at_map_and_cleared_by_focus() {
         "urgency must be clearable, or a window that rings once can never ring again"
     );
 }
+
+/// `XRaiseWindow` — what Java AWT's `Window.toFront`, Tk's `raise` and
+/// any raw-Xlib application compile to. It arrives as a
+/// `ConfigureRequest` carrying only a stack mode, which used to resolve
+/// to the window's current rectangle and therefore to nothing at all.
+///
+/// Asserted against the X server's own stacking rather than the
+/// compositor's, because the two are what this connects: `QueryTree`
+/// returns the server's children bottom-to-top, and the compositor now
+/// publishes its order into exactly that list. The first poll is a real
+/// assertion in its own right — it is the outbound half, which no call
+/// in this repository made before.
+#[test]
+#[ignore = "needs a live Wayland session to nest in"]
+fn an_x_raise_window_request_reaches_the_x_servers_stacking_order() {
+    let mut session =
+        Session::boot("xwayland-raise", SessionOptions::default()).expect("nested compositor boots");
+    let display = xwayland_display(&session);
+    let _ = ewmh_display(&session);
+    let (conn, screen_num) =
+        x11rb::rust_connection::RustConnection::connect(Some(&format!(":{display}")))
+            .expect("connect to nested XWayland");
+    let root = conn.setup().roots[screen_num].root;
+
+    let (lower, _) = map_probe_window(&mut session, &conn, screen_num, "raise-lower", None);
+    let (upper, _) = map_probe_window(&mut session, &conn, screen_num, "raise-upper", None);
+
+    // Where each window sits in the server's bottom-to-top child list. A
+    // managed X11 window is reparented into a frame, so the entry to
+    // look for is whichever ancestor is a child of root.
+    let depth_of = |target: u32| -> usize {
+        let children = conn.query_tree(root).unwrap().reply().unwrap().children;
+        let mut ancestors = vec![target];
+        let mut node = target;
+        while let Ok(reply) = conn.query_tree(node).unwrap().reply() {
+            if reply.parent == root || reply.parent == 0 {
+                ancestors.push(node);
+                break;
+            }
+            node = reply.parent;
+            ancestors.push(node);
+        }
+        children
+            .iter()
+            .position(|child| ancestors.contains(child))
+            .unwrap_or_else(|| panic!("window {target:#x} is not in the server's tree"))
+    };
+
+    poll_until(EVENT, "the compositor to publish its order to the server", || {
+        (depth_of(upper) > depth_of(lower)).then_some(())
+    })
+    .expect("the window mapped last must be on top on the server too");
+
+    // The bare Xlib raise: a ConfigureRequest with a stack mode and no
+    // geometry.
+    conn.configure_window(
+        lower,
+        &x11rb::protocol::xproto::ConfigureWindowAux::new()
+            .stack_mode(x11rb::protocol::xproto::StackMode::ABOVE),
+    )
+    .unwrap();
+    conn.flush().unwrap();
+
+    poll_until(EVENT, "XRaiseWindow to move the server's stacking order", || {
+        (depth_of(lower) > depth_of(upper)).then_some(())
+    })
+    .unwrap_or_else(|e| {
+        let children = conn.query_tree(root).unwrap().reply().unwrap().children;
+        panic!(
+            "{e}\nlower={lower:#x} at {} upper={upper:#x} at {}\nroot children: {children:#x?}",
+            depth_of(lower),
+            depth_of(upper)
+        )
+    });
+}

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -1356,6 +1356,14 @@ impl<B: Backend> WindowManager<B> {
                     self.miniaturize(id);
                 }
             }
+            // `XRaiseWindow`. The same raise a click performs, and
+            // nothing more: the client asked for the front, not for the
+            // keyboard, and `raise_client_to_top` is exactly that verb.
+            BackendEvent::RaiseRequest(window) => {
+                if let Some(&id) = self.window_index.get(&window) {
+                    self.raise_client_to_top(id);
+                }
+            }
             BackendEvent::KeyPress(combo) => self.handle_key_press(combo),
             BackendEvent::KeyRelease(combo) => self.handle_key_release(combo),
             BackendEvent::PointerEnter { surface } => self.handle_pointer_enter(surface),
@@ -4548,6 +4556,53 @@ mod tests {
             !wm.client(noisy_id).unwrap().flags.contains(ClientFlags::URGENT),
             "attention was asked for and given; an urgency that cannot be dismissed is worse than none"
         );
+    }
+
+    /// `XRaiseWindow` asks for the front and nothing else. Answering
+    /// it with an activation would hand over the keyboard the client
+    /// never asked for.
+    #[test]
+    fn a_raise_request_raises_without_taking_focus() {
+        let mut backend = FakeBackend::new();
+        let lower = backend.create_window();
+        let upper = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(lower));
+        wm.dispatch(BackendEvent::MapRequest(upper));
+        let lower_id = wm.client_for_window(lower).unwrap();
+        let lower_frame = wm.client(lower_id).unwrap().frame.unwrap();
+        let upper_id = wm.client_for_window(upper).unwrap();
+        assert!(wm.client(upper_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+        wm.backend_mut().raised_frames.clear();
+
+        wm.dispatch(BackendEvent::RaiseRequest(lower));
+
+        assert_eq!(
+            wm.backend().raised_frames,
+            vec![lower_frame],
+            "the window that asked must come to the front"
+        );
+        assert!(
+            wm.client(upper_id).unwrap().flags.contains(ClientFlags::FOCUSED),
+            "a raise is not an activation; the keyboard must not move"
+        );
+        assert!(!wm.client(lower_id).unwrap().flags.contains(ClientFlags::FOCUSED));
+    }
+
+    /// A stale id is ignored rather than panicking, the same way every
+    /// other backend-request arm treats one.
+    #[test]
+    fn a_raise_request_for_an_unknown_window_is_ignored() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        wm.dispatch(BackendEvent::Destroyed(window));
+        wm.backend_mut().raised_frames.clear();
+
+        wm.dispatch(BackendEvent::RaiseRequest(window));
+
+        assert!(wm.backend().raised_frames.is_empty());
     }
 
     #[test]

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -276,6 +276,18 @@ pub enum BackendEvent<Win, Frame> {
     /// miniaturization is a WM gesture) left the button dead in every
     /// client-decorated application — reported live from LibreOffice.
     MinimizeRequest(Win),
+    /// An X11 `ConfigureRequest` carrying a stack mode of `Above` with
+    /// no sibling — `XRaiseWindow`, which is what Java AWT's
+    /// `Window.toFront`, Tk's `raise` and any raw-Xlib application
+    /// compile to.
+    ///
+    /// Distinct from [`Self::ActivateRequested`] because it asks for
+    /// strictly less: a raise, not a raise *and* the keyboard. A
+    /// toolkit that checked `_NET_SUPPORTED` would have sent
+    /// `_NET_ACTIVE_WINDOW` instead; everything below that layer sends
+    /// this, and answering it with an activation would move focus the
+    /// client never asked for.
+    RaiseRequest(Win),
     PointerButton {
         surface: SurfaceRef<Win, Frame>,
         local: Point,

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -993,6 +993,7 @@ impl Backend for WaylandBackend {
     fn raise(&mut self, frame: Self::FrameId) {
         if raise_stack_entry(&mut self.stacking, StackEntry::Frame(frame)) {
             self.damage = true;
+            self.stacking_dirty = true;
         }
     }
 
@@ -1012,6 +1013,7 @@ impl Backend for WaylandBackend {
     fn raise_frameless(&mut self, window: Self::WindowId) {
         if raise_stack_entry(&mut self.stacking, StackEntry::Window(window)) {
             self.damage = true;
+            self.stacking_dirty = true;
         }
     }
 
@@ -1029,9 +1031,17 @@ impl Backend for WaylandBackend {
             .filter(|frame| self.frames.contains_key(frame))
             .map(|&frame| StackEntry::Frame(frame))
             .collect();
+        let before = self.stacking.clone();
         self.stacking.retain(|entry| !matches!(entry, StackEntry::Frame(f) if order_back_to_front.contains(f)));
         self.stacking.extend(listed);
         self.damage = true;
+        // Compared rather than assumed: `restack` is called from the
+        // workspace-switch and Alt-Tab paths on every pass they run,
+        // and a "dirty" that meant "mentioned" would grab the X server
+        // once a frame (see `WaylandBackend::stacking_dirty`).
+        if self.stacking != before {
+            self.stacking_dirty = true;
+        }
     }
 
     // -- focus / close ----------------------------------------------------

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -604,6 +604,16 @@ pub struct WaylandBackend {
     pub(crate) shells: HashMap<WlShellId, ShellRecord>,
     /// Bottom-to-top managed application order — see [`StackEntry`].
     pub(crate) stacking: Vec<StackEntry>,
+    /// Whether [`Self::stacking`] has actually moved since the X server
+    /// was last told about it.
+    ///
+    /// "Dirty means changed, not mentioned", the same discipline
+    /// `EwmhLedger`'s `note_*` methods keep: the stacking vector is
+    /// re-derived on paths that run every pass, and telling XWayland
+    /// unconditionally would put a `grab_server`/`ungrab_server` pair
+    /// on the XWM connection once a frame. Only the three verbs that
+    /// return "the vector moved" set this.
+    pub(crate) stacking_dirty: bool,
     /// Bottom-to-top order within both shell bands. A shell's `above`
     /// bit chooses its band; entries of the other band are skipped.
     /// This is the single source of shell order for both rendering and
@@ -934,6 +944,7 @@ impl WaylandBackend {
             monitors,
             monitor_scales,
             monitor_outputs,
+            stacking_dirty: false,
             input_devices: Vec::new(),
             ime_popups: Vec::new(),
             output_size,
@@ -2241,6 +2252,11 @@ impl Compositor {
         // XWayland root after the drains, so `xprop`/`wmctrl` read the
         // state the desktop just settled into, never a half-applied
         // pass. A no-op until XWayland is ready (see `xewmh::flush`).
+        // The X server's own stacking, before the EWMH publish that
+        // rewrites `_NET_CLIENT_LIST_STACKING` from it — so the list a
+        // pager reads and the order the server holds are settled in
+        // that order and cannot disagree within a pass.
+        crate::xwayland::sync_stacking_order(self);
         crate::xewmh::flush(self);
         // Layer surfaces settle beside them and before the damage test
         // for the same reason: a bar that just changed its exclusive

--- a/crates/wm-wayland/src/xwayland.rs
+++ b/crates/wm-wayland/src/xwayland.rs
@@ -44,7 +44,7 @@ use wm_core::{BackendEvent, NetState, NetStateAction};
 use wm_theme_api::{clamp_client_size, Point, Rect, ResizeEdge, Size};
 
 use crate::state::{
-    Compositor, ManagedSurface, WaylandBackend, WindowRecord, WlFrameId, WlWindowId,
+    Compositor, ManagedSurface, StackEntry, WaylandBackend, WindowRecord, WlFrameId, WlWindowId,
 };
 
 type WmEvent = BackendEvent<WlWindowId, WlFrameId>;
@@ -64,6 +64,64 @@ delegate_xwayland_shell!(Compositor);
 /// wl_surface-based lookup in `state.rs` cannot serve here: an X11
 /// window exists — and needs configure/property routing — before its
 /// wl_surface association ever arrives.
+/// Tells the X server the stacking order the compositor just settled on.
+///
+/// Three of smithay's XWM entry points exist to connect the compositor's
+/// stacking vector to the server's, and none of them was called: an
+/// `XRaiseWindow` was dropped on the way in, and the desktop's own
+/// raises and restacks never reached the server on the way out, so
+/// `_NET_CLIENT_LIST_STACKING` — which smithay rewrites from that same
+/// internal list — described an order no window was actually in.
+///
+/// A whole-order update rather than `raise_window` per raise:
+/// `raise_window` only expresses "move to top", which would leave
+/// `restack` — the Alt-Tab and workspace-switch path — out of sync.
+///
+/// `update_stacking_order_upwards` is the variant that matches this
+/// compositor's bottom-to-top vector, which is worth stating because
+/// the pairing is not the one the names suggest: `_downwards` compares
+/// `last_pos < pos` and issues `StackMode::BELOW`, `_upwards` compares
+/// `last_pos > pos` and issues `ABOVE`, so it is `_upwards` that walks
+/// a bottom-to-top list and lifts each entry above the one before it.
+/// The `_downwards` spelling silently does nothing for this input —
+/// no error, no movement — which is how it was first written here and
+/// what the regression test caught.
+///
+/// Strictly gated on the dirty flag: the call puts a
+/// `grab_server`/`ungrab_server` pair on the XWM connection, and the
+/// stacking vector is re-derived on paths that run every pass.
+pub(crate) fn sync_stacking_order(comp: &mut Compositor) {
+    if !std::mem::take(&mut comp.wm.backend_mut().stacking_dirty) {
+        return;
+    }
+    let Some(mut xwm) = comp.xwm.take() else {
+        return;
+    };
+    // Bottom-to-top, X11 surfaces only — a Wayland window in the middle
+    // of the stack is simply not in the order the X server keeps, and
+    // smithay skips over what it does not know either way.
+    let order: Vec<X11Surface> = comp
+        .wm
+        .backend()
+        .stacking
+        .iter()
+        .filter_map(|entry| {
+            let window = match entry {
+                StackEntry::Frame(frame) => comp.wm.backend().frames.get(frame).map(|record| record.window)?,
+                StackEntry::Window(window) => *window,
+            };
+            match &comp.wm.backend().windows.get(&window)?.surface {
+                ManagedSurface::X11(surface) => Some(surface.clone()),
+                ManagedSurface::Xdg(_) => None,
+            }
+        })
+        .collect();
+    if let Err(error) = xwm.update_stacking_order_upwards(order.iter()) {
+        tracing::warn!(?error, "could not publish the stacking order to XWayland");
+    }
+    comp.xwm = Some(xwm);
+}
+
 fn x11_window_id(backend: &WaylandBackend, window: &X11Surface) -> Option<WlWindowId> {
     backend.windows.iter().find_map(|(id, record)| match &record.surface {
         ManagedSurface::X11(existing) if existing == window => Some(*id),
@@ -238,7 +296,7 @@ impl XwmHandler for Compositor {
         y: Option<i32>,
         w: Option<u32>,
         h: Option<u32>,
-        _reorder: Option<Reorder>,
+        reorder: Option<Reorder>,
     ) {
         // Merge the request over the current geometry — X11 configure
         // requests name only the fields the client cares about.
@@ -263,6 +321,21 @@ impl XwmHandler for Compositor {
             // everything verbatim pre-manage via `configure_unmanaged`).
             let requested = wm_rect(requested, backend.output_size);
             backend.queue(WmEvent::ConfigureRequest { window: id, requested });
+            // A ConfigureRequest carrying only a stack mode resolves to
+            // the window's *current* rectangle above, which `wm-core`
+            // reads as a no-op — so an `XRaiseWindow` used to vanish
+            // here with no log line. `Top` is the case that matters and
+            // the only one an ordinary client sends; the other three
+            // are named honestly rather than mistranslated.
+            match reorder {
+                Some(Reorder::Top) => backend.queue(WmEvent::RaiseRequest(id)),
+                Some(other) => tracing::debug!(
+                    ?other,
+                    ?id,
+                    "ignoring an X11 restack mode this desktop does not model"
+                ),
+                None => {}
+            }
         } else {
             // Never mapped, no record yet: honor directly — ICCCM
             // requires acknowledging pre-map configures or clients


### PR DESCRIPTION
Fixes #87

## Root cause

The compositor kept its own stacking vector, the X server kept its own, and nothing connected the two — in either direction.

**Outbound**: smithay exposes `raise_window`, `update_stacking_order_downwards` and `update_stacking_order_upwards` for exactly this, and a workspace-wide grep found no call to any of them. So `_NET_CLIENT_LIST_STACKING` — which smithay rewrites from that same internal list — described an order no window was actually in.

**Inbound**: `configure_request` bound the client's requested reorder as `_reorder` and never read it. A `ConfigureRequest` carrying only a stack mode therefore produced a `ConfigureRequest` event with the window's *current* rectangle, which `wm-core` resolves to a no-op. That request is `XRaiseWindow` — what Java AWT's `Window.toFront`, Tk's `raise` and any raw-Xlib application compile to. The window asked to come to the front and stayed exactly where it was, with no log line.

## Behavioral change

- **`WaylandBackend::stacking_dirty`**, set only by the three verbs that report the vector actually moved. `raise`/`raise_frameless` already returned "changed"; `restack` did not, so it compares before and after. The discipline is `EwmhLedger`'s: dirty means *changed*, not *mentioned*. `restack` runs on the workspace-switch and Alt-Tab paths every pass they execute, and an unconditional publish would put a `grab_server`/`ungrab_server` pair on the XWM connection once a frame.
- **`xwayland::sync_stacking_order`**, called from `dispatch_pending` immediately before `xewmh::flush` — the server's own order settles first, then the EWMH publish that is derived from it, so the two cannot disagree within a pass.
- **`BackendEvent::RaiseRequest`**, dispatched to `raise_client_to_top`. Deliberately *not* `ActivateRequested`, which raises **and** focuses: `XRaiseWindow` asks for strictly less, and a toolkit that wanted focus too would have checked `_NET_SUPPORTED` and sent `_NET_ACTIVE_WINDOW` (which this desktop already handles). It also gives `wm-x11` somewhere to route its own equally-unhandled `ConfigureRequest` stack modes.
- `Reorder::Top` is translated; `Bottom`, `Above(id)` and `Below(id)` are logged by name and ignored, rather than mistranslated.

## The API pairing, because it is not the one the names suggest

`update_stacking_order_upwards` is the variant that matches a bottom-to-top vector. `_downwards` compares `last_pos < pos` and issues `StackMode::BELOW`; `_upwards` compares `last_pos > pos` and issues `ABOVE`, so it is `_upwards` that walks a bottom-to-top list lifting each entry above the one before it.

I wrote `_downwards` first, on the strength of its doc comment saying "order here is also bottom -> top". It returns `Ok(())`, logs nothing, and moves nothing. The regression test is what caught it, and the reason it is asserted against `QueryTree` rather than against the compositor's own ledger: a test that checked our side would have passed against a completely inert publish. The doc comment on `sync_stacking_order` records this so the next reader does not repeat it.

## Invariants and edge cases

- Only X11 surfaces go into the published order. A Wayland window in the middle of the stack is not in the order the X server keeps, and smithay skips unknown ids either way.
- The XWM handle is taken and put back around the call (`comp.xwm.take()`), because the order is built by reading `comp.wm.backend()` while the handle is borrowed mutably.
- A failure to publish warns and leaves the compositor's own order untouched — the X server falling out of step is a compatibility problem, not a reason to disturb what is on screen.

## Tests added

`wm-core`:
- `a_raise_request_raises_without_taking_focus` — the frame is raised and the *other* window keeps the keyboard. This is the assertion that separates `RaiseRequest` from `ActivateRequested`.
- `a_raise_request_for_an_unknown_window_is_ignored`

`chonk-testkit/tests/xwayland_input.rs`: `an_x_raise_window_request_reaches_the_x_servers_stacking_order`, wire-level with raw x11rb clients (no `zenity`). It asserts against the **X server's** `QueryTree`, bottom-to-top, walking each client window's ancestors to find its reparented frame. Two assertions, one per direction:
1. after both windows map, the one mapped last is on top *on the server* — the outbound half, which nothing published before;
2. after a bare `ConfigureWindow` with `StackMode::ABOVE` and no geometry, the raised window is on top on the server — the inbound half.

### Fails without the fix

Replacing the `Some(Reorder::Top)` arm with a no-op, rebuilding, re-running:

```
test an_x_raise_window_request_reaches_the_x_servers_stacking_order ... FAILED
timed out after 10s waiting for XRaiseWindow to move the server's stacking order
```

## Commands run

```
cargo test -p wm-core                                        213 passed
cargo test --workspace --all-targets                         all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                      clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                   clean
git diff --check                                             clean
cargo test -p chonk-testkit --test xwayland_input -- \
  --ignored --test-threads=1                                 6 passed, 0 failed
```

The `xwayland_input` run includes #88's two tests, which landed on `main` while this was in progress; all six pass together. `scripts/e2e.sh --headless` cannot run on this machine: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. CI's `wayland` job has the full client set.

## Known limitations / follow-up

- `Reorder::Bottom`, `Above(id)` and `Below(id)` are still ignored. `Top` is the case an ordinary client sends; the other three want a sibling-relative insert into the compositor's vector, which is its own change with its own test.
- The issue also suggests using `configure_notify`'s `above` to reposition **override-redirect** windows relative to a named sibling. Not in this PR: the ordering it would fix is between a menu and its parent, which needs a test that can observe an override-redirect window's depth, and that is a different fixture from this one. Left as follow-up rather than done untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfMY6512A4MwuuBrC3ZkD4
