### PR TITLE
Complete seven desktop integration gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ crate and both session binaries carry the same number.
 
 ### Fixed
 
+- **Transient dialogs now behave as a family on both Wayland and X11.**
+  Toplevel children are centred on their parent, modal children redirect
+  parent focus/drag/close gestures, and minimize, restore, and workspace
+  moves carry the bounded transient tree. Runtime parent and modal changes
+  are tracked through xdg-dialog, `WM_TRANSIENT_FOR`, and
+  `_NET_WM_STATE_MODAL` ([#55](https://github.com/iconidentify/chonkstep/issues/55)).
+- **A mid-session XWayland crash no longer leaves ghost frames or a stale
+  `DISPLAY`.** The live XWM disconnect path retires every X11 window and its
+  auxiliary state, then makes one bounded restart attempt; an end-to-end
+  test kills the real server and maps a window through its replacement
+  ([#58](https://github.com/iconidentify/chonkstep/issues/58)).
+- **Configuration decisions are inspectable.** Both binaries support
+  `--check-config [PATH]` and `--print-config [PATH]`, effective values name
+  their winning layer, Hyprland parser refusals are retained by
+  `hyprctl configerrors`, and formerly silent plugin/animation directives
+  are reported ([#60](https://github.com/iconidentify/chonkstep/issues/60)).
+- **Secret storage and portal global shortcuts are routed explicitly.** The
+  compositor serves Hyprland's global-shortcuts protocol with bounded,
+  duplicate-safe registrations and maps configured `global, app:id`
+  bindings to press/release events; the portal documentation now inventories
+  exported and missing interfaces honestly
+  ([#61](https://github.com/iconidentify/chonkstep/issues/61)).
+- **Desktop menus are keyboard-operable.** Up/Down wrap through enabled
+  rows, Left/Right traverse cascades, Enter/Space activate the highlighted
+  item, menus hold the modal keyboard grab while open, and `root-menu` is a
+  bindable action ([#62](https://github.com/iconidentify/chonkstep/issues/62)).
+- **Assistive and automation clients can inject a pointer.** The compositor
+  serves `zwlr_virtual_pointer_manager_v1` v2, maps absolute input to an
+  optional output, batches protocol frames, and routes motion, buttons, and
+  axes through the same focus, grab, confinement, shell, and idle path as
+  physical devices ([#63](https://github.com/iconidentify/chonkstep/issues/63)).
 - **Monitor hot-plug now reconciles the live desktop instead of leaving
   dark or phantom outputs.** Debounced DRM probes adopt new connectors,
   withdraw unplugged output globals, rebuild output-management and gamma
@@ -97,6 +128,11 @@ crate and both session binaries carry the same number.
 
 ### Performance
 
+- **Opaque compositor-owned buffers now participate in occlusion.** Theme
+  chrome and the black-backed cover wallpaper declare their full opaque
+  region at import, avoiding needless blending and allowing lower scene
+  elements to be culled; arbitrary client shell buffers remain conservative
+  ([#64](https://github.com/iconidentify/chonkstep/issues/64)).
 - **DRM composition is deadline-scheduled against predicted vblank.** A
   per-output, time-based asymmetric render estimator delays steady-cadence
   composition for fresher input, grows its safety margin after misses, and

--- a/README.md
+++ b/README.md
@@ -641,6 +641,13 @@ about and skipped, and a completely unreadable file just means the
 defaults. See [docs/config.example.toml](docs/config.example.toml) for
 a fully commented example of every option.
 
+Validate the same four-layer configuration the session will resolve before
+logging out with `chonkstep --check-config [PATH]`; a fatal TOML error exits
+non-zero, while declined live Hyprland directives and the binding count are
+printed in full. `chonkstep --print-config [PATH]` prints the effective values
+with the layer that last wrote each one. The commands are identical on
+`chonkstep-wayland`.
+
 The settings, each documented in full in that file: `focus_follows_mouse`
 (click-to-focus by default), `scale` (HiDPI UI scaling; the
 `CHONKSTEP_SCALE` environment variable overrides it), `theme` (a theme

--- a/crates/chonk-hyprland-ipc/src/server.rs
+++ b/crates/chonk-hyprland-ipc/src/server.rs
@@ -271,7 +271,16 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
         "reload" => ("ok".to_string(), Some(Action::ReloadConfig)),
         "binds" => (if json { json_bindings(snapshot) } else { plain_bindings(snapshot) }, None),
         "devices" => (json_devices(snapshot), None),
-        "configerrors" => (if json { "[]".to_string() } else { String::new() }, None),
+        "configerrors" => (
+            if json {
+                serde_json::Value::Array(
+                    snapshot.config_errors.iter().map(|error| serde_json::json!({ "error": error })).collect()
+                ).to_string()
+            } else {
+                snapshot.config_errors.join("\n")
+            },
+            None,
+        ),
         "splash" => ("chonkstep".to_string(), None),
         // Hyprland's literal reply for a verb it does not have, and the
         // exact string Quickshell tests for when probing `j/status`.
@@ -1072,6 +1081,21 @@ mod enabled_tests {
     #[test]
     fn the_common_case_is_an_unset_variable_and_it_means_yes() {
         with_value(None, || assert!(Server::enabled()));
+    }
+
+    #[test]
+    fn configerrors_reports_the_retained_diagnostics_in_both_forms() {
+        let snapshot = Snapshot {
+            config_errors: vec!["bind: SUPER J — tiling-only".into(), "keyword: plugin — Hyprland-only".into()],
+            ..Snapshot::default()
+        };
+        let plain = Request::parse(b"/configerrors").unwrap();
+        assert_eq!(answer(&plain, &snapshot).0, snapshot.config_errors.join("\n"));
+
+        let json = Request::parse(b"j/configerrors").unwrap();
+        let value: serde_json::Value = serde_json::from_str(&answer(&json, &snapshot).0).unwrap();
+        assert_eq!(value[0]["error"], snapshot.config_errors[0]);
+        assert_eq!(value[1]["error"], snapshot.config_errors[1]);
     }
 
     #[test]

--- a/crates/chonk-hyprland-ipc/src/state.rs
+++ b/crates/chonk-hyprland-ipc/src/state.rs
@@ -212,6 +212,8 @@ pub struct Snapshot {
     /// compositor has received its first pointer motion.
     pub cursor_position: Option<(i32, i32)>,
     pub bindings: Vec<Binding>,
+    /// Effective configuration refusals, one actionable message each.
+    pub config_errors: Vec<String>,
     pub devices: Devices,
 }
 

--- a/crates/chonk-hyprland-ipc/tests/protocol.rs
+++ b/crates/chonk-hyprland-ipc/tests/protocol.rs
@@ -79,6 +79,7 @@ fn desktop() -> Snapshot {
         locked: false,
         cursor_position: Some((321, 654)),
         bindings: Vec::new(),
+        config_errors: Vec::new(),
         devices: Devices::default(),
     }
 }

--- a/crates/chonk-shell/src/desktop.rs
+++ b/crates/chonk-shell/src/desktop.rs
@@ -18,7 +18,7 @@ use std::rc::Rc;
 
 use tiny_skia::{FilterQuality, Pixmap, PixmapPaint, Transform};
 use wm_core::{Backend, ClientId, DragHandle};
-use wm_theme::cascade::{CascadeMenu, MenuClick};
+use wm_theme::cascade::{CascadeMenu, MenuClick, MenuKey};
 use wm_theme::menu::MenuItem;
 use wm_theme::switcher::{self, SwitcherEntry};
 use wm_theme::workspace;
@@ -930,6 +930,19 @@ impl<Id: Copy + Eq + std::fmt::Debug> ShellMenu<Id> {
         local: Point,
     ) -> Option<MenuAction> {
         match self.menu.click(host, theme, font_system, window, local)? {
+            MenuClick::Action(action) => resolve_session_action(&self.session, action),
+            MenuClick::OpenedSubmenu | MenuClick::Dismissed => None,
+        }
+    }
+
+    fn key<H: wm_theme_api::PopupHost<PopupId = Id>>(
+        &mut self,
+        host: &mut H,
+        theme: &Theme,
+        font_system: &mut cosmic_text::FontSystem,
+        key: MenuKey,
+    ) -> Option<MenuAction> {
+        match self.menu.key(host, theme, font_system, key)? {
             MenuClick::Action(action) => resolve_session_action(&self.session, action),
             MenuClick::OpenedSubmenu | MenuClick::Dismissed => None,
         }
@@ -3587,6 +3600,17 @@ impl<B: Backend> Desktop<B> {
         B: wm_theme_api::PopupHost<PopupId = B::ShellId>,
     {
         let action = self.menu.click(backend, theme, &mut self.fonts.system(), window, local);
+        self.sync_escape_key_grab(backend);
+        action
+    }
+
+    /// Resolves one keyboard gesture against the deepest open menu
+    /// level through the same session/action mapping pointer clicks use.
+    pub fn key_menu(&mut self, backend: &mut B, theme: &Theme, key: MenuKey) -> Option<MenuAction>
+    where
+        B: wm_theme_api::PopupHost<PopupId = B::ShellId>,
+    {
+        let action = self.menu.key(backend, theme, &mut self.fonts.system(), key);
         self.sync_escape_key_grab(backend);
         action
     }

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -18,6 +18,7 @@ use wm_core::{
     Backend, BackendEvent, ClientFlags, ClientId, KeyCombo, Lifecycle, MaximizeDirections, MonitorInfo, MouseButton,
     Notification, ScrollDelta, WindowManager,
 };
+use wm_theme::cascade::MenuKey;
 use wm_theme::{FontState, RasterThemeEngine, Theme};
 use wm_theme_api::{DecorationBuffer, Point, PopupHost, Rect, Size};
 
@@ -707,7 +708,7 @@ fn bindings_for_grabs(state: &SessionState) -> Vec<(KeyCombo, Action)> {
 
 fn apply_binding_behaviors<B: Backend>(backend: &mut B, previous: &[wm_config::Binding], next: &[wm_config::Binding]) {
     for binding in previous {
-        if binding.release {
+        if binding.release || matches!(&binding.action, Action::GlobalShortcut(_)) {
             backend.set_key_release(binding.combo, false);
         }
         if binding.locked {
@@ -718,7 +719,7 @@ fn apply_binding_behaviors<B: Backend>(backend: &mut B, previous: &[wm_config::B
         }
     }
     for binding in next {
-        if binding.release {
+        if binding.release || matches!(&binding.action, Action::GlobalShortcut(_)) {
             backend.set_key_release(binding.combo, true);
         }
         if binding.locked {
@@ -942,6 +943,7 @@ fn primary_rect(monitors: &[MonitorInfo], screen: Size) -> Rect {
 /// action, so the event does not leak through to the focused client.
 pub enum KeyResolution {
     Action(Action),
+    Menu(MenuKey),
     Consumed,
 }
 
@@ -1244,7 +1246,9 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             release_keymap: state
                 .bindings
                 .iter()
-                .filter(|binding| binding.release)
+                .filter(|binding| {
+                    binding.release || matches!(&binding.action, Action::GlobalShortcut(_))
+                })
                 .map(|binding| (binding.combo, binding.action.clone()))
                 .collect(),
             layer_keymap: HashMap::new(),
@@ -1331,7 +1335,9 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         self.release_keymap = next
             .bindings
             .iter()
-            .filter(|binding| binding.release)
+            .filter(|binding| {
+                binding.release || matches!(&binding.action, Action::GlobalShortcut(_))
+            })
             .map(|binding| (binding.combo, binding.action.clone()))
             .collect();
         let grab_bindings = bindings_for_grabs(&next);
@@ -1636,6 +1642,29 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             self.overview_key = Some(*combo);
             return Some(KeyResolution::Action(Action::Overview));
         }
+        // An open menu owns the keyboard as completely as Overview.
+        // Recognized navigation is returned for immediate dispatch;
+        // every other key is still consumed so typing cannot leak into
+        // the client behind a modal menu.
+        if self.desktop.menu_visible() {
+            if combo.modifiers.is_empty() {
+                let key = match combo.keysym {
+                    XK_UP => Some(MenuKey::Up),
+                    XK_DOWN => Some(MenuKey::Down),
+                    XK_LEFT => Some(MenuKey::Left),
+                    XK_RIGHT => Some(MenuKey::Right),
+                    XK_RETURN | XK_KP_ENTER => Some(MenuKey::Enter),
+                    0x20 => Some(MenuKey::Space),
+                    crate::desktop::PANEL_DISMISS_KEYSYM => {
+                        self.transient_escape = true;
+                        None
+                    }
+                    _ => None,
+                };
+                return Some(key.map_or(KeyResolution::Consumed, KeyResolution::Menu));
+            }
+            return Some(KeyResolution::Consumed);
+        }
         // Escape belongs to the open transient before it belongs to a
         // configured binding or the focused client. The shared grab is
         // held only while a menu or instrument panel is visible, and
@@ -1755,6 +1784,26 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             // right-click raises, so the menu, its items and its
             // dispatch are shared verbatim.
             Action::WindowMenu => wm.request_window_menu_for_focused(),
+            Action::RootMenu => {
+                let at = wm
+                    .focused_client()
+                    .and_then(|id| wm.client(id))
+                    .map(|client| client.geometry.pos)
+                    .or_else(|| {
+                        wm.monitors()
+                            .into_iter()
+                            .find(|monitor| monitor.primary)
+                            .map(|monitor| monitor.geometry.pos)
+                    })
+                    .unwrap_or(Point::new(0, 0));
+                self.desktop
+                    .open_root_menu(wm.backend_mut(), &self.theme, at);
+            }
+            // The Wayland compositor intercepts this variant and sends
+            // the matching protocol object. The X11 frontend has no
+            // such registry; keeping it a quiet no-op lets one shared
+            // Hyprland config remain usable on both backends.
+            Action::GlobalShortcut(_) => {}
             Action::WorkspaceNext => wm.switch_workspace(wm.current_workspace() + 1),
             Action::WorkspacePrev => {
                 if wm.current_workspace() > 0 {
@@ -1852,6 +1901,44 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         ShellOutcome::Continue
     }
 
+    /// Drives an open root/window/dock menu and executes a fired row
+    /// through the exact same dispatch used by a pointer release.
+    pub fn run_menu_key(&mut self, wm: &mut WindowManager<B>, key: MenuKey) -> ShellOutcome {
+        match self.desktop.key_menu(wm.backend_mut(), &self.theme, key) {
+            Some(action) => self.run_menu_action(wm, action),
+            None => ShellOutcome::Continue,
+        }
+    }
+
+    fn run_menu_action(&mut self, wm: &mut WindowManager<B>, action: MenuAction) -> ShellOutcome {
+        match action {
+            MenuAction::Root(action) => {
+                let outcome = root_action_outcome(&action);
+                self.run_root_menu_action(wm, action);
+                outcome
+            }
+            MenuAction::DockItem(id, action) => {
+                self.desktop
+                    .dock_item_menu_action(wm.backend_mut(), &self.theme, &id, action);
+                ShellOutcome::Continue
+            }
+            MenuAction::Window(client, action) => {
+                match action {
+                    WindowMenuAction::ToggleMaximize => wm.toggle_maximize_full(client),
+                    WindowMenuAction::Miniaturize => wm.miniaturize(client),
+                    WindowMenuAction::ToggleShade => wm.toggle_shade(client),
+                    WindowMenuAction::ToggleFullscreen => wm.toggle_fullscreen(client),
+                    WindowMenuAction::MoveToWorkspace(ws) => {
+                        wm.move_client_to_workspace(client, ws)
+                    }
+                    WindowMenuAction::Close => wm.close_client(client),
+                    WindowMenuAction::Kill => wm.kill_client(client),
+                }
+                ShellOutcome::Continue
+            }
+        }
+    }
+
     /// Opens the Overview and takes the modal keyboard grab — the same
     /// `Backend::grab_keyboard` the Alt-Tab cycle uses, taken from the
     /// shell layer because this modality lives here. Grabbed only if
@@ -1867,7 +1954,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         }
         self.populate_overview(wm);
         if self.desktop.overview_visible() {
-            wm.backend_mut().grab_keyboard();
+            Backend::grab_keyboard(wm.backend_mut());
         }
     }
 
@@ -1923,7 +2010,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
     /// bare desktop after an Escape, commanding a card that no longer
     /// exists on screen. A no-op when no menu is open.
     fn close_overview(&mut self, wm: &mut WindowManager<B>) {
-        wm.backend_mut().ungrab_keyboard();
+        Backend::ungrab_keyboard(wm.backend_mut());
         self.desktop.close_menu(wm.backend_mut());
         self.desktop.hide_overview(wm.backend_mut());
     }
@@ -2241,37 +2328,11 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             return ShellOutcome::Continue;
         }
 
-        if let Some(action) = self.desktop.click_menu(wm.backend_mut(), &self.theme, surface, local) {
-            match action {
-                MenuAction::Root(action) => {
-                    let outcome = root_action_outcome(&action);
-                    self.run_root_menu_action(wm, action);
-                    return outcome;
-                }
-                // A window-menu pick carries the client it was opened
-                // for. Every call below is a stale-id-safe no-op by
-                // `wm-core` contract — the client may well have
-                // vanished while the menu sat open — so no
-                // re-validation is needed here.
-                // A dock tile's own menu. The pick carries the tile's
-                // persistence id rather than its slot, so a reorder or
-                // a crash while the menu sat open cannot make it
-                // command a different tile than the one right-clicked;
-                // a stale id is silently nothing, like every other
-                // stale target here.
-                MenuAction::DockItem(id, action) => {
-                    self.desktop.dock_item_menu_action(wm.backend_mut(), &self.theme, &id, action);
-                }
-                MenuAction::Window(client, action) => match action {
-                    WindowMenuAction::ToggleMaximize => wm.toggle_maximize_full(client),
-                    WindowMenuAction::Miniaturize => wm.miniaturize(client),
-                    WindowMenuAction::ToggleShade => wm.toggle_shade(client),
-                    WindowMenuAction::ToggleFullscreen => wm.toggle_fullscreen(client),
-                    WindowMenuAction::MoveToWorkspace(ws) => wm.move_client_to_workspace(client, ws),
-                    WindowMenuAction::Close => wm.close_client(client),
-                    WindowMenuAction::Kill => wm.kill_client(client),
-                },
-            }
+        if let Some(action) = self
+            .desktop
+            .click_menu(wm.backend_mut(), &self.theme, surface, local)
+        {
+            return self.run_menu_action(wm, action);
         }
 
         ShellOutcome::Continue

--- a/crates/chonk-shell/src/startup.rs
+++ b/crates/chonk-shell/src/startup.rs
@@ -223,6 +223,9 @@ pub struct SessionState {
     pub input: wm_config::InputConfig,
     pub monitor_rules: Vec<wm_config::hyprland::directive::Monitor>,
     pub keybindings: Vec<(KeyCombo, Action)>,
+    /// Retained configuration refusals for the Hyprland-compatible
+    /// `configerrors` query.
+    pub config_diagnostics: Vec<String>,
 }
 
 impl SessionState {
@@ -283,6 +286,7 @@ impl SessionState {
             input: config.input.clone(),
             monitor_rules: config.monitor_rules.clone(),
             keybindings: config.keybindings.clone(),
+            config_diagnostics: config.diagnostics.clone(),
         }
     }
 
@@ -922,6 +926,7 @@ mod tests {
             input: wm_config::InputConfig::default(),
             monitor_rules: Vec::new(),
             keybindings: Vec::new(),
+            config_diagnostics: Vec::new(),
         };
         assert_eq!(state.theme(), base.scaled(2.0));
         // The load-bearing half: the state still holds the *unscaled*

--- a/crates/chonk-shell/src/wallpaper.rs
+++ b/crates/chonk-shell/src/wallpaper.rs
@@ -225,7 +225,13 @@ fn load_image(path: &Path) -> Option<Pixmap> {
 fn cover(source: &Pixmap, screen: Size) -> DecorationBuffer {
     let (screen_w, screen_h) = (screen.w.max(1), screen.h.max(1));
     let mut dest = Pixmap::new(screen_w, screen_h).expect("a non-zero pixmap");
-    let scale = (screen_w as f32 / source.width() as f32).max(screen_h as f32 / source.height() as f32);
+    // A wallpaper is the bottom of the scene, so transparent source
+    // pixels must resolve here rather than force every renderer to
+    // blend the full output forever. Black is the neutral fallback and
+    // keeps every pixel we publish honestly opaque.
+    dest.fill(tiny_skia::Color::from_rgba8(0, 0, 0, 255));
+    let scale =
+        (screen_w as f32 / source.width() as f32).max(screen_h as f32 / source.height() as f32);
     let offset_x = (screen_w as f32 - source.width() as f32 * scale) * 0.5;
     let offset_y = (screen_h as f32 - source.height() as f32 * scale) * 0.5;
     let image_paint = PixmapPaint { quality: FilterQuality::Bicubic, ..PixmapPaint::default() };
@@ -374,6 +380,19 @@ mod tests {
         // A degenerate screen never panics or divides by zero.
         let dot = cover(&source, Size::new(0, 0));
         assert_eq!((dot.width, dot.height), (1, 1));
+    }
+
+    #[test]
+    fn cover_resolves_transparency_to_an_opaque_wallpaper() {
+        let mut source = Pixmap::new(2, 2).unwrap();
+        source.fill(tiny_skia::Color::from_rgba8(255, 0, 0, 80));
+        let covered = cover(&source, Size::new(8, 8));
+        assert!(covered
+            .pixels
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .all(|pixel| pixel[3] == 255));
     }
 
     /// A decoded image arrives straight-alpha and leaves premultiplied,

--- a/crates/chonk-testkit/tests/dock_toggle.rs
+++ b/crates/chonk-testkit/tests/dock_toggle.rs
@@ -67,7 +67,8 @@ fn hiding_the_dock_from_the_root_menu_gives_a_maximized_window_its_strip() {
         "dock-toggle",
         SessionOptions {
             scale: Some(1.0),
-            config_extra: "[keybindings]\n\"super+d\" = \"toggle-dock\"\n".to_string(),
+            config_extra: "[keybindings]\n\"super+d\" = \"toggle-dock\"\n\"super+r\" = \"root-menu\"\n"
+                .to_string(),
             env: vec![("OMARCHY_PATH".to_string(), no_omarchy.to_string_lossy().into_owned())],
             ..SessionOptions::default()
         },
@@ -84,14 +85,6 @@ fn hiding_the_dock_from_the_root_menu_gives_a_maximized_window_its_strip() {
     assert_eq!(home.x + home.w as i32, output_w as i32, "flush against the right edge");
     assert!(!session.state_file("dock-visibility").exists(), "no choice made yet, so none is stored");
 
-    // Open the root menu while there is still bare desktop to click.
-    // Once the window below is maximized there is intentionally no
-    // background under the pointer, so asking a later right-click to
-    // open the root menu would send that click to the client instead.
-    let menu = session
-        .open_root_menu(&metrics, PLAIN.row_count())
-        .expect("a right-click on bare desk should open the root menu with a Dock row");
-
     session.launch("foot", &[]).unwrap();
     let window = session.wait_for_window("foot").unwrap();
     toggle_maximize(&mut session);
@@ -101,6 +94,19 @@ fn hiding_the_dock_from_the_root_menu_gives_a_maximized_window_its_strip() {
     })
     .expect("a maximized window must stop where the dock column begins");
     assert_eq!(short.x, 0, "and start at the left edge");
+
+    // A menu owns a modal keyboard grab, so keeping it open while
+    // asking the window to maximize would correctly consume that chord.
+    // Open it after maximizing through the keyboard entry point instead;
+    // this also proves a maximized client does not make the root menu
+    // unreachable merely because there is no bare desk left to click.
+    session.door().chord(keys::LEFTMETA, KEY_R).unwrap();
+    let wanted = metrics.height_for(PLAIN.row_count());
+    let menu = poll_until(Duration::from_secs(10), "the keyboard-opened root menu to map", || {
+        let world = session.world().ok()?;
+        world.menus().into_iter().find(|menu| menu.h == wanted)
+    })
+    .expect("the root-menu binding should open a menu with a Dock row");
 
     // -- the menu hides it: the surface goes, the strip is released ----
     hide_dock_from_menu(&mut session, &metrics, &menu);
@@ -276,6 +282,6 @@ fn a_session_configured_dockless_never_shows_the_dock_and_a_binding_brings_it_ba
     assert_eq!(std::fs::read_to_string(session.state_file("dock-visibility")).unwrap().trim(), "shown");
 }
 
-/// `KEY_D` from input-event-codes.h — the one keycode this test needs
-/// that `chonk_testkit::keys` has no reason to carry.
+/// Keycodes from input-event-codes.h used only by this test.
+const KEY_R: u32 = 19;
 const KEY_D: u32 = 32;

--- a/crates/chonk-testkit/tests/wayland_globals.rs
+++ b/crates/chonk-testkit/tests/wayland_globals.rs
@@ -55,6 +55,8 @@ fn ordinary_desktop_globals_bind_successfully() {
         "ext_foreign_toplevel_image_capture_source_manager_v1",
         "hyprland_toplevel_mapping_manager_v1",
         "hyprland_focus_grab_manager_v1",
+        "hyprland_global_shortcuts_manager_v1",
+        "zwlr_virtual_pointer_manager_v1",
     ] {
         assert!(
             report.contains(&format!("interface: '{interface}'")),

--- a/crates/chonk-testkit/tests/xwayland_input.rs
+++ b/crates/chonk-testkit/tests/xwayland_input.rs
@@ -162,6 +162,58 @@ fn assert_clicks_match(
     }
 }
 
+fn xwayland_child_pid(session: &Session) -> u32 {
+    poll_until(EVENT, "the compositor's Xwayland child process", || {
+        let children = std::fs::read_to_string(format!(
+            "/proc/{}/task/{}/children",
+            session.compositor_pid(),
+            session.compositor_pid()
+        ))
+        .ok()?;
+        children.split_whitespace().find_map(|pid| {
+            let comm = std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?;
+            comm.trim()
+                .eq_ignore_ascii_case("xwayland")
+                .then(|| pid.parse().ok())
+                .flatten()
+        })
+    })
+    .expect("Xwayland is a child of the nested compositor")
+}
+
+fn map_plain_x11_window(display: u32, title: &str) -> x11rb::rust_connection::RustConnection {
+    let (conn, screen_num) =
+        x11rb::rust_connection::RustConnection::connect(Some(&format!(":{display}")))
+            .expect("connect to nested XWayland");
+    let screen = &conn.setup().roots[screen_num];
+    let xid = conn.generate_id().unwrap();
+    conn.create_window(
+        COPY_DEPTH_FROM_PARENT,
+        xid,
+        screen.root,
+        0,
+        0,
+        320,
+        200,
+        0,
+        WindowClass::INPUT_OUTPUT,
+        COPY_FROM_PARENT,
+        &CreateWindowAux::new().background_pixel(screen.black_pixel),
+    )
+    .unwrap();
+    conn.change_property8(
+        x11rb::protocol::xproto::PropMode::REPLACE,
+        xid,
+        AtomEnum::WM_NAME,
+        AtomEnum::STRING,
+        title.as_bytes(),
+    )
+    .unwrap();
+    conn.map_window(xid).unwrap();
+    conn.flush().unwrap();
+    conn
+}
+
 #[test]
 #[ignore = "needs a Wayland session to nest inside"]
 fn xwayland_geometry_and_clicks_match_at_scale_two_from_first_map() {
@@ -273,6 +325,71 @@ fn xwayland_geometry_and_clicks_match_at_scale_two_from_first_map() {
     assert_x11_rect(&conn, root, xid, &moved);
     while conn.poll_for_event().unwrap().is_some() {}
     assert_clicks_match(&mut session, &conn, &moved);
+}
+
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn an_xwayland_crash_retires_ghosts_and_restarts_exactly_once() {
+    let mut session = Session::boot("xwayland-restart", SessionOptions::default())
+        .expect("nested compositor boots");
+    let display = xwayland_display(&session);
+    let first_client = map_plain_x11_window(display, "before-xwayland-crash");
+    poll_until(EVENT, "the first X11 window to map", || {
+        session
+            .world()
+            .ok()?
+            .windows
+            .iter()
+            .any(|window| window.mapped)
+            .then_some(())
+    })
+    .expect("first X11 generation is usable");
+
+    let first_pid = xwayland_child_pid(&session);
+    // This is the failure the compositor must survive: Xwayland gets no
+    // teardown opportunity and its XWM channel simply closes.
+    // SAFETY: the pid was resolved from this live session's direct child
+    // list and is used only to deliver a signal; no Rust memory is touched.
+    unsafe { libc::kill(first_pid as i32, libc::SIGKILL) };
+    drop(first_client);
+
+    poll_until(
+        EVENT,
+        "the dead generation's X11 records to disappear",
+        || session.world().ok()?.windows.is_empty().then_some(()),
+    )
+    .expect("no X11 ghost frames survive the disconnect");
+    let restarted_display = poll_until(EVENT, "one replacement XWayland generation", || {
+        let displays: Vec<u32> = session
+            .log()
+            .lines()
+            .filter(|line| line.contains("XWayland ready"))
+            .filter_map(|line| line.split("display=").nth(1)?.trim().parse().ok())
+            .collect();
+        (displays.len() == 2).then(|| *displays.last().unwrap())
+    })
+    .expect("the bounded restart becomes ready");
+    assert_ne!(xwayland_child_pid(&session), first_pid);
+
+    let _second_client = map_plain_x11_window(restarted_display, "after-xwayland-crash");
+    poll_until(
+        EVENT,
+        "an X11 window to map through the replacement",
+        || {
+            session
+                .world()
+                .ok()?
+                .windows
+                .iter()
+                .any(|window| window.mapped)
+                .then_some(())
+        },
+    )
+    .expect("the replacement XWayland accepts applications");
+    assert!(
+        session.compositor_alive(),
+        "the Wayland session survives the X server crash"
+    );
 }
 
 /// XSETTINGS does not reach Java, Electron's X11 backend or Xcursor.

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -35,10 +35,55 @@ fn print_version_and_exit_if_asked() {
 }
 
 #[cfg(target_os = "linux")]
+fn inspect_config_and_exit_if_asked() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some((index, print)) =
+        args.iter()
+            .enumerate()
+            .find_map(|(index, arg)| match arg.as_str() {
+                "--check-config" => Some((index, false)),
+                "--print-config" => Some((index, true)),
+                _ => None,
+            })
+    else {
+        return;
+    };
+    let _ = tracing_subscriber::fmt()
+        .without_time()
+        .with_max_level(tracing::Level::WARN)
+        .try_init();
+    let path = args
+        .get(index + 1)
+        .filter(|arg| !arg.starts_with('-'))
+        .map(std::path::Path::new);
+    let config = match wm_config::inspect(path) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("config error: {error}");
+            std::process::exit(1);
+        }
+    };
+    if print {
+        print!("{}", wm_config::effective_config_report(&config));
+    } else {
+        for diagnostic in &config.diagnostics {
+            println!("{diagnostic}");
+        }
+        println!(
+            "resolved {} bindings; {} diagnostics",
+            config.keybindings.len(),
+            config.diagnostics.len()
+        );
+    }
+    std::process::exit(0);
+}
+
+#[cfg(target_os = "linux")]
 fn main() {
     // Before the subscriber, so `--version` prints one clean line
     // rather than a line preceded by whatever RUST_LOG asked for.
     print_version_and_exit_if_asked();
+    inspect_config_and_exit_if_asked();
     let allocator_policy_pinned = chonk_shell::startup::pin_glibc_large_allocation_policy();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
     if !allocator_policy_pinned {

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -46,12 +46,59 @@ fn print_version_and_exit_if_asked() {
     std::process::exit(0);
 }
 
+fn inspect_config_and_exit_if_asked() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some((index, print)) =
+        args.iter()
+            .enumerate()
+            .find_map(|(index, arg)| match arg.as_str() {
+                "--check-config" => Some((index, false)),
+                "--print-config" => Some((index, true)),
+                _ => None,
+            })
+    else {
+        return;
+    };
+    // Offline inspection still needs the parser's per-entry warnings;
+    // the normal subscriber is intentionally installed only after
+    // this early-exit path.
+    let _ = tracing_subscriber::fmt()
+        .without_time()
+        .with_max_level(tracing::Level::WARN)
+        .try_init();
+    let path = args
+        .get(index + 1)
+        .filter(|arg| !arg.starts_with('-'))
+        .map(std::path::Path::new);
+    let config = match wm_config::inspect(path) {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("config error: {error}");
+            std::process::exit(1);
+        }
+    };
+    if print {
+        print!("{}", wm_config::effective_config_report(&config));
+    } else {
+        for diagnostic in &config.diagnostics {
+            println!("{diagnostic}");
+        }
+        println!(
+            "resolved {} bindings; {} diagnostics",
+            config.keybindings.len(),
+            config.diagnostics.len()
+        );
+    }
+    std::process::exit(0);
+}
+
 fn main() {
     // Before the subscriber, so `--version` prints one clean line
     // rather than a line preceded by whatever RUST_LOG asked for.
     // Also before `restart_in_place`'s re-exec can ever matter: that
     // path passes no arguments, so a restarted session never sees one.
     print_version_and_exit_if_asked();
+    inspect_config_and_exit_if_asked();
     let allocator_policy_pinned = pin_glibc_large_allocation_policy();
     tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
     if !allocator_policy_pinned {
@@ -277,11 +324,19 @@ fn main() {
                     if let Some(motion) = pending_motion.take() {
                         dispatch_motion(&mut wm, &mut shell, motion);
                     }
-                    if let chonk_shell::shell::KeyResolution::Action(action) = resolution {
-                        let outcome = shell.run_action(&mut wm, &action);
-                        if exit_requested(&mut shell, outcome) {
-                            should_exit = true;
+                    let outcome = match resolution {
+                        chonk_shell::shell::KeyResolution::Action(action) => {
+                            shell.run_action(&mut wm, &action)
                         }
+                        chonk_shell::shell::KeyResolution::Menu(key) => {
+                            shell.run_menu_key(&mut wm, key)
+                        }
+                        chonk_shell::shell::KeyResolution::Consumed => {
+                            chonk_shell::shell::ShellOutcome::Continue
+                        }
+                    };
+                    if exit_requested(&mut shell, outcome) {
+                        should_exit = true;
                     }
                     continue;
                 }

--- a/crates/wm-config/src/hyprland/conf.rs
+++ b/crates/wm-config/src/hyprland/conf.rs
@@ -220,9 +220,13 @@ fn directive(keyword: &str, value: &str, out: &mut Vec<Directive>) {
         // sourced file exactly where its line sat — which is what makes
         // "the user's file is read after the defaults" true.
         "source" => out.push(Directive::Include(Include::Path(value.to_string()))),
-        // Hyprland's own machinery: plugin loading, animation curves,
-        // the blur layer list, debug switches.
-        "plugin" | "bezier" | "animation" | "blurls" | "debug" => {}
+        // Hyprland's own machinery is unsupported here, but it must be
+        // reported like every other declined directive. Silence made a
+        // plugin or debug setting look successfully applied.
+        "plugin" | "bezier" | "animation" | "blurls" | "debug" => out.push(Directive::Ignored {
+            kind: "keyword",
+            detail: format!("{keyword} = {} (Hyprland-only machinery)", truncate(value)),
+        }),
         _ => out.push(Directive::Ignored {
             kind: "keyword",
             detail: format!("{keyword} = {}", truncate(value)),

--- a/crates/wm-config/src/hyprland/dispatch.rs
+++ b/crates/wm-config/src/hyprland/dispatch.rs
@@ -249,12 +249,20 @@ fn compositor_verb(name: &str, arg: &str) -> Verb {
             Verb::Unbound(Unbound::NoVerb)
         }
         // Talking to the compositor about itself.
+        "global" => {
+            let target = arg.trim();
+            match target.split_once(':') {
+                Some((_, id)) if !id.is_empty() => {
+                    Verb::Action(Action::GlobalShortcut(target.to_string()))
+                }
+                _ => Verb::Unbound(Unbound::NoVerb),
+            }
+        }
         "exit"
         | "forcerendererreload"
         | "dpms"
         | "exec-shutdown"
         | "submap"
-        | "global"
         | "setprop"
         | "toggleopaque"
         | "renameworkspace" => Verb::Unbound(Unbound::HyprlandOnly),

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -835,6 +835,21 @@ fn a_doubled_hash_stays_a_hash_in_a_url() {
     assert_eq!(command, "launch-webapp \"https://x.com/#anchor\"");
 }
 
+#[test]
+fn a_global_dispatcher_becomes_a_portal_shortcut_target() {
+    let root = scratch("global-shortcut");
+    write(
+        &root.join(".config/hypr/hyprland.conf"),
+        "bind = SUPER, M, global, org.example.Player:mute\n",
+    );
+    let reading = read(&Roots::under(&root));
+    assert_eq!(
+        action_for(&reading, "super+m"),
+        Some(Action::GlobalShortcut("org.example.Player:mute".into()))
+    );
+    let _ = std::fs::remove_dir_all(root);
+}
+
 /// Hyprland's `$variables`, which every hand-written `hyprland.conf`
 /// from the upstream wiki uses for its modifier.
 #[test]

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -76,7 +76,7 @@ pub mod hyprland;
 pub mod preset;
 
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub use wm_core::DecorationRules;
 pub use wm_core::{FocusDirection, FocusPolicy};
@@ -151,6 +151,11 @@ pub enum Action {
     /// are modal machinery like the Alt-Tab switcher's, not
     /// per-binding config.
     Overview,
+    /// Open the desktop's root menu from a configured keybinding.
+    RootMenu,
+    /// Trigger a portal-registered global shortcut identified by the
+    /// Hyprland protocol's `app_id:id` key.
+    GlobalShortcut(String),
     /// Open the window commands menu for the focused window, at the
     /// keyboard rather than by right-clicking a titlebar.
     ///
@@ -234,7 +239,15 @@ pub struct InputConfig {
 /// for unknown names — including `"none"`, which the caller must treat
 /// as unbinding *before* asking here.
 fn action_from_name(name: &str) -> Option<Action> {
-    match name.trim().to_ascii_lowercase().as_str() {
+    let name = name.trim();
+    let normalized = name.to_ascii_lowercase();
+    if normalized.starts_with("global-shortcut ") {
+        let target = name.get("global-shortcut ".len()..)?.trim();
+        let (app_id, id) = target.split_once(':')?;
+        return (!app_id.is_empty() && !id.is_empty())
+            .then(|| Action::GlobalShortcut(target.to_string()));
+    }
+    match normalized.as_str() {
         "spawn-terminal" => Some(Action::SpawnTerminal),
         "close" => Some(Action::Close),
         "toggle-maximize" => Some(Action::ToggleMaximize),
@@ -250,6 +263,7 @@ fn action_from_name(name: &str) -> Option<Action> {
         "workspace-carry-next" => Some(Action::WorkspaceCarryNext),
         "workspace-carry-prev" => Some(Action::WorkspaceCarryPrev),
         "overview" => Some(Action::Overview),
+        "root-menu" => Some(Action::RootMenu),
         "window-menu" => Some(Action::WindowMenu),
         "toggle-dock" => Some(Action::ToggleDock),
         "reload" => Some(Action::Reload),
@@ -524,6 +538,12 @@ pub struct Config {
     pub bindings: Vec<Binding>,
     pub layer_bindings: BTreeMap<String, Vec<Binding>>,
     pub keybindings: Vec<(KeyCombo, Action)>,
+    /// Human-readable refusals retained for `hyprctl configerrors` and
+    /// the offline inspection commands.
+    pub diagnostics: Vec<String>,
+    /// Last writer of each effective setting: built-in, preset, live
+    /// Hyprland configuration, or the chonkstep config file.
+    pub provenance: BTreeMap<String, String>,
 }
 
 /// The `hyprland_config` key, read out of the raw table before the
@@ -570,7 +590,7 @@ impl Config {
                 .expect("default keybinding specs are constants and must always parse");
             (combo, action)
         }
-        Config {
+        let mut config = Config {
             focus_follows_mouse: false,
             autoraise: true,
             scale: None,
@@ -641,7 +661,40 @@ impl Config {
                 // decorate itself a safe policy rather than a gamble.
                 bind("control+escape", Action::WindowMenu),
             ],
+            diagnostics: Vec::new(),
+            provenance: BTreeMap::new(),
+        };
+        for key in [
+            "focus_follows_mouse",
+            "scale",
+            "theme",
+            "appearance",
+            "placement",
+            "edge_resistance",
+            "terminal_font_px",
+            "decorations",
+            "drag_modifier",
+            "restore_session",
+            "lock_command",
+            "commands",
+            "terminal",
+            "autostart",
+            "omarchy_menu",
+            "omarchy_shell",
+            "show_dock",
+            "omarchy_bar",
+            "desktop",
+            "keymap",
+            "hyprland_config",
+            "input",
+            "monitor_rules",
+            "keybindings",
+        ] {
+            config
+                .provenance
+                .insert(key.to_string(), "built-in".to_string());
         }
+        config
     }
 }
 
@@ -1049,7 +1102,27 @@ pub fn parse_with(
     // *place* in the order is the preset's, which is what matters.
     config.hyprland_config = hyprland_switch(&table);
     if hyprland::wanted(&config) {
-        hyprland::apply(&mut config, live().as_ref());
+        let reading = live();
+        if let Some(reading) = &reading {
+            config.diagnostics.extend(
+                reading
+                    .skipped
+                    .iter()
+                    .map(|skip| format!("{}: {} — {}", skip.kind, skip.what, skip.why)),
+            );
+            for key in [
+                "keybindings",
+                "commands",
+                "autostart",
+                "input",
+                "monitor_rules",
+            ] {
+                config
+                    .provenance
+                    .insert(key.into(), "live Hyprland config".into());
+            }
+        }
+        hyprland::apply(&mut config, reading.as_ref());
     }
     if let Some((keybindings, bindings, layer_bindings, commands)) = preserve_keymap {
         config.keybindings = keybindings;
@@ -1303,6 +1376,63 @@ pub fn parse_with(
             ),
         }
     }
+    for (key, value) in &table {
+        // Provenance describes the setting that actually won, not just
+        // the last layer that mentioned its name. Reuse the same
+        // validators as the application pass above so a rejected typo
+        // continues to point at the inherited source.
+        let provenance_key = match key.as_str() {
+            "focus_follows_mouse"
+            | "restore_session"
+            | "omarchy_menu"
+            | "omarchy_shell"
+            | "omarchy_bar"
+            | "show_dock"
+            | "hyprland_config"
+                if value.is_bool() =>
+            {
+                Some(key.as_str())
+            }
+            "scale" if scale_from_value(value).is_some() => Some("scale"),
+            "theme" if value.is_str() => Some("theme"),
+            "appearance"
+                if value.as_str().is_some_and(|name| {
+                    matches!(name.trim().to_ascii_lowercase().as_str(), "light" | "dark")
+                }) =>
+            {
+                Some("appearance")
+            }
+            "placement" if placement_from_value(value).is_some() => Some("placement"),
+            "edge_resistance" if edge_resistance_from_value(value).is_some() => {
+                Some("edge_resistance")
+            }
+            "terminal_font_px" if terminal_font_px_from_value(value).is_some() => {
+                Some("terminal_font_px")
+            }
+            "lock_command"
+                if value
+                    .as_str()
+                    .is_some_and(|command| !command.trim().is_empty()) =>
+            {
+                Some("lock_command")
+            }
+            "drag_modifier" if value.as_str().and_then(drag_modifier_from_name).is_some() => {
+                Some("drag_modifier")
+            }
+            "terminal" if argv_from_value(value, "terminal").is_some() => Some("terminal"),
+            "self_decorating_apps" if value.is_array() => Some("decorations"),
+            "decorations" if value.is_table() => Some("decorations"),
+            "commands" if value.is_table() => Some("commands"),
+            "autostart" if value.is_array() => Some("autostart"),
+            "keybindings" if value.is_table() => Some("keybindings"),
+            _ => None,
+        };
+        if let Some(key) = provenance_key {
+            config
+                .provenance
+                .insert(key.to_string(), "config file".to_string());
+        }
+    }
     // `run <name>` is checked here, after the whole file has been read,
     // rather than inside `apply_keybindings`. TOML tables reach us in
     // an order we do not control, so a binding may well be parsed
@@ -1430,29 +1560,69 @@ fn config_path() -> Option<PathBuf> {
 ///   error, then the defaults.
 /// - File fine but individual entries bad: [`parse`] warns and skips
 ///   those entries, keeping the rest.
-pub fn load() -> Config {
-    let Some(path) = config_path() else {
-        return Config::default_config();
+pub fn inspect(path: Option<&Path>) -> Result<Config, String> {
+    let path = match path {
+        Some(path) => path.to_path_buf(),
+        None => match config_path() {
+            Some(path) => path,
+            None => return Ok(Config::default_config()),
+        },
     };
     let text = match std::fs::read_to_string(&path) {
         Ok(text) => text,
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-            return Config::default_config();
+            return Ok(Config::default_config());
         }
-        Err(err) => {
-            tracing::warn!(path = %path.display(), %err, "config: unreadable, using defaults");
-            return Config::default_config();
-        }
+        Err(err) => return Err(format!("{}: {err}", path.display())),
     };
-    // The one call site with a machine in front of it, and so the one
-    // that reads the user's live Hyprland configuration — see
-    // `parse_with` for why that is a parameter rather than something
-    // `parse` does for itself.
-    match parse_with(&text, &hyprland::load) {
+    parse_with(&text, &hyprland::load).map_err(|error| format!("{}: {error}", path.display()))
+}
+
+/// Stable, line-oriented effective configuration with the last writer
+/// beside every setting. Intended for `--print-config`, not as a second
+/// configuration format.
+pub fn effective_config_report(config: &Config) -> String {
+    let mut out = String::new();
+    let mut line = |key: &str, value: String| {
+        let source = config
+            .provenance
+            .get(key)
+            .map(String::as_str)
+            .unwrap_or("resolved");
+        out.push_str(&format!("{key} = {value}\t# {source}\n"));
+    };
+    line("desktop", config.desktop.id().into());
+    line("keymap", config.keymap.id().into());
+    line(
+        "focus_follows_mouse",
+        config.focus_follows_mouse.to_string(),
+    );
+    line("scale", format!("{:?}", config.scale));
+    line("theme", format!("{:?}", config.theme));
+    line("appearance", format!("{:?}", config.appearance));
+    line("placement", format!("{:?}", config.placement));
+    line("edge_resistance", config.edge_resistance.to_string());
+    line("terminal_font_px", config.terminal_font_px.to_string());
+    line("drag_modifier", format!("{:?}", config.drag_modifier));
+    line("restore_session", config.restore_session.to_string());
+    line("show_dock", config.show_dock.to_string());
+    line("omarchy_bar", format!("{:?}", config.omarchy_bar));
+    line("input", format!("{:?}", config.input));
+    line("monitor_rules", config.monitor_rules.len().to_string());
+    line("keybindings", config.keybindings.len().to_string());
+    line("commands", config.commands.len().to_string());
+    line("autostart", config.autostart.len().to_string());
+    out
+}
+
+pub fn load() -> Config {
+    match inspect(None) {
         Ok(config) => config,
         Err(err) => {
-            tracing::warn!(path = %path.display(), %err, "config: using defaults");
-            Config::default_config()
+            tracing::warn!(%err, "config: using defaults");
+            let mut config = Config::default_config();
+            config.diagnostics.push(err);
+            config
         }
     }
 }
@@ -2051,8 +2221,14 @@ mod tests {
             ("workspace-send 4", Action::WorkspaceSend(3)),
             ("workspace-carry 4", Action::WorkspaceCarry(3)),
             ("overview", Action::Overview),
+            ("root-menu", Action::RootMenu),
             ("window-menu", Action::WindowMenu),
             ("toggle-dock", Action::ToggleDock),
+            (
+                "global-shortcut org.example.App:mute",
+                Action::GlobalShortcut("org.example.App:mute".into()),
+            ),
+            ("reload", Action::Reload),
             ("restart", Action::Restart),
         ];
         // One letter per action rather than one function key: the list
@@ -2080,6 +2256,40 @@ mod tests {
         let config = parse(text).unwrap();
         assert_eq!(action_for(&config, "super+a"), Some(Action::Close));
         assert_eq!(action_for(&config, "super+b"), Some(Action::SpawnTerminal));
+    }
+
+    #[test]
+    fn inspection_retains_hyprland_refusals_and_reports_provenance() {
+        let config = parse_with(
+            "hyprland_config = true\nfocus_follows_mouse = true\n",
+            &|| {
+                let mut reading = hyprland::Reading::default();
+                reading.skipped.push(hyprland::Skipped {
+                    kind: "bind".into(),
+                    what: "SUPER J".into(),
+                    why: "tiling-only".into(),
+                });
+                Some(reading)
+            },
+        )
+        .unwrap();
+        assert_eq!(config.diagnostics, vec!["bind: SUPER J — tiling-only"]);
+        let report = effective_config_report(&config);
+        assert!(report.contains("focus_follows_mouse = true\t# config file"));
+        assert!(report.contains("keybindings = 12\t# live Hyprland config"));
+    }
+
+    #[test]
+    fn inspection_rejects_fatally_invalid_toml_with_the_path() {
+        let path = std::env::temp_dir().join(format!(
+            "chonkstep-config-{}-invalid.toml",
+            std::process::id()
+        ));
+        std::fs::write(&path, "[broken").unwrap();
+        let error = inspect(Some(&path)).unwrap_err();
+        assert!(error.contains(&path.display().to_string()));
+        assert!(error.contains("invalid TOML"));
+        let _ = std::fs::remove_file(path);
     }
 
     // ---- parse: merge semantics ---------------------------------------

--- a/crates/wm-config/src/preset.rs
+++ b/crates/wm-config/src/preset.rs
@@ -191,6 +191,32 @@ pub fn base(table: &toml::Table) -> Config {
     config.keymap = keymap;
     apply_desktop(&mut config, desktop);
     apply_keymap(&mut config, keymap);
+    if desktop == Desktop::Omarchy {
+        for key in ["show_dock", "omarchy_bar", "theme"] {
+            config
+                .provenance
+                .insert(key.into(), "desktop preset (omarchy)".into());
+        }
+    }
+    if keymap == Keymap::Omarchy {
+        for key in ["keybindings", "commands"] {
+            config
+                .provenance
+                .insert(key.into(), "keymap preset (omarchy)".into());
+        }
+    }
+    if matches!(table.get("desktop"), Some(toml::Value::String(name)) if Desktop::from_name(name).is_some())
+    {
+        config
+            .provenance
+            .insert("desktop".into(), "config file".into());
+    }
+    if matches!(table.get("keymap"), Some(toml::Value::String(name)) if Keymap::from_name(name).is_some())
+    {
+        config
+            .provenance
+            .insert("keymap".into(), "config file".into());
+    }
     config
 }
 

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -2,8 +2,8 @@ use wm_theme_api::{DecorationBuffer, DecorationLayout, Point, Rect, ResizeEdge, 
 
 use crate::client::MonitorInfo;
 use crate::types::{
-    BackendEvent, DecorationRules, DragHandle, KeyCombo, Modifiers, MouseButton, ScrollDelta, SizeHints, WindowType,
-    WmClass, WmProtocol,
+    BackendEvent, DecorationRules, DragHandle, KeyCombo, Modifiers, MouseButton, NetStateSnapshot, ScrollDelta,
+    SizeHints, WindowType, WmClass, WmProtocol,
 };
 
 /// Everything the protocol-agnostic core needs from a windowing backend
@@ -411,6 +411,11 @@ pub trait Backend {
     fn window_parent(&self, _window: Self::WindowId) -> Option<Self::WindowId> {
         None
     }
+    /// Whether this transient currently blocks interaction with its
+    /// parent (`xdg_dialog_v1.set_modal` / `_NET_WM_STATE_MODAL`).
+    fn window_is_modal(&self, _window: Self::WindowId) -> bool {
+        false
+    }
     /// Installs (or removes) the passive pointer grabs the move/resize
     /// modifier-drag needs on one managed client's own window.
     ///
@@ -475,15 +480,7 @@ pub trait Backend {
     fn publish_workarea(&mut self, _area: Rect, _workspace_count: usize) {}
     /// Publishes a client's `_NET_WM_STATE` property from the WM's own
     /// authoritative flags.
-    fn publish_net_state(
-        &mut self,
-        _window: Self::WindowId,
-        _fullscreen: bool,
-        _max_h: bool,
-        _max_v: bool,
-        _shaded: bool,
-        _hidden: bool,
-    ) {
+    fn publish_net_state(&mut self, _window: Self::WindowId, _state: NetStateSnapshot) {
     }
     /// Publishes a client's `_NET_WM_DESKTOP` property — which
     /// workspace the window lives on, for pagers and taskbars.

--- a/crates/wm-core/src/client.rs
+++ b/crates/wm-core/src/client.rs
@@ -95,6 +95,10 @@ bitflags::bitflags! {
         const NO_FOCUS = 1 << 9;
         /// Client-originated activation requests may not steal focus.
         const NO_ACTIVATE = 1 << 10;
+        /// This toplevel is a modal transient. Its parent remains
+        /// visible, but focus, close and drag gestures are redirected
+        /// to the live modal child until the dialog is dismissed.
+        const MODAL = 1 << 11;
     }
 }
 
@@ -138,6 +142,10 @@ pub struct Client<B: Backend> {
     pub layout: DecorationLayout,
     pub lifecycle: Lifecycle,
     pub flags: ClientFlags,
+    /// Managed transient parent, resolved from `xdg_toplevel.set_parent`
+    /// or `WM_TRANSIENT_FOR`. Kept in core state so placement and every
+    /// lifecycle transition use the same relationship as stacking.
+    pub parent: Option<ClientId>,
     /// Whether this client's first over-limit geometry has already
     /// been logged. Client sizes cross several paths (initial map,
     /// later ConfigureRequest, session restore); one bit keeps a buggy
@@ -174,6 +182,7 @@ impl<B: Backend> Client<B> {
             layout: DecorationLayout::default(),
             lifecycle: Lifecycle::Normal,
             flags: ClientFlags::empty(),
+            parent: None,
             geometry_clamp_logged: false,
             restore_geometry: None,
             // `WindowManager::handle_map_request` overwrites this with

--- a/crates/wm-core/src/fake_backend.rs
+++ b/crates/wm-core/src/fake_backend.rs
@@ -7,7 +7,7 @@ use wm_theme_api::{
 
 use crate::backend::Backend;
 use crate::client::MonitorInfo;
-use crate::types::{BackendEvent, DragHandle, KeyCombo, MouseButton, ScrollDelta, SizeHints, WindowType, WmClass, WmProtocol};
+use crate::types::{BackendEvent, DragHandle, KeyCombo, MouseButton, NetStateSnapshot, ScrollDelta, SizeHints, WindowType, WmClass, WmProtocol};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct FakeWindowId(pub u64);
@@ -148,6 +148,8 @@ pub struct FakeBackend {
     /// `WM_TRANSIENT_FOR` report them — see
     /// [`Self::set_window_parent`].
     pub parents: std::collections::HashMap<FakeWindowId, FakeWindowId>,
+    /// Windows currently declaring modal transient state.
+    pub modal_windows: HashSet<FakeWindowId>,
     /// Whether each client's own content window is currently mapped —
     /// defaults to "mapped" (absent from the map) the moment a window is
     /// created, matching a real client that maps itself before the WM
@@ -180,9 +182,9 @@ pub struct FakeBackend {
     /// `(area, workspace_count)`.
     pub published_workareas: Vec<(Rect, usize)>,
     /// Every `publish_net_state` call in order, as
-    /// `(window, fullscreen, max_h, max_v, shaded, hidden)` — matching
+    /// `(window, fullscreen, max_h, max_v, shaded, hidden, modal)` — matching
     /// the trait method's parameter order exactly.
-    pub published_net_states: Vec<(FakeWindowId, bool, bool, bool, bool, bool)>,
+    pub published_net_states: Vec<(FakeWindowId, bool, bool, bool, bool, bool, bool)>,
     /// Every `publish_window_desktop` call in order, as
     /// `(window, desktop)` — a history, so a test can assert both the
     /// initial manage-time publish and a later move's re-publish, not
@@ -260,6 +262,14 @@ impl FakeBackend {
     /// `xdg_toplevel.set_parent` and `WM_TRANSIENT_FOR` do.
     pub fn set_window_parent(&mut self, child: FakeWindowId, parent: FakeWindowId) {
         self.parents.insert(child, parent);
+    }
+
+    pub fn set_window_modal(&mut self, window: FakeWindowId, modal: bool) {
+        if modal {
+            self.modal_windows.insert(window);
+        } else {
+            self.modal_windows.remove(&window);
+        }
     }
 
     /// Stages a scroll for the next `take_shell_scroll` drain, as a
@@ -424,6 +434,10 @@ impl Backend for FakeBackend {
         self.parents.get(&window).copied()
     }
 
+    fn window_is_modal(&self, window: Self::WindowId) -> bool {
+        self.modal_windows.contains(&window)
+    }
+
     fn raise(&mut self, frame: Self::FrameId) {
         self.raised_frames.push(frame);
     }
@@ -516,8 +530,17 @@ impl Backend for FakeBackend {
         self.published_workareas.push((area, workspace_count));
     }
 
-    fn publish_net_state(&mut self, window: Self::WindowId, fullscreen: bool, max_h: bool, max_v: bool, shaded: bool, hidden: bool) {
-        self.published_net_states.push((window, fullscreen, max_h, max_v, shaded, hidden));
+    fn publish_net_state(&mut self, window: Self::WindowId, state: NetStateSnapshot) {
+        self.published_net_states
+            .push((
+                window,
+                state.fullscreen,
+                state.maximized_horizontally,
+                state.maximized_vertically,
+                state.shaded,
+                state.hidden,
+                state.modal,
+            ));
     }
 
     fn publish_window_desktop(&mut self, window: Self::WindowId, desktop: usize) {

--- a/crates/wm-core/src/lib.rs
+++ b/crates/wm-core/src/lib.rs
@@ -43,6 +43,6 @@ pub use placement::{place_frame, FloatDecision, FloatPolicy, PlacementPolicy, Wi
 pub use snap::snap_position;
 pub use types::{
     BackendEvent, ClientChrome, DecorationRules, DragHandle, KeyCombo, Modifiers, MouseButton, NetState,
-    NetStateAction, ScrollDelta, SizeHints, SurfaceRef, WindowType, WmClass, WmProtocol,
+    NetStateAction, NetStateSnapshot, ScrollDelta, SizeHints, SurfaceRef, WindowType, WmClass, WmProtocol,
 };
 pub use wm_theme_api::{Point, Rect, Size};

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -14,8 +14,8 @@ use crate::placement::{self, FloatPolicy, PlacementPolicy};
 use crate::resize;
 use crate::snap;
 use crate::types::{
-    BackendEvent, ClientChrome, DragHandle, KeyCombo, Modifiers, MouseButton, NetState, NetStateAction, SurfaceRef,
-    WindowType,
+    BackendEvent, ClientChrome, DragHandle, KeyCombo, Modifiers, MouseButton, NetState, NetStateAction,
+    NetStateSnapshot, SurfaceRef, WindowType,
 };
 
 /// How close together (in ms) two presses on the same titlebar must land
@@ -1170,6 +1170,12 @@ impl<B: Backend> WindowManager<B> {
     /// next/previous workspace" window actions. A no-op if `id` is
     /// already on `workspace` or if the index is out of range.
     pub fn move_client_to_workspace(&mut self, id: ClientId, workspace: usize) {
+        for member in self.transient_family(id) {
+            self.move_one_client_to_workspace(member, workspace);
+        }
+    }
+
+    fn move_one_client_to_workspace(&mut self, id: ClientId, workspace: usize) {
         if workspace >= MAX_WORKSPACES {
             return;
         }
@@ -1344,6 +1350,10 @@ impl<B: Backend> WindowManager<B> {
             }
             BackendEvent::TitleChanged(window) => self.handle_title_changed(window),
             BackendEvent::ChromeChanged(window) => self.handle_chrome_changed(window),
+            BackendEvent::ParentChanged(window) => self.handle_parent_changed(window),
+            BackendEvent::ModalChanged { window, modal } => {
+                self.handle_modal_changed(window, modal)
+            }
             BackendEvent::MoveRequest(window) => self.handle_move_request(window),
             BackendEvent::DragEnded => self.end_active_drag(),
             BackendEvent::ResizeRequest { window, edge } => self.handle_resize_request(window, edge),
@@ -1443,7 +1453,17 @@ impl<B: Backend> WindowManager<B> {
         client.class = self.backend.window_class(window).map(|c| c.class).unwrap_or_default();
         client.geometry = content;
         Self::clamp_geometry(&mut client, self.backend.screen_size());
-        client.workspace = self.current_workspace;
+        client.parent = self
+            .backend
+            .window_parent(window)
+            .and_then(|parent| self.window_index.get(&parent).copied());
+        client.workspace = client
+            .parent
+            .and_then(|parent| self.clients.get(parent).map(|parent| parent.workspace))
+            .unwrap_or(self.current_workspace);
+        client
+            .flags
+            .set(ClientFlags::MODAL, self.backend.window_is_modal(window));
 
         let window_rule = self
             .float_policy
@@ -1523,7 +1543,24 @@ impl<B: Backend> WindowManager<B> {
         // position the client asked for: the whole rule is "this window
         // appears in the middle at this size", and honoring a
         // placeholder origin would put half of it under the dock.
-        let frame_pos = if floated.is_none() && content.pos != Point::new(0, 0) {
+        let transient_pos = client.parent.and_then(|parent| {
+            let parent = self.clients.get(parent)?;
+            (parent.lifecycle == Lifecycle::Normal).then(|| {
+                let parent_frame = client_frame_rect(parent);
+                let center = Point::new(
+                    parent_frame.pos.x + parent_frame.size.w as i32 / 2,
+                    parent_frame.pos.y + parent_frame.size.h as i32 / 2,
+                );
+                let desired = Point::new(
+                    center.x - layout.frame_size.w as i32 / 2,
+                    center.y - layout.frame_size.h as i32 / 2,
+                );
+                placement::clamp_to(self.usable_area_at(center), layout.frame_size, desired)
+            })
+        });
+        let frame_pos = if let Some(pos) = transient_pos {
+            pos
+        } else if floated.is_none() && content.pos != Point::new(0, 0) {
             content.pos
         } else {
             let workarea = self.placement_area();
@@ -1725,6 +1762,11 @@ impl<B: Backend> WindowManager<B> {
                 self.backend.destroy_decoration(frame);
             }
         }
+        for (_, child) in &mut self.clients {
+            if child.parent == Some(id) {
+                child.parent = None;
+            }
+        }
         self.managed_order.retain(|&other| other != window);
         self.backend.publish_client_list(&self.managed_order);
         // After `clients.remove`, so the dying window can never be
@@ -1774,6 +1816,80 @@ impl<B: Backend> WindowManager<B> {
         client.title = title;
         self.bump_protocol_state_revision();
         self.repaint_decoration(id);
+    }
+
+    /// Refreshes the transient edge after a client reparents itself.
+    /// Late parenting is common (LibreOffice does it after map), so the
+    /// relationship cannot be a map-time-only hint.
+    fn handle_parent_changed(&mut self, window: B::WindowId) {
+        let Some(&id) = self.window_index.get(&window) else {
+            return;
+        };
+        let parent = self
+            .backend
+            .window_parent(window)
+            .and_then(|parent| self.window_index.get(&parent).copied())
+            .filter(|parent| *parent != id);
+        if self
+            .clients
+            .get(id)
+            .is_some_and(|client| client.parent == parent)
+        {
+            return;
+        }
+        if let Some(client) = self.clients.get_mut(id) {
+            client.parent = parent;
+        }
+        let Some(parent) = parent else {
+            return;
+        };
+        let Some(parent_client) = self.clients.get(parent) else {
+            return;
+        };
+        let workspace = parent_client.workspace;
+        let parent_frame = client_frame_rect(parent_client);
+        let center = Point::new(
+            parent_frame.pos.x + parent_frame.size.w as i32 / 2,
+            parent_frame.pos.y + parent_frame.size.h as i32 / 2,
+        );
+        self.move_client_to_workspace(id, workspace);
+        if let Some(child) = self.clients.get(id) {
+            let desired = Point::new(
+                center.x - child.layout.frame_size.w as i32 / 2,
+                center.y - child.layout.frame_size.h as i32 / 2,
+            );
+            let frame_pos = placement::clamp_to(
+                self.usable_area_at(center),
+                child.layout.frame_size,
+                desired,
+            );
+            if let Some(child) = self.clients.get_mut(id) {
+                child.geometry.pos = Point::new(
+                    frame_pos.x + child.layout.client_offset.x,
+                    frame_pos.y + child.layout.client_offset.y,
+                );
+            }
+            self.reflow_frame(id);
+        }
+        self.raise_client(parent);
+    }
+
+    fn handle_modal_changed(&mut self, window: B::WindowId, modal: bool) {
+        let Some(&id) = self.window_index.get(&window) else {
+            return;
+        };
+        let Some(client) = self.clients.get_mut(id) else {
+            return;
+        };
+        if client.flags.contains(ClientFlags::MODAL) == modal {
+            return;
+        }
+        client.flags.set(ClientFlags::MODAL, modal);
+        self.bump_protocol_state_revision();
+        self.publish_client_net_state(id);
+        if modal {
+            self.focus_client(id);
+        }
     }
 
     fn handle_configure_request(&mut self, window: B::WindowId, requested: Rect) {
@@ -1898,6 +2014,14 @@ impl<B: Backend> WindowManager<B> {
         if !pressed {
             return;
         }
+        let Some(&id) = self.window_index.get(&window) else {
+            self.backend.replay_pointer();
+            return;
+        };
+        if let Some(modal) = self.modal_blocker(id) {
+            self.focus_client(modal);
+            return;
+        }
         // The modifier-drag: a move or a resize begun over a window's
         // own content, reaching windows a titlebar cannot.
         //
@@ -1908,16 +2032,12 @@ impl<B: Backend> WindowManager<B> {
         // move or a resize that exists, and the reason this desktop can
         // honor a client's request to decorate itself without risking a
         // window nobody can shift off the corner it opened in.
-        if let Some(&id) = self.window_index.get(&window) {
-            if self.is_drag_gesture(mods) && matches!(button, MouseButton::Left | MouseButton::Right) {
-                self.focus_client(id);
-                self.begin_modifier_drag(id, local, button);
-                return;
-            }
-        }
-        if let Some(&id) = self.window_index.get(&window) {
+        if self.is_drag_gesture(mods) && matches!(button, MouseButton::Left | MouseButton::Right) {
             self.focus_client(id);
+            self.begin_modifier_drag(id, local, button);
+            return;
         }
+        self.focus_client(id);
         // A click on a client's own content only ever reaches this
         // handler at all via the passive grab `focus_client` maintains
         // on unfocused clients (an already-focused client isn't
@@ -1944,6 +2064,12 @@ impl<B: Backend> WindowManager<B> {
 
         if !pressed {
             self.handle_frame_button_release(id, local, button);
+            return;
+        }
+
+        if let Some(modal) = self.modal_blocker(id) {
+            self.active_button_press = None;
+            self.focus_client(modal);
             return;
         }
 
@@ -2061,9 +2187,7 @@ impl<B: Backend> WindowManager<B> {
         if still_over {
             match active.kind {
                 ButtonKind::Close => {
-                    if let Some(client) = self.clients.get(id) {
-                        self.backend.send_close(client.window);
-                    }
+                    self.close_client(id);
                 }
                 ButtonKind::Miniaturize => self.miniaturize(id),
                 ButtonKind::Maximize => self.toggle_maximize(id, MaximizeDirections::FULL),
@@ -2707,6 +2831,12 @@ impl<B: Backend> WindowManager<B> {
     /// once unmapped, there's nothing left to capture (see
     /// `Backend::capture_window_image`).
     pub fn miniaturize(&mut self, id: ClientId) {
+        for member in self.transient_family(id) {
+            self.miniaturize_one(member);
+        }
+    }
+
+    fn miniaturize_one(&mut self, id: ClientId) {
         let Some(client) = self.clients.get(id) else {
             return;
         };
@@ -2733,6 +2863,12 @@ impl<B: Backend> WindowManager<B> {
     }
 
     pub fn deminiaturize(&mut self, id: ClientId) {
+        for member in self.transient_family(id) {
+            self.deminiaturize_one(member);
+        }
+    }
+
+    fn deminiaturize_one(&mut self, id: ClientId) {
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2755,7 +2891,7 @@ impl<B: Backend> WindowManager<B> {
         // below doesn't matter; it's pure assignment plus the
         // `_NET_WM_DESKTOP` republish pagers need.)
         let current = self.current_workspace;
-        self.move_client_to_workspace(id, current);
+        self.move_one_client_to_workspace(id, current);
         self.show_client_surface(id);
         // Same nudge unshade needs (see there): the client's own pixels
         // weren't retained while unmapped either.
@@ -2805,7 +2941,8 @@ impl<B: Backend> WindowManager<B> {
     /// disagree with the other two entry points about how a window
     /// dies. A no-op for an unknown/stale `id`.
     pub fn close_client(&mut self, id: ClientId) {
-        let Some(client) = self.clients.get(id) else {
+        let target = self.modal_blocker(id).unwrap_or(id);
+        let Some(client) = self.clients.get(target) else {
             return;
         };
         self.backend.send_close(client.window);
@@ -2828,10 +2965,9 @@ impl<B: Backend> WindowManager<B> {
     /// (`WM_DELETE_WINDOW` when supported, force-kill otherwise), so
     /// both paths can never disagree about how a window dies.
     fn handle_close_request(&mut self, window: B::WindowId) {
-        if !self.window_index.contains_key(&window) {
-            return;
+        if let Some(&id) = self.window_index.get(&window) {
+            self.close_client(id);
         }
-        self.backend.send_close(window);
     }
 
     /// `_NET_WM_STATE`: applies `action` to the (up to two) states in
@@ -2859,6 +2995,7 @@ impl<B: Backend> WindowManager<B> {
                 NetState::MaximizedVert => maximize_directions |= MaximizeDirections::VERTICAL,
                 NetState::Pinned => self.apply_pin_action(id, action),
                 NetState::DemandsAttention => self.apply_attention_action(id, action),
+                NetState::Modal => self.apply_modal_action(id, action),
             }
         }
         if !maximize_directions.is_empty() {
@@ -2898,6 +3035,22 @@ impl<B: Backend> WindowManager<B> {
             NetStateAction::Toggle => !currently,
         };
         self.set_urgent(id, target);
+    }
+
+    fn apply_modal_action(&mut self, id: ClientId, action: NetStateAction) {
+        let currently = self
+            .clients
+            .get(id)
+            .is_some_and(|client| client.flags.contains(ClientFlags::MODAL));
+        let target = match action {
+            NetStateAction::Add => true,
+            NetStateAction::Remove => false,
+            NetStateAction::Toggle => !currently,
+        };
+        let Some(window) = self.clients.get(id).map(|client| client.window) else {
+            return;
+        };
+        self.handle_modal_changed(window, target);
     }
 
     fn apply_fullscreen_action(&mut self, id: ClientId, action: NetStateAction) {
@@ -3096,6 +3249,53 @@ impl<B: Backend> WindowManager<B> {
         tracing::debug!(?id, "drag broke the maximized state");
     }
 
+    /// Root followed by its transient descendants, parent before child.
+    /// Both depth and membership are bounded so hostile parent cycles
+    /// cannot turn a lifecycle gesture into an unbounded walk.
+    fn transient_family(&self, root: ClientId) -> Vec<ClientId> {
+        const MAX_TRANSIENT_DEPTH: usize = 8;
+        let mut children_by_parent: HashMap<ClientId, Vec<ClientId>> = HashMap::new();
+        for (id, client) in &self.clients {
+            if let Some(parent) = client.parent {
+                children_by_parent.entry(parent).or_default().push(id);
+            }
+        }
+        let mut family = vec![root];
+        let mut seen = HashSet::from([root]);
+        let mut level = vec![root];
+        for _ in 0..MAX_TRANSIENT_DEPTH {
+            let mut next = Vec::new();
+            for parent in level {
+                for &id in children_by_parent.get(&parent).into_iter().flatten() {
+                    if seen.insert(id) {
+                        family.push(id);
+                        next.push(id);
+                    }
+                }
+            }
+            if next.is_empty() {
+                break;
+            }
+            level = next;
+        }
+        family
+    }
+
+    /// Topmost live modal descendant that blocks `id`, if any.
+    fn modal_blocker(&self, id: ClientId) -> Option<ClientId> {
+        let family = self.transient_family(id);
+        self.managed_order.iter().rev().find_map(|window| {
+            let candidate = self.window_index.get(window).copied()?;
+            (candidate != id
+                && family.contains(&candidate)
+                && self.clients.get(candidate).is_some_and(|client| {
+                    client.lifecycle == Lifecycle::Normal
+                        && client.flags.contains(ClientFlags::MODAL)
+                }))
+            .then_some(candidate)
+        })
+    }
+
     /// Focus `id` and bring it to the front — what a click means, and
     /// what every caller that is not a bare pointer crossing wants.
     fn focus_client(&mut self, id: ClientId) {
@@ -3110,7 +3310,12 @@ impl<B: Backend> WindowManager<B> {
     /// crossed it. Splitting them costs one parameter and leaves every
     /// existing caller bit-identical through [`Self::focus_client`].
     fn focus_client_with(&mut self, id: ClientId, raise: bool) {
-        if self.clients.get(id).is_some_and(|client| client.flags.contains(ClientFlags::NO_FOCUS)) {
+        let id = self.modal_blocker(id).unwrap_or(id);
+        if self
+            .clients
+            .get(id)
+            .is_some_and(|client| client.flags.contains(ClientFlags::NO_FOCUS))
+        {
             tracing::debug!(?id, "window rule refused focus");
             return;
         }
@@ -3197,17 +3402,17 @@ impl<B: Backend> WindowManager<B> {
         let Some(client) = self.clients.get(id) else {
             return;
         };
-        self.backend.publish_net_state(
-            client.window,
-            client.flags.contains(ClientFlags::FULLSCREEN),
-            client.flags.contains(ClientFlags::MAXIMIZED_H),
-            client.flags.contains(ClientFlags::MAXIMIZED_V),
-            client.flags.contains(ClientFlags::SHADED),
+        self.backend.publish_net_state(client.window, NetStateSnapshot {
+            fullscreen: client.flags.contains(ClientFlags::FULLSCREEN),
+            maximized_horizontally: client.flags.contains(ClientFlags::MAXIMIZED_H),
+            maximized_vertically: client.flags.contains(ClientFlags::MAXIMIZED_V),
+            shaded: client.flags.contains(ClientFlags::SHADED),
             // EWMH `_NET_WM_STATE_HIDDEN` means "would be shown by a
             // pager's activate request" — exactly this WM's
             // miniaturized state, and nothing else here qualifies.
-            client.lifecycle == Lifecycle::Miniaturized,
-        );
+            hidden: client.lifecycle == Lifecycle::Miniaturized,
+            modal: client.flags.contains(ClientFlags::MODAL),
+        });
     }
 
     /// Put a managed client on screen, whichever way it is realized.
@@ -3396,7 +3601,7 @@ impl<B: Backend> WindowManager<B> {
     /// reason no raise site in this file names a frame directly any
     /// more.
     fn raise_client(&mut self, id: ClientId) {
-        self.raise_client_and_children(id, 0);
+        self.raise_transient_family(id);
         // `pin` means both sticky and above ordinary windows. Reassert
         // that invariant after every normal raise, including focus.
         let pinned: Vec<ClientId> = self
@@ -3408,7 +3613,7 @@ impl<B: Backend> WindowManager<B> {
             .map(|(other, _)| other)
             .collect();
         for pinned in pinned {
-            self.raise_client_and_children(pinned, 0);
+            self.raise_transient_family(pinned);
         }
     }
 
@@ -3424,43 +3629,21 @@ impl<B: Backend> WindowManager<B> {
     /// to do nothing — the request is sent, and the application is
     /// right to refuse it.
     ///
-    /// Depth-capped rather than cycle-checked: a client is free to
-    /// declare nonsense (a parent chain that loops), and the honest
-    /// response is to stop, not to hang the compositor. Real chains are
-    /// two or three deep — a document, its dialog, that dialog's own
-    /// confirmation.
-    fn raise_client_and_children(&mut self, id: ClientId, depth: usize) {
-        /// Deep enough for any real dialog chain; shallow enough that a
-        /// malicious or confused client cannot cost anything.
-        const MAX_TRANSIENT_DEPTH: usize = 8;
-
-        let Some(client) = self.clients.get(id) else {
-            return;
-        };
-        let window = client.window;
-        match (client.frame, window) {
-            (Some(frame), _) => self.backend.raise(frame),
-            (None, window) => self.backend.raise_frameless(window),
-        }
-        if depth >= MAX_TRANSIENT_DEPTH {
-            return;
-        }
-        // Asked of the backend per raise rather than cached at map
-        // time: a client may parent a dialog after mapping it, and
-        // LibreOffice does — its "Welcome" dialog maps first and is
-        // parented to the document window a moment later.
-        let children: Vec<ClientId> = self
-            .clients
-            .iter()
-            .filter(|(other_id, other)| {
-                *other_id != id
-                    && other.lifecycle == Lifecycle::Normal
-                    && self.backend.window_parent(other.window) == Some(window)
-            })
-            .map(|(other_id, _)| other_id)
-            .collect();
-        for child in children {
-            self.raise_client_and_children(child, depth + 1);
+    /// The stored parent graph is indexed once for the walk, so a deep
+    /// dialog chain does not re-query the backend or rescan every client
+    /// at each level.
+    fn raise_transient_family(&mut self, id: ClientId) {
+        for member in self.transient_family(id) {
+            let Some(client) = self.clients.get(member) else {
+                continue;
+            };
+            if client.lifecycle != Lifecycle::Normal {
+                continue;
+            }
+            match (client.frame, client.window) {
+                (Some(frame), _) => self.backend.raise(frame),
+                (None, window) => self.backend.raise_frameless(window),
+            }
         }
     }
 
@@ -5570,7 +5753,12 @@ mod tests {
         // Parented after mapping, which is what LibreOffice does.
         let parent_id = wm.client_for_window(parent).unwrap();
         wm.backend_mut().set_window_parent(dialog, parent);
-        let dialog_frame = wm.client(wm.client_for_window(dialog).unwrap()).unwrap().frame.unwrap();
+        wm.dispatch(BackendEvent::ParentChanged(dialog));
+        let dialog_frame = wm
+            .client(wm.client_for_window(dialog).unwrap())
+            .unwrap()
+            .frame
+            .unwrap();
         let parent_frame = wm.client(parent_id).unwrap().frame.unwrap();
 
         wm.backend_mut().raised_frames.clear();
@@ -5580,6 +5768,119 @@ mod tests {
         let parent_at = raises.iter().position(|f| *f == parent_frame).expect("the parent was raised");
         let dialog_at = raises.iter().position(|f| *f == dialog_frame).expect("its dialog was raised too");
         assert!(dialog_at > parent_at, "the dialog must be raised after — and so above — its parent: {raises:?}");
+    }
+
+    #[test]
+    fn a_transient_is_centered_on_its_parent_and_follows_its_lifecycle() {
+        let mut backend = FakeBackend::new();
+        let parent = backend.create_window();
+        let dialog = backend.create_window();
+        backend.set_geometry(
+            parent,
+            Rect {
+                pos: Point::new(500, 300),
+                size: Size::new(600, 400),
+            },
+        );
+        backend.set_geometry(
+            dialog,
+            Rect {
+                pos: Point::new(0, 0),
+                size: Size::new(260, 140),
+            },
+        );
+        backend.set_window_parent(dialog, parent);
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(parent));
+        wm.dispatch(BackendEvent::MapRequest(dialog));
+        let parent_id = wm.client_for_window(parent).unwrap();
+        let dialog_id = wm.client_for_window(dialog).unwrap();
+
+        let parent_frame = client_frame_rect(wm.client(parent_id).unwrap());
+        let dialog_frame = client_frame_rect(wm.client(dialog_id).unwrap());
+        assert_eq!(
+            Point::new(
+                dialog_frame.pos.x + dialog_frame.size.w as i32 / 2,
+                dialog_frame.pos.y + dialog_frame.size.h as i32 / 2,
+            ),
+            Point::new(
+                parent_frame.pos.x + parent_frame.size.w as i32 / 2,
+                parent_frame.pos.y + parent_frame.size.h as i32 / 2,
+            ),
+            "a transient belongs visually to the parent, not the pointer's output"
+        );
+
+        wm.move_client_to_workspace(parent_id, 2);
+        assert_eq!(wm.client(parent_id).unwrap().workspace, 2);
+        assert_eq!(wm.client(dialog_id).unwrap().workspace, 2);
+        wm.miniaturize(parent_id);
+        assert_eq!(
+            wm.client(parent_id).unwrap().lifecycle,
+            Lifecycle::Miniaturized
+        );
+        assert_eq!(
+            wm.client(dialog_id).unwrap().lifecycle,
+            Lifecycle::Miniaturized
+        );
+        wm.deminiaturize(parent_id);
+        assert_eq!(wm.client(parent_id).unwrap().lifecycle, Lifecycle::Normal);
+        assert_eq!(wm.client(dialog_id).unwrap().lifecycle, Lifecycle::Normal);
+    }
+
+    #[test]
+    fn a_modal_child_redirects_parent_focus_drag_and_close() {
+        let mut backend = FakeBackend::new();
+        let parent = backend.create_window();
+        let dialog = backend.create_window();
+        backend.set_geometry(
+            parent,
+            Rect {
+                pos: Point::new(100, 100),
+                size: Size::new(500, 350),
+            },
+        );
+        backend.set_geometry(
+            dialog,
+            Rect {
+                pos: Point::new(0, 0),
+                size: Size::new(240, 120),
+            },
+        );
+        backend.set_window_parent(dialog, parent);
+        backend.set_window_modal(dialog, true);
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(parent));
+        wm.dispatch(BackendEvent::MapRequest(dialog));
+        let parent_id = wm.client_for_window(parent).unwrap();
+        let dialog_id = wm.client_for_window(dialog).unwrap();
+        let before = wm.client(parent_id).unwrap().geometry;
+
+        wm.dispatch(BackendEvent::PointerButton {
+            surface: SurfaceRef::Client(parent),
+            local: Point::new(30, 30),
+            button: MouseButton::Left,
+            pressed: true,
+            time_ms: 1,
+            mods: DEFAULT_DRAG_MODIFIER,
+        });
+        wm.dispatch(BackendEvent::PointerMotion {
+            root: Point::new(700, 500),
+            surface_local: None,
+        });
+        assert_eq!(
+            wm.client(parent_id).unwrap().geometry,
+            before,
+            "a modal parent cannot be dragged"
+        );
+        assert!(wm
+            .client(dialog_id)
+            .unwrap()
+            .flags
+            .contains(ClientFlags::FOCUSED));
+
+        wm.close_client(parent_id);
+        assert!(wm.backend().close_requests.contains(&dialog));
+        assert!(!wm.backend().close_requests.contains(&parent));
     }
 
     /// A client is free to declare a parent chain that loops. The
@@ -5596,6 +5897,8 @@ mod tests {
         wm.dispatch(BackendEvent::MapRequest(b));
         wm.backend_mut().set_window_parent(a, b);
         wm.backend_mut().set_window_parent(b, a);
+        wm.dispatch(BackendEvent::ParentChanged(a));
+        wm.dispatch(BackendEvent::ParentChanged(b));
 
         // Terminating at all is the assertion.
         let a_id = wm.client_for_window(a).unwrap();
@@ -7564,7 +7867,7 @@ mod tests {
         assert_eq!(wm.client(id).unwrap().lifecycle, Lifecycle::Miniaturized);
         assert_eq!(
             wm.backend().published_net_states.last(),
-            Some(&(window, false, false, false, false, true)),
+            Some(&(window, false, false, false, false, true, false)),
             "miniaturizing must publish the client as hidden"
         );
 
@@ -7581,7 +7884,7 @@ mod tests {
         );
         assert_eq!(
             wm.backend().published_net_states.last(),
-            Some(&(window, false, false, false, false, false)),
+            Some(&(window, false, false, false, false, false, false)),
             "the restored client must be re-published as not hidden"
         );
     }
@@ -7672,15 +7975,27 @@ mod tests {
             Some(&monitor),
             "the frame must be exactly the monitor rect"
         );
-        assert!(wm.backend().raised_frames.contains(&frame), "entering fullscreen must raise");
-        assert_eq!(wm.backend().published_net_states.last(), Some(&(window, true, false, false, false, false)));
+        assert!(
+            wm.backend().raised_frames.contains(&frame),
+            "entering fullscreen must raise"
+        );
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, true, false, false, false, false, false))
+        );
 
         wm.dispatch(toggle);
 
         let client = wm.client(id).unwrap();
         assert!(!client.flags.contains(ClientFlags::FULLSCREEN));
-        assert_eq!(client.geometry, original_geometry, "a second toggle must restore the prior geometry exactly");
-        assert_eq!(wm.backend().published_net_states.last(), Some(&(window, false, false, false, false, false)));
+        assert_eq!(
+            client.geometry, original_geometry,
+            "a second toggle must restore the prior geometry exactly"
+        );
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, false, false, false, false, false, false))
+        );
     }
 
     /// Mirror of `fullscreen_toggle_covers_the_monitor_and_a_second_
@@ -7711,15 +8026,27 @@ mod tests {
             Some(&monitor),
             "the frame must be exactly the monitor rect"
         );
-        assert!(wm.backend().raised_frames.contains(&frame), "entering fullscreen must raise");
-        assert_eq!(wm.backend().published_net_states.last(), Some(&(window, true, false, false, false, false)));
+        assert!(
+            wm.backend().raised_frames.contains(&frame),
+            "entering fullscreen must raise"
+        );
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, true, false, false, false, false, false))
+        );
 
         wm.toggle_fullscreen(id);
 
         let client = wm.client(id).unwrap();
         assert!(!client.flags.contains(ClientFlags::FULLSCREEN));
-        assert_eq!(client.geometry, original_geometry, "the second toggle must restore the prior geometry exactly");
-        assert_eq!(wm.backend().published_net_states.last(), Some(&(window, false, false, false, false, false)));
+        assert_eq!(
+            client.geometry, original_geometry,
+            "the second toggle must restore the prior geometry exactly"
+        );
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, false, false, false, false, false, false))
+        );
     }
 
     /// The reason `fullscreen_restore` is its own slot and not
@@ -7781,8 +8108,13 @@ mod tests {
         });
 
         let client = wm.client(id).unwrap();
-        assert!(client.flags.contains(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V));
-        assert_eq!(wm.backend().published_net_states.last(), Some(&(window, false, true, true, false, false)));
+        assert!(client
+            .flags
+            .contains(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V));
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, false, true, true, false, false, false))
+        );
 
         wm.dispatch(BackendEvent::NetStateRequested {
             window,
@@ -7794,6 +8126,39 @@ mod tests {
         let client = wm.client(id).unwrap();
         assert!(!client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V));
         assert_eq!(client.geometry, original_geometry, "removing both axes must restore the pre-maximize geometry");
+    }
+
+    #[test]
+    fn net_state_modal_uses_the_same_flag_as_xdg_dialog_modality() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        let id = wm.client_for_window(window).unwrap();
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Add,
+            first: NetState::Modal,
+            second: None,
+        });
+        assert!(wm.client(id).unwrap().flags.contains(ClientFlags::MODAL));
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, false, false, false, false, false, true))
+        );
+
+        wm.dispatch(BackendEvent::NetStateRequested {
+            window,
+            action: NetStateAction::Toggle,
+            first: NetState::Modal,
+            second: None,
+        });
+        assert!(!wm.client(id).unwrap().flags.contains(ClientFlags::MODAL));
+        assert_eq!(
+            wm.backend().published_net_states.last(),
+            Some(&(window, false, false, false, false, false, false))
+        );
     }
 
     #[test]

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -150,6 +150,20 @@ pub enum NetState {
     /// `_NET_WM_STATE_DEMANDS_ATTENTION`, and the ICCCM `WM_HINTS`
     /// urgency bit, which is how most X11 applications actually ask.
     DemandsAttention,
+    Modal,
+}
+
+/// The complete `_NET_WM_STATE`-relevant truth published for one
+/// client. Keeping this as one value prevents a growing row of booleans
+/// from being transposed at backend boundaries.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct NetStateSnapshot {
+    pub fullscreen: bool,
+    pub maximized_horizontally: bool,
+    pub maximized_vertically: bool,
+    pub shaded: bool,
+    pub hidden: bool,
+    pub modal: bool,
 }
 
 /// Coarse EWMH `_NET_WM_WINDOW_TYPE` classification — just enough to
@@ -229,6 +243,14 @@ pub enum BackendEvent<Win, Frame> {
     ///
     /// [`Backend::client_draws_own_chrome`]: crate::Backend::client_draws_own_chrome
     ChromeChanged(Win),
+    /// The toplevel's transient parent changed. Backends emit this for
+    /// `xdg_toplevel.set_parent` and `WM_TRANSIENT_FOR` updates.
+    ParentChanged(Win),
+    /// The toplevel entered or left modal state.
+    ModalChanged {
+        window: Win,
+        modal: bool,
+    },
     /// The client asked the window manager to start moving it — X11's
     /// `_NET_WM_MOVERESIZE`, or a Wayland toplevel's `move` request.
     ///

--- a/crates/wm-theme-api/src/popup.rs
+++ b/crates/wm-theme-api/src/popup.rs
@@ -33,4 +33,11 @@ pub trait PopupHost {
 
     fn grab_pointer(&mut self) -> PopupGrab;
     fn ungrab_pointer(&mut self, grab: PopupGrab);
+
+    /// Gives a modal popup the keyboard for its lifetime. Defaults are
+    /// deliberately inert for lightweight SDK hosts; desktop backends
+    /// override both halves so menu navigation cannot leak into the
+    /// focused client.
+    fn grab_keyboard(&mut self) {}
+    fn ungrab_keyboard(&mut self) {}
 }

--- a/crates/wm-theme/src/cascade.rs
+++ b/crates/wm-theme/src/cascade.rs
@@ -63,6 +63,17 @@ pub enum MenuClick {
     Dismissed,
 }
 
+/// A keyboard gesture understood by an open cascade menu.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MenuKey {
+    Up,
+    Down,
+    Left,
+    Right,
+    Enter,
+    Space,
+}
+
 /// Owns zero or more cascaded popup windows for one open menu session.
 /// `Id` is the host's `PopupHost::PopupId`.
 pub struct CascadeMenu<Id> {
@@ -132,13 +143,83 @@ impl<Id: Copy + Eq + std::fmt::Debug> CascadeMenu<Id> {
             self.levels.push(level);
         }
         self.grab = Some(host.grab_pointer());
+        host.grab_keyboard();
     }
 
     pub fn close<H: PopupHost<PopupId = Id>>(&mut self, host: &mut H) {
         self.truncate(host, 0);
         if let Some(grab) = self.grab.take() {
             host.ungrab_pointer(grab);
+            host.ungrab_keyboard();
         }
+    }
+
+    /// Drives the same highlight and activation path as pointer input.
+    /// The deepest open level owns the selection; entering a submenu
+    /// selects its first row, and moving left restores its parent.
+    pub fn key<H: PopupHost<PopupId = Id>>(
+        &mut self,
+        host: &mut H,
+        theme: &Theme,
+        font_system: &mut cosmic_text::FontSystem,
+        key: MenuKey,
+    ) -> Option<MenuClick> {
+        let level = self.levels.len().checked_sub(1)?;
+        match key {
+            MenuKey::Up | MenuKey::Down => {
+                let len = self.levels[level].items.len();
+                if len == 0 {
+                    return None;
+                }
+                let selected = self.levels[level].highlighted.unwrap_or(0);
+                let next = if key == MenuKey::Down {
+                    (selected + 1) % len
+                } else {
+                    (selected + len - 1) % len
+                };
+                self.levels[level].highlighted = Some(next);
+                self.repaint_level(host, theme, font_system, level);
+                None
+            }
+            MenuKey::Left => {
+                if level > 0 {
+                    self.truncate(host, level);
+                    self.repaint_level(host, theme, font_system, level - 1);
+                }
+                None
+            }
+            MenuKey::Right => self.activate_selection(host, theme, font_system, level, false),
+            MenuKey::Enter | MenuKey::Space => {
+                self.activate_selection(host, theme, font_system, level, true)
+            }
+        }
+    }
+
+    fn activate_selection<H: PopupHost<PopupId = Id>>(
+        &mut self,
+        host: &mut H,
+        theme: &Theme,
+        font_system: &mut cosmic_text::FontSystem,
+        level: usize,
+        allow_action: bool,
+    ) -> Option<MenuClick> {
+        let selected = self.levels.get(level)?.highlighted?;
+        if self.levels[level].items[selected].is_submenu() {
+            self.open_submenu(host, theme, font_system, level, selected);
+            if let Some(child) = self.levels.get_mut(level + 1) {
+                child.highlighted = (!child.items.is_empty()).then_some(0);
+                self.repaint_level(host, theme, font_system, level + 1);
+            }
+            return Some(MenuClick::OpenedSubmenu);
+        }
+        if !allow_action {
+            return None;
+        }
+        let MenuItem::Action { action, .. } = self.levels[level].items[selected] else {
+            return None;
+        };
+        self.close(host);
+        Some(MenuClick::Action(action))
     }
 
     /// If `window` belongs to this menu's chain, resolves a click on it:
@@ -211,6 +292,25 @@ impl<Id: Copy + Eq + std::fmt::Debug> CascadeMenu<Id> {
         }
         let hovered = self.levels[level].item_rects.iter().position(|r| r.contains(local));
         if hovered == self.levels[level].highlighted {
+            let child_belongs_to = self.levels.get(level + 1).and_then(|c| c.opened_from_item);
+            let already_pending = self.pending_submenu.as_ref().is_some_and(|pending| {
+                pending.level == level && pending.item_index == hovered.unwrap_or(usize::MAX)
+            });
+            if !already_pending {
+                self.pending_submenu = match hovered {
+                    Some(i)
+                        if self.levels[level].items[i].is_submenu()
+                            && child_belongs_to != Some(i) =>
+                    {
+                        Some(PendingSubmenu {
+                            level,
+                            item_index: i,
+                            hovered_since: Instant::now(),
+                        })
+                    }
+                    _ => None,
+                };
+            }
             return true;
         }
         self.levels[level].highlighted = hovered;
@@ -288,7 +388,21 @@ impl<Id: Copy + Eq + std::fmt::Debug> CascadeMenu<Id> {
         let geom = Rect { pos: at, size: Size::new(render.buffer.width, render.buffer.height) };
         let window = host.create_popup(geom, self.background)?;
         host.paint_popup(window, &render.buffer);
-        Some(OpenLevel { window, title, items, item_rects: render.item_rects, highlighted: None, geom, opened_from_item })
+        let highlighted = (!items.is_empty()).then_some(0);
+        if highlighted.is_some() {
+            let render =
+                menu::render_menu(theme, font_system, &title, &items, highlighted, closable);
+            host.paint_popup(window, &render.buffer);
+        }
+        Some(OpenLevel {
+            window,
+            title,
+            items,
+            item_rects: render.item_rects,
+            highlighted,
+            geom,
+            opened_from_item,
+        })
     }
 
     /// Opens a submenu cascading from `item_index` in level
@@ -374,6 +488,8 @@ mod tests {
         destroyed_total: u32,
         grabs: u32,
         ungrabs: u32,
+        keyboard_grabs: u32,
+        keyboard_ungrabs: u32,
     }
 
     impl PopupHost for FakeHost {
@@ -401,6 +517,14 @@ mod tests {
 
         fn ungrab_pointer(&mut self, _grab: PopupGrab) {
             self.ungrabs += 1;
+        }
+
+        fn grab_keyboard(&mut self) {
+            self.keyboard_grabs += 1;
+        }
+
+        fn ungrab_keyboard(&mut self) {
+            self.keyboard_ungrabs += 1;
         }
     }
 
@@ -462,6 +586,11 @@ mod tests {
             self.cascade.tick(&mut self.host, &self.theme, &mut self.font_system);
         }
 
+        fn key(&mut self, key: MenuKey) -> Option<MenuClick> {
+            self.cascade
+                .key(&mut self.host, &self.theme, &mut self.font_system, key)
+        }
+
         fn only_open_window(&self) -> u32 {
             assert_eq!(self.host.open.len(), 1, "expected exactly one open popup");
             *self.host.open.iter().next().unwrap()
@@ -469,13 +598,49 @@ mod tests {
     }
 
     #[test]
-    fn opening_creates_exactly_one_popup_and_grabs_the_pointer() {
+    fn opening_creates_exactly_one_popup_and_grabs_input() {
         let mut f = Fixture::new();
         f.open(vec![action("Terminal", 1)]);
 
         assert_eq!(f.host.open.len(), 1);
         assert_eq!(f.host.grabs, 1);
+        assert_eq!(f.host.keyboard_grabs, 1);
         assert!(f.cascade.is_open());
+    }
+
+    #[test]
+    fn keyboard_reaches_actions_and_nested_submenus_without_a_pointer() {
+        let mut f = Fixture::new();
+        f.open(vec![
+            action("First", 1),
+            submenu(
+                "Applications",
+                vec![action("Editor", 20), action("Terminal", 21)],
+            ),
+            action("Exit", 3),
+        ]);
+
+        assert_eq!(f.key(MenuKey::Down), None);
+        assert_eq!(f.key(MenuKey::Right), Some(MenuClick::OpenedSubmenu));
+        assert_eq!(f.host.open.len(), 2);
+        assert_eq!(f.key(MenuKey::Down), None);
+        assert_eq!(f.key(MenuKey::Enter), Some(MenuClick::Action(21)));
+        assert!(!f.cascade.is_open());
+        assert_eq!(f.host.keyboard_ungrabs, 1);
+    }
+
+    #[test]
+    fn left_returns_to_the_parent_and_space_activates_its_selection() {
+        let mut f = Fixture::new();
+        f.open(vec![
+            submenu("Apps", vec![action("Editor", 7)]),
+            action("Exit", 9),
+        ]);
+        assert_eq!(f.key(MenuKey::Enter), Some(MenuClick::OpenedSubmenu));
+        assert_eq!(f.key(MenuKey::Left), None);
+        assert_eq!(f.host.open.len(), 1);
+        assert_eq!(f.key(MenuKey::Down), None);
+        assert_eq!(f.key(MenuKey::Space), Some(MenuClick::Action(9)));
     }
 
     #[test]
@@ -577,7 +742,14 @@ mod tests {
 
         let child = *f.host.open.iter().find(|w| **w != root).expect("submenu popup open");
         let painted = f.host.painted.get(&child).expect("submenu was painted").clone();
-        let expected = menu::render_menu(&f.theme, &mut f.font_system, "Applications", &sub_items, None, false);
+        let expected = menu::render_menu(
+            &f.theme,
+            &mut f.font_system,
+            "Applications",
+            &sub_items,
+            Some(0),
+            false,
+        );
         let wrong = menu::render_menu(&f.theme, &mut f.font_system, "chonkstep", &sub_items, None, false);
         assert_eq!(painted, expected.buffer, "cascade must be titled by its submenu label");
         assert_ne!(painted, wrong.buffer, "the two titles must actually render differently");

--- a/crates/wm-theme/src/raster.rs
+++ b/crates/wm-theme/src/raster.rs
@@ -643,6 +643,15 @@ mod tests {
             buffer.pixels.as_chunks::<4>().0.iter().any(|px| px.as_slice() != first),
             "decoration should not be a single flat color"
         );
+        assert!(
+            buffer
+                .pixels
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .all(|pixel| pixel[3] == 255),
+            "server decorations are an opaque plane and may be submitted as one"
+        );
     }
 
     /// Regression test: the resize-corner grip marks (the visual half

--- a/crates/wm-wayland/protocols/hyprland-global-shortcuts-v1.xml
+++ b/crates/wm-wayland/protocols/hyprland-global-shortcuts-v1.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_global_shortcuts_v1">
+  <copyright>
+    Copyright © 2022 Vaxry
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  </copyright>
+
+  <description summary="registering global shortcuts">
+    This protocol allows a client to register triggerable actions,
+    meant to be global shortcuts.
+  </description>
+
+  <interface name="hyprland_global_shortcuts_manager_v1" version="1">
+    <description summary="manager to register global shortcuts">
+      This object is a manager which offers requests to create global shortcuts.
+    </description>
+
+    <request name="register_shortcut">
+      <description summary="register a shortcut">
+        Register a new global shortcut.
+
+        A global shortcut is anonymous, meaning the app does not know what key(s) trigger it.
+
+        The shortcut's keybinding shall be dealt with by the compositor.
+
+        In the case of a duplicate app_id + id combination, the already_taken protocol error is raised.
+      </description>
+      <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
+      <arg name="id" type="string" summary="a unique id for the shortcut"/>
+      <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
+      <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
+      <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="already_taken" value="0"
+        summary="the app_id + id combination has already been registered."/>
+    </enum>
+  </interface>
+
+  <interface name="hyprland_global_shortcut_v1" version="1">
+    <description summary="a shortcut">
+      This object represents a single shortcut.
+    </description>
+
+    <event name="pressed">
+      <description summary="keystroke pressed">
+        The keystroke was pressed.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="released">
+      <description summary="keystroke released">
+        The keystroke was released.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the shortcut. Can be sent at any time by the client.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -40,7 +40,7 @@ use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgToplevelState;
 use smithay::reexports::wayland_server::backend::protocol::ProtocolError;
 use smithay::reexports::wayland_server::Resource;
-use smithay::utils::{Logical, Rectangle as SmithayRect, Transform};
+use smithay::utils::{Buffer, Logical, Rectangle as SmithayRect, Transform};
 use smithay::wayland::compositor::with_states;
 use smithay::wayland::shell::xdg::{SurfaceCachedState, ToplevelSurface, XdgToplevelSurfaceData};
 use smithay::xwayland::xwm::WmWindowType;
@@ -86,17 +86,22 @@ fn smithay_rect(rect: Rect) -> SmithayRect<i32, Logical> {
 ///
 /// `None` for an empty buffer (nothing to show; callers keep whatever
 /// they had), mirroring `wm-x11`'s blit ignoring empty buffers.
-fn import_buffer(buffer: &DecorationBuffer) -> Option<MemoryRenderBuffer> {
+fn import_buffer(buffer: &DecorationBuffer, opaque: bool) -> Option<MemoryRenderBuffer> {
     if buffer.width == 0 || buffer.height == 0 {
         return None;
     }
+    let opaque_regions = opaque.then(|| {
+        vec![SmithayRect::<i32, Buffer>::from_size(
+            (buffer.width as i32, buffer.height as i32).into(),
+        )]
+    });
     Some(MemoryRenderBuffer::from_slice(
         &buffer.pixels,
         Fourcc::Abgr8888,
         (buffer.width as i32, buffer.height as i32),
         1,
         Transform::Normal,
-        None,
+        opaque_regions,
     ))
 }
 
@@ -254,7 +259,7 @@ impl Backend for WaylandBackend {
 
     fn paint_shell_surface(&mut self, id: Self::ShellId, buffer: &DecorationBuffer) {
         if let Some(shell) = self.shells.get_mut(&id) {
-            if let Some(imported) = import_buffer(buffer) {
+            if let Some(imported) = import_buffer(buffer, false) {
                 shell.buffer = Some(imported);
                 shell.buffer_bytes = buffer.pixels.len();
                 self.damage = true;
@@ -296,7 +301,7 @@ impl Backend for WaylandBackend {
     fn paint_root_image(&mut self, buffer: &DecorationBuffer) {
         // An empty buffer keeps the previous background rather than
         // installing a zero-sized image nothing can render.
-        if let Some(imported) = import_buffer(buffer) {
+        if let Some(imported) = import_buffer(buffer, true) {
             self.root_background = RootBackground::Image(imported);
             self.damage = true;
         }
@@ -666,7 +671,7 @@ impl Backend for WaylandBackend {
 
     fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
         if let Some(record) = self.frames.get_mut(&frame) {
-            if let Some(imported) = import_buffer(buffer) {
+            if let Some(imported) = import_buffer(buffer, true) {
                 record.buffer = Some(imported);
                 self.damage = true;
             }
@@ -1308,19 +1313,21 @@ impl Backend for WaylandBackend {
     ///   no xdg state) and is deliberately unpublished — which is why
     ///   `xewmh.rs` leaves `_NET_WM_STATE_SHADED` out of
     ///   `_NET_SUPPORTED`.
-    fn publish_net_state(
-        &mut self,
-        window: Self::WindowId,
-        fullscreen: bool,
-        max_h: bool,
-        max_v: bool,
-        shaded: bool,
-        hidden: bool,
-    ) {
+    fn publish_net_state(&mut self, window: Self::WindowId, state: wm_core::NetStateSnapshot) {
+        let wm_core::NetStateSnapshot {
+            fullscreen,
+            maximized_horizontally: max_h,
+            maximized_vertically: max_v,
+            shaded,
+            hidden,
+            modal,
+        } = state;
         let _ = shaded;
+        self.ewmh.note_window_modal(window, modal);
         let Some(record) = self.windows.get_mut(&window) else {
             return;
         };
+        record.modal = modal;
         let fullscreen_changed = record.fullscreen != fullscreen;
         record.fullscreen = fullscreen;
         let maximized = both_axes_maximized(max_h, max_v);
@@ -1427,8 +1434,8 @@ impl Backend for WaylandBackend {
         let record = self.windows.get(&window)?;
         match &record.surface {
             ManagedSurface::Xdg(toplevel) => {
-                let parent = toplevel.parent()?;
-                self.window_for_surface(&parent)
+                let _ = toplevel;
+                record.parent
             }
             ManagedSurface::X11(surface) => {
                 let parent = surface.is_transient_for()?;
@@ -1444,6 +1451,10 @@ impl Backend for WaylandBackend {
                     .map(|(id, _)| *id)
             }
         }
+    }
+
+    fn window_is_modal(&self, window: Self::WindowId) -> bool {
+        self.windows.get(&window).is_some_and(|record| record.modal)
     }
 
     fn set_decoration_rules(&mut self, rules: wm_core::DecorationRules) {
@@ -1625,6 +1636,14 @@ impl wm_theme_api::PopupHost for WaylandBackend {
     }
 
     fn ungrab_pointer(&mut self, _grab: wm_theme_api::PopupGrab) {}
+
+    fn grab_keyboard(&mut self) {
+        <Self as Backend>::grab_keyboard(self);
+    }
+
+    fn ungrab_keyboard(&mut self) {
+        <Self as Backend>::ungrab_keyboard(self);
+    }
 }
 
 #[cfg(test)]

--- a/crates/wm-wayland/src/core_protocols.rs
+++ b/crates/wm-wayland/src/core_protocols.rs
@@ -299,7 +299,25 @@ impl InputMethodHandler for Compositor {
     }
 }
 
-impl smithay::wayland::shell::xdg::dialog::XdgDialogHandler for Compositor {}
+impl smithay::wayland::shell::xdg::dialog::XdgDialogHandler for Compositor {
+    fn modal_changed(
+        &mut self,
+        toplevel: smithay::wayland::shell::xdg::ToplevelSurface,
+        is_modal: bool,
+    ) {
+        let backend = self.wm.backend_mut();
+        let Some(window) = backend.window_for_surface(toplevel.wl_surface()) else {
+            return;
+        };
+        if let Some(record) = backend.windows.get_mut(&window) {
+            record.modal = is_modal;
+        }
+        backend.queue(BackendEvent::ModalChanged {
+            window,
+            modal: is_modal,
+        });
+    }
+}
 
 impl smithay::wayland::xdg_toplevel_tag::XdgToplevelTagHandler for Compositor {}
 

--- a/crates/wm-wayland/src/global_shortcuts.rs
+++ b/crates/wm-wayland/src/global_shortcuts.rs
@@ -1,0 +1,195 @@
+//! Hyprland's global-shortcuts protocol, used by
+//! xdg-desktop-portal-hyprland to turn portal registrations into
+//! compositor-owned shortcut objects.
+//!
+//! The client deliberately never learns the key chord. Hyprland config
+//! binds a chord to `global, app:id`; the shell resolves that action
+//! after all ordinary session bindings, and this registry sends the
+//! matching object's pressed/released event. Duplicate registrations
+//! and a bounded per-client population are rejected at registration.
+
+use smithay::reexports::wayland_server::{
+    backend::{ClientId, GlobalId},
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource,
+};
+
+use crate::state::Compositor;
+
+#[allow(non_upper_case_globals, non_camel_case_types, non_snake_case)]
+#[allow(dead_code, unused_imports, unused_variables, unused_unsafe)]
+#[allow(missing_docs, clippy::all)]
+pub(crate) mod bindings {
+    use smithay::reexports::wayland_server;
+    use smithay::reexports::wayland_server::protocol::*;
+
+    pub mod __interfaces {
+        use smithay::reexports::wayland_server::backend as wayland_backend;
+        use smithay::reexports::wayland_server::protocol::__interfaces::*;
+        wayland_scanner::generate_interfaces!("protocols/hyprland-global-shortcuts-v1.xml");
+    }
+    use self::__interfaces::*;
+    wayland_scanner::generate_server_code!("protocols/hyprland-global-shortcuts-v1.xml");
+}
+
+use bindings::hyprland_global_shortcut_v1::{self, HyprlandGlobalShortcutV1};
+use bindings::hyprland_global_shortcuts_manager_v1::{self, HyprlandGlobalShortcutsManagerV1};
+
+const VERSION: u32 = 1;
+const MAX_SHORTCUTS_PER_CLIENT: usize = 128;
+
+pub(crate) struct GlobalShortcuts {
+    _global: GlobalId,
+    entries: Vec<Entry>,
+}
+
+struct Entry {
+    resource: HyprlandGlobalShortcutV1,
+    client: ClientId,
+    app_id: String,
+    id: String,
+}
+
+impl GlobalShortcuts {
+    /// Fires a configured `app:id` target when it is currently
+    /// registered. A miss is intentionally a no-op: configurations may
+    /// outlive applications and a portal session may come and go.
+    pub(crate) fn trigger(
+        &mut self,
+        target: &str,
+        pressed: bool,
+        elapsed: std::time::Duration,
+    ) -> bool {
+        let Some((app_id, id)) = target.split_once(':') else {
+            return false;
+        };
+        self.entries.retain(|entry| entry.resource.is_alive());
+        let Some(entry) = self
+            .entries
+            .iter()
+            .find(|entry| entry.app_id == app_id && entry.id == id)
+        else {
+            return false;
+        };
+        let seconds = elapsed.as_secs();
+        let hi = (seconds >> 32) as u32;
+        let lo = seconds as u32;
+        if pressed {
+            entry.resource.pressed(hi, lo, elapsed.subsec_nanos());
+        } else {
+            entry.resource.released(hi, lo, elapsed.subsec_nanos());
+        }
+        true
+    }
+}
+
+pub(crate) fn init(display_handle: &DisplayHandle) -> GlobalShortcuts {
+    let global = display_handle
+        .create_global::<Compositor, HyprlandGlobalShortcutsManagerV1, ()>(VERSION, ());
+    tracing::info!(version = VERSION, "hyprland-global-shortcuts advertised");
+    GlobalShortcuts {
+        _global: global,
+        entries: Vec::new(),
+    }
+}
+
+impl GlobalDispatch<HyprlandGlobalShortcutsManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<HyprlandGlobalShortcutsManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+}
+
+impl Dispatch<HyprlandGlobalShortcutsManagerV1, ()> for Compositor {
+    fn request(
+        state: &mut Self,
+        client: &Client,
+        resource: &HyprlandGlobalShortcutsManagerV1,
+        request: hyprland_global_shortcuts_manager_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        use hyprland_global_shortcuts_manager_v1::{Error, Request};
+        match request {
+            Request::RegisterShortcut {
+                shortcut,
+                id,
+                app_id,
+                description: _,
+                trigger_description: _,
+            } => {
+                state
+                    .global_shortcuts
+                    .entries
+                    .retain(|entry| entry.resource.is_alive());
+                if state
+                    .global_shortcuts
+                    .entries
+                    .iter()
+                    .any(|entry| entry.app_id == app_id && entry.id == id)
+                {
+                    resource.post_error(
+                        Error::AlreadyTaken,
+                        "this app_id + id is already registered",
+                    );
+                    return;
+                }
+                let client_id = client.id();
+                if state
+                    .global_shortcuts
+                    .entries
+                    .iter()
+                    .filter(|entry| entry.client == client_id)
+                    .count()
+                    >= MAX_SHORTCUTS_PER_CLIENT
+                {
+                    resource.post_error(
+                        Error::AlreadyTaken,
+                        "global shortcut registration ceiling reached",
+                    );
+                    return;
+                }
+                let resource = data_init.init(shortcut, ());
+                state.global_shortcuts.entries.push(Entry {
+                    resource,
+                    client: client_id,
+                    app_id,
+                    id,
+                });
+            }
+            Request::Destroy => {}
+        }
+    }
+}
+
+impl Dispatch<HyprlandGlobalShortcutV1, ()> for Compositor {
+    fn request(
+        _state: &mut Self,
+        _client: &Client,
+        _resource: &HyprlandGlobalShortcutV1,
+        request: hyprland_global_shortcut_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        let _ = request;
+    }
+
+    fn destroyed(
+        state: &mut Self,
+        _client: ClientId,
+        resource: &HyprlandGlobalShortcutV1,
+        _data: &(),
+    ) {
+        state
+            .global_shortcuts
+            .entries
+            .retain(|entry| &entry.resource != resource);
+    }
+}

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -309,8 +309,18 @@ fn build_snapshot(
         devices.mice.push(PointerDevice { name: "chonkstep-pointer".into() });
     }
     Snapshot {
-        monitors, workspaces, windows, focused: focused.map(wm_core::ClientId::as_u64), locked,
-        cursor_position: wm.backend().pointer_position().map(|point| (point.x, point.y)), bindings, devices,
+        monitors,
+        workspaces,
+        windows,
+        focused: focused.map(wm_core::ClientId::as_u64),
+        locked,
+        cursor_position: wm
+            .backend()
+            .pointer_position()
+            .map(|point| (point.x, point.y)),
+        bindings,
+        config_errors: session.config_diagnostics.clone(),
+        devices,
     }
 }
 

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -1447,12 +1447,26 @@ fn on_pointer_move_absolute<I: InputBackend>(state: &mut Compositor, event: I::P
 /// compositor equivalent of the X server keeping the pointer on the
 /// screen.
 fn on_pointer_move_relative<I: InputBackend>(state: &mut Compositor, event: I::PointerMotionEvent) {
+    pointer_move_relative_values(
+        state,
+        event.delta(),
+        event.delta_unaccel(),
+        event.time_msec(),
+    );
+}
+
+fn pointer_move_relative_values(
+    state: &mut Compositor,
+    delta: LogicalPoint<f64, Logical>,
+    delta_unaccel: LogicalPoint<f64, Logical>,
+    time: u32,
+) {
     let relative = RelativeMotionEvent {
-        delta: event.delta(),
-        delta_unaccel: event.delta_unaccel(),
-        utime: event.time_msec() as u64 * 1_000,
+        delta,
+        delta_unaccel,
+        utime: time as u64 * 1_000,
     };
-    let proposed = confine_to_outputs(&state.wm.backend().monitors, state.pointer_location + event.delta());
+    let proposed = confine_to_outputs(&state.wm.backend().monitors, state.pointer_location + delta);
     let mut position = proposed;
     if let Some((pointer, surface)) = state
         .seat
@@ -1484,7 +1498,30 @@ fn on_pointer_move_relative<I: InputBackend>(state: &mut Compositor, event: I::P
             }
         });
     }
-    pointer_moved(state, position, event.time_msec(), Some(relative));
+    pointer_moved(state, position, time, Some(relative));
+}
+
+/// Injects relative virtual-pointer motion through the physical
+/// pointer's confinement, focus, grab, shell and idle path.
+pub(crate) fn inject_pointer_motion(state: &mut Compositor, dx: f64, dy: f64, time: u32) {
+    crate::idle::note_activity(state);
+    let delta = LogicalPoint::<f64, Logical>::from((dx, dy));
+    pointer_move_relative_values(state, delta, delta, time);
+}
+
+/// Injects an already-mapped absolute virtual-pointer coordinate.
+pub(crate) fn inject_pointer_motion_absolute(
+    state: &mut Compositor,
+    position: LogicalPoint<f64, Logical>,
+    time: u32,
+) {
+    crate::idle::note_activity(state);
+    pointer_moved(
+        state,
+        confine_to_outputs(&state.wm.backend().monitors, position),
+        time,
+        None,
+    );
 }
 
 fn surface_focus_at(
@@ -1772,13 +1809,27 @@ fn pointer_moved(
 /// [`DragGrab`] outranks that target while one is held, and the release
 /// that ends the drag is the reason it exists.
 fn on_pointer_button<I: InputBackend>(state: &mut Compositor, event: I::PointerButtonEvent) {
+    pointer_button(
+        state,
+        event.time_msec(),
+        event.button_code(),
+        event.state(),
+        event.button().and_then(wm_button),
+    );
+}
+
+fn pointer_button(
+    state: &mut Compositor,
+    time: u32,
+    button_code: u32,
+    button_state: ButtonState,
+    button: Option<MouseButton>,
+) {
     let serial = SERIAL_COUNTER.next_serial();
-    let time = event.time_msec();
-    let pressed = event.state() == ButtonState::Pressed;
+    let pressed = button_state == ButtonState::Pressed;
     // L/M/R map onto the WM's vocabulary; anything else (side buttons,
     // wheel tilt) is client-only — `wm-x11` swallowed those outright,
     // here they at least still reach a client under the pointer.
-    let button = event.button().and_then(wm_button);
     let Some(pointer) = state.seat.get_pointer() else {
         return;
     };
@@ -1796,7 +1847,15 @@ fn on_pointer_button<I: InputBackend>(state: &mut Compositor, event: I::PointerB
     // queues, no WM events, no implicit-grab bookkeeping to inherit
     // after unlock.
     if state.wm.backend().locked {
-        pointer.button(state, &ButtonEvent { serial, time, button: event.button_code(), state: event.state() });
+        pointer.button(
+            state,
+            &ButtonEvent {
+                serial,
+                time,
+                button: button_code,
+                state: button_state,
+            },
+        );
         pointer.frame(state);
         return;
     }
@@ -1819,12 +1878,12 @@ fn on_pointer_button<I: InputBackend>(state: &mut Compositor, event: I::PointerB
     // means no implicit grab was recorded to route it by.
     if pressed && route.target.is_none() && grab_excludes(state, &hit) {
         crate::focus_grab::dismiss(state);
-        with_input(&seat, |input| input.grab_dismissals.push(event.button_code()));
+        with_input(&seat, |input| input.grab_dismissals.push(button_code));
         return;
     }
     if !pressed {
         let swallowed = with_input(&seat, |input| {
-            let code = event.button_code();
+            let code = button_code;
             let found = input.grab_dismissals.contains(&code);
             input.grab_dismissals.retain(|held| *held != code);
             found
@@ -2023,9 +2082,42 @@ fn on_pointer_button<I: InputBackend>(state: &mut Compositor, event: I::PointerB
     }
 
     if deliver_to_client {
-        pointer.button(state, &ButtonEvent { serial, time, button: event.button_code(), state: event.state() });
+        pointer.button(
+            state,
+            &ButtonEvent {
+                serial,
+                time,
+                button: button_code,
+                state: button_state,
+            },
+        );
         pointer.frame(state);
     }
+}
+
+/// Injects a Linux input button code through the physical button path.
+pub(crate) fn inject_pointer_button(state: &mut Compositor, time: u32, code: u32, pressed: bool) {
+    crate::idle::note_activity(state);
+    if state.wm.backend().locked {
+        sync_pointer_focus(state);
+    }
+    let button = match code {
+        0x110 => Some(MouseButton::Left),
+        0x111 => Some(MouseButton::Right),
+        0x112 => Some(MouseButton::Middle),
+        _ => None,
+    };
+    pointer_button(
+        state,
+        time,
+        code,
+        if pressed {
+            ButtonState::Pressed
+        } else {
+            ButtonState::Released
+        },
+        button,
+    );
 }
 
 /// Gives the keyboard to a clicked layer surface that declared
@@ -2307,7 +2399,28 @@ fn take_whole(residual: &mut f64) -> i32 {
 /// too, so a scroll during a drag reaches the same place on both
 /// backends. Without this, the two would disagree in precisely the
 /// situation nobody tests by hand.
-fn route_shell_scroll<I: InputBackend>(state: &mut Compositor, event: &I::PointerAxisEvent) -> bool {
+fn route_shell_scroll<I: InputBackend>(
+    state: &mut Compositor,
+    event: &I::PointerAxisEvent,
+) -> bool {
+    route_shell_scroll_values(
+        state,
+        event.amount(Axis::Horizontal),
+        event.amount_v120(Axis::Horizontal),
+        event.amount(Axis::Vertical),
+        event.amount_v120(Axis::Vertical),
+        event.source(),
+    )
+}
+
+fn route_shell_scroll_values(
+    state: &mut Compositor,
+    horizontal: Option<f64>,
+    horizontal_v120: Option<f64>,
+    vertical: Option<f64>,
+    vertical_v120: Option<f64>,
+    source: AxisSource,
+) -> bool {
     // Locked: nothing here is the shell's — the axis flows to the seat
     // and lands on the lock surface like every other locked input.
     if state.wm.backend().locked {
@@ -2328,8 +2441,8 @@ fn route_shell_scroll<I: InputBackend>(state: &mut Compositor, event: &I::Pointe
     // client can UNDO that inversion for content-following gestures
     // like pinch-zoom, and a dock tile's ±1 step wants the direction
     // the user configured, not the raw hardware one.
-    let up = -axis_notches(event.amount_v120(Axis::Vertical), event.amount(Axis::Vertical));
-    let right = axis_notches(event.amount_v120(Axis::Horizontal), event.amount(Axis::Horizontal));
+    let up = -axis_notches(vertical_v120, vertical);
+    let right = axis_notches(horizontal_v120, horizontal);
 
     let seat = state.seat.clone();
     let position = state.pointer_location;
@@ -2362,9 +2475,9 @@ fn route_shell_scroll<I: InputBackend>(state: &mut Compositor, event: &I::Pointe
     // was building belongs to that gesture and not to the next one.
     // (Checked before the fold so a stop event carrying zeros cannot
     // resurrect an old fraction.)
-    if event.source() == AxisSource::Finger
-        && event.amount(Axis::Vertical).unwrap_or(0.0) == 0.0
-        && event.amount(Axis::Horizontal).unwrap_or(0.0) == 0.0
+    if source == AxisSource::Finger
+        && vertical.unwrap_or(0.0) == 0.0
+        && horizontal.unwrap_or(0.0) == 0.0
     {
         with_input(&seat, |input| input.scroll.reset());
         return true;
@@ -2388,6 +2501,61 @@ fn route_shell_scroll<I: InputBackend>(state: &mut Compositor, event: &I::Pointe
     };
     backend.shell_scrolls.push_back((owner, local, delta));
     true
+}
+
+/// Injects one virtual-pointer axis frame through shell scroll routing
+/// and the focused client's wl_pointer stream.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn inject_pointer_axis(
+    state: &mut Compositor,
+    time: u32,
+    horizontal: Option<f64>,
+    vertical: Option<f64>,
+    horizontal_discrete: Option<i32>,
+    vertical_discrete: Option<i32>,
+    source: AxisSource,
+    stop_horizontal: bool,
+    stop_vertical: bool,
+) {
+    crate::idle::note_activity(state);
+    if state.wm.backend().locked {
+        sync_pointer_focus(state);
+    }
+    let horizontal_v120 = horizontal_discrete.map(|steps| f64::from(steps) * 120.0);
+    let vertical_v120 = vertical_discrete.map(|steps| f64::from(steps) * 120.0);
+    if route_shell_scroll_values(
+        state,
+        horizontal,
+        horizontal_v120,
+        vertical,
+        vertical_v120,
+        source,
+    ) {
+        return;
+    }
+    let mut frame = AxisFrame::new(time).source(source);
+    if let Some(value) = horizontal {
+        frame = frame.value(Axis::Horizontal, value);
+    }
+    if let Some(value) = vertical {
+        frame = frame.value(Axis::Vertical, value);
+    }
+    if let Some(steps) = horizontal_discrete {
+        frame = frame.v120(Axis::Horizontal, steps.saturating_mul(120));
+    }
+    if let Some(steps) = vertical_discrete {
+        frame = frame.v120(Axis::Vertical, steps.saturating_mul(120));
+    }
+    if stop_horizontal {
+        frame = frame.stop(Axis::Horizontal);
+    }
+    if stop_vertical {
+        frame = frame.stop(Axis::Vertical);
+    }
+    if let Some(pointer) = state.seat.get_pointer() {
+        pointer.axis(state, frame);
+        pointer.frame(state);
+    }
 }
 
 // -- hit-testing ---------------------------------------------------------

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -40,6 +40,7 @@ mod hyprland_ipc;
 // Session backend only; see its module docs for the DRM mechanism and
 // the honest nested answer.
 mod gamma;
+mod global_shortcuts;
 mod idle;
 mod image_capture;
 mod inhibit_bus;
@@ -57,6 +58,7 @@ mod test_door;
 mod toplevel_mapping;
 // virtual-keyboard-v1: `wtype` and everything Omarchy builds on it.
 mod virtual_keyboard;
+mod virtual_pointer;
 mod xdg;
 mod xewmh;
 mod xwayland;

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -390,6 +390,12 @@ pub(crate) struct WindowRecord {
     /// layers by its own [`StackEntry::Window`] slot like any framed
     /// neighbour.
     pub window_type: WindowType,
+    /// Resolved managed parent. XDG updates this on commits and X11 on
+    /// `WM_TRANSIENT_FOR` property changes, allowing the backend query
+    /// to stay cheap and stable across lifecycle transitions.
+    pub parent: Option<WlWindowId>,
+    /// Protocol-declared modal state (`xdg_dialog_v1` or EWMH modal).
+    pub modal: bool,
     /// Most recent preview of this window's contents, refreshed by
     /// [`crate::capture`] while rendering and served back through
     /// `Backend::capture_window_image`. `None` until the first
@@ -473,6 +479,8 @@ impl WindowRecord {
             title: None,
             app_id: None,
             window_type: WindowType::Normal,
+            parent: None,
+            modal: false,
             snapshot: None,
             snapshot_dirty: true,
             snapshot_attempted_at: None,
@@ -1930,6 +1938,10 @@ pub struct Compositor {
     /// XWayland's display number, mirrored into `DISPLAY` so children
     /// the shell spawns find it.
     pub xdisplay: Option<u32>,
+    /// A crashed, previously-ready XWayland gets one clean restart.
+    /// Consumed before spawning so a repeatedly failing server cannot
+    /// become a tight supervisor loop inside the compositor.
+    xwayland_restart_available: bool,
     /// The XSETTINGS manager publishing this session's DPI, scaling
     /// factor and cursor size to every X client on the XWayland
     /// display, once XWayland is up.
@@ -2007,6 +2019,8 @@ pub struct Compositor {
     /// disables the feature and the popouts never close. See
     /// `focus_grab.rs`.
     pub(crate) focus_grab: crate::focus_grab::FocusGrab,
+    /// Registered portal shortcut objects keyed by `app_id:id`.
+    pub(crate) global_shortcuts: crate::global_shortcuts::GlobalShortcuts,
     /// ext-idle-notify + idle-inhibit: the timers `swayidle` runs on,
     /// reset from the input path — see `idle.rs`.
     pub(crate) idle: crate::idle::Idle,
@@ -2017,6 +2031,9 @@ pub struct Compositor {
     /// there is nothing here to reconcile per pass. Same shape as
     /// `Idle::_inhibit`. See `virtual_keyboard.rs`.
     pub(crate) _virtual_keyboard: smithay::wayland::virtual_keyboard::VirtualKeyboardManagerState,
+    /// wlr virtual pointer v2, lowering synthetic motion/buttons/axis
+    /// through the same funnel as physical input.
+    pub(crate) _virtual_pointer: crate::virtual_pointer::VirtualPointerState,
 
     /// Latest pointer position in compositor space, maintained by
     /// `input.rs` — the renderer draws the cursor here, and hit-tests
@@ -2117,10 +2134,25 @@ impl Compositor {
                     if let Some(motion) = pending_motion.take() {
                         self.dispatch_motion(motion);
                     }
-                    if let chonk_shell::shell::KeyResolution::Action(action) = resolution {
-                        let outcome = self.shell.run_action(&mut self.wm, &action);
-                        self.note_outcome(outcome);
-                    }
+                    let outcome = match resolution {
+                        chonk_shell::shell::KeyResolution::Action(
+                            wm_config::Action::GlobalShortcut(target),
+                        ) => {
+                            self.global_shortcuts
+                                .trigger(&target, true, self.start_time.elapsed());
+                            chonk_shell::shell::ShellOutcome::Continue
+                        }
+                        chonk_shell::shell::KeyResolution::Action(action) => {
+                            self.shell.run_action(&mut self.wm, &action)
+                        }
+                        chonk_shell::shell::KeyResolution::Menu(key) => {
+                            self.shell.run_menu_key(&mut self.wm, key)
+                        }
+                        chonk_shell::shell::KeyResolution::Consumed => {
+                            chonk_shell::shell::ShellOutcome::Continue
+                        }
+                    };
+                    self.note_outcome(outcome);
                     continue;
                 }
             }
@@ -2129,7 +2161,17 @@ impl Compositor {
                     if let Some(motion) = pending_motion.take() {
                         self.dispatch_motion(motion);
                     }
-                    let outcome = self.shell.run_action(&mut self.wm, &action);
+                    let outcome = match action {
+                        wm_config::Action::GlobalShortcut(target) => {
+                            self.global_shortcuts.trigger(
+                                &target,
+                                false,
+                                self.start_time.elapsed(),
+                            );
+                            chonk_shell::shell::ShellOutcome::Continue
+                        }
+                        action => self.shell.run_action(&mut self.wm, &action),
+                    };
                     self.note_outcome(outcome);
                     continue;
                 }
@@ -3240,6 +3282,95 @@ fn recovery_locker_argv<'a>(
     Some((program, parts.collect()))
 }
 
+fn register_xwayland_source(
+    display_handle: &DisplayHandle,
+    loop_handle: &LoopHandle<'static, Compositor>,
+) -> Result<(), String> {
+    let (xwayland, xwayland_client) = match XWayland::spawn(
+        display_handle,
+        None,
+        std::iter::empty::<(String, String)>(),
+        true,
+        Stdio::null(),
+        Stdio::null(),
+        |_| (),
+    ) {
+        Ok(pair) => pair,
+        Err(error) => {
+            tracing::warn!(?error, "could not spawn XWayland; X11 apps unavailable");
+            return Ok(());
+        }
+    };
+    loop_handle
+        .insert_source(xwayland, move |event, _, comp| match event {
+            XWaylandEvent::Ready {
+                x11_socket,
+                display_number,
+            } => {
+                match X11Wm::start_wm(
+                    comp.loop_handle.clone(),
+                    x11_socket,
+                    xwayland_client.clone(),
+                ) {
+                    Ok(xwm) => {
+                        comp.xwm = Some(xwm);
+                        comp.xdisplay = Some(display_number);
+                        std::env::set_var("DISPLAY", format!(":{display_number}"));
+                        tracing::info!(display = display_number, "XWayland ready");
+                        comp.start_xsettings(display_number);
+                        crate::xewmh::start(comp, display_number);
+                    }
+                    Err(error) => {
+                        tracing::error!(
+                            ?error,
+                            "failed to attach the X11 window manager to XWayland"
+                        );
+                    }
+                }
+            }
+            XWaylandEvent::Error => comp.handle_xwayland_loss("startup failure"),
+        })
+        .map(|_| ())
+        .map_err(|error| format!("failed to register the XWayland event source: {error}"))
+}
+
+impl Compositor {
+    /// Retires every piece of state owned by one XWayland generation.
+    /// Called by the startup source and, critically, by
+    /// `XwmHandler::disconnected` after a running X server dies.
+    pub(crate) fn handle_xwayland_loss(&mut self, reason: &'static str) {
+        let was_ready = self.xdisplay.is_some() || self.xwm.is_some();
+        tracing::warn!(reason, "XWayland exited; X11 apps temporarily unavailable");
+        self.xwm = None;
+        self.xdisplay = None;
+        self.xsettings = None;
+        self.xewmh = None;
+        std::env::remove_var("DISPLAY");
+
+        let backend = self.wm.backend_mut();
+        let orphaned: Vec<WlWindowId> = backend
+            .windows
+            .iter()
+            .filter(|(_, record)| matches!(record.surface, ManagedSurface::X11(_)))
+            .map(|(id, _)| *id)
+            .collect();
+        for id in orphaned {
+            backend.forget_window(id);
+            backend.queue(BackendEvent::Destroyed(id));
+        }
+        backend.mark_damaged();
+
+        if was_ready && std::mem::take(&mut self.xwayland_restart_available) {
+            tracing::info!("restarting XWayland once after disconnect");
+            let display_handle = self.display_handle.clone();
+            let loop_handle = self.loop_handle.clone();
+            if let Err(error) = register_xwayland_source(&display_handle, &loop_handle) {
+                tracing::warn!(%error, "could not register the XWayland restart");
+            }
+        }
+    }
+}
+
 pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> {
     // Consume the supervisor's one-shot marker before bringing up any
     // display machinery. A recovery with no resolved locker must fail
@@ -3502,6 +3633,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // and finding it absent is what makes every popout in that shell
     // impossible to dismiss by clicking away. See `focus_grab.rs`.
     let focus_grab = crate::focus_grab::init(&display_handle);
+    let global_shortcuts = crate::global_shortcuts::init(&display_handle);
     // The ecosystem protocols, under the same timing rule. Layer-shell
     // is what fuzzel/mako/waybar look for the moment they connect;
     // session-lock is unfiltered (any client may lock — swaylock is
@@ -3529,6 +3661,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // what guarantees that, and `virtual_keyboard::init` says so out
     // loud if it ever stops being true.
     let virtual_keyboard = crate::virtual_keyboard::init(&display_handle, &seat);
+    let virtual_pointer = crate::virtual_pointer::init(&display_handle);
 
     // The listening socket clients connect to, plus the display's own
     // fd so wayland-server processes client requests — both plain
@@ -3698,84 +3831,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // reports ready. Failure to start is a degraded session — X11
     // apps unavailable — not a dead one, so it logs instead of
     // erroring out.
-    match XWayland::spawn(
-        &display_handle,
-        None,
-        std::iter::empty::<(String, String)>(),
-        true,
-        Stdio::null(),
-        Stdio::null(),
-        |_| (),
-    ) {
-        Ok((xwayland, xwayland_client)) => {
-            loop_handle
-                .insert_source(xwayland, move |event, _, comp| match event {
-                    XWaylandEvent::Ready { x11_socket, display_number } => {
-                        match X11Wm::start_wm(comp.loop_handle.clone(), x11_socket, xwayland_client.clone()) {
-                            Ok(xwm) => {
-                                comp.xwm = Some(xwm);
-                                comp.xdisplay = Some(display_number);
-                                // Children the shell spawns (terminals,
-                                // X11 apps) inherit this, same as the
-                                // X11 session's DISPLAY inheritance.
-                                std::env::set_var("DISPLAY", format!(":{display_number}"));
-                                tracing::info!(display = display_number, "XWayland ready");
-                                // The earliest moment an X selection can
-                                // be taken, and the only one worth
-                                // taking it at: there is no display to
-                                // own before this, and every X client
-                                // that will ever run in this session
-                                // connects after it.
-                                comp.start_xsettings(display_number);
-                                // And the EWMH publisher, on its own
-                                // connection for the same two-readers
-                                // reason `start_xsettings` gives.
-                                crate::xewmh::start(comp, display_number);
-                            }
-                            Err(error) => {
-                                tracing::error!(?error, "failed to attach the X11 window manager to XWayland");
-                            }
-                        }
-                    }
-                    XWaylandEvent::Error => {
-                        tracing::warn!("XWayland exited or failed to start; X11 apps unavailable");
-                        // Every X11 window died with it. Nothing else
-                        // will ever report those surfaces destroyed -
-                        // the destroy notifications came through the
-                        // X11 WM connection that just went away - so
-                        // without this their ledger entries, frames and
-                        // stacking slots outlive them: chrome painted
-                        // around windows that no longer exist, and
-                        // clicks routed into them. Tearing them down
-                        // through the normal Destroyed path lets
-                        // `wm-core` retract focus and drop decorations
-                        // exactly as it would for one window closing.
-                        comp.xwm = None;
-                        comp.xdisplay = None;
-                        // The EWMH connection pointed at the display
-                        // that just died; its next write would only
-                        // fail noisily.
-                        comp.xewmh = None;
-                        let backend = comp.wm.backend_mut();
-                        let orphaned: Vec<WlWindowId> = backend
-                            .windows
-                            .iter()
-                            .filter(|(_, record)| matches!(record.surface, ManagedSurface::X11(_)))
-                            .map(|(id, _)| *id)
-                            .collect();
-                        for id in orphaned {
-                            backend.forget_window(id);
-                            backend.queue(BackendEvent::Destroyed(id));
-                        }
-                        backend.mark_damaged();
-                    }
-                })
-                .map_err(|error| format!("failed to register the XWayland event source: {error}"))?;
-        }
-        Err(error) => {
-            tracing::warn!(?error, "could not spawn XWayland; X11 apps unavailable");
-        }
-    }
+    register_xwayland_source(&display_handle, &loop_handle)?;
 
     let mut comp = Compositor {
         hyprland_ipc,
@@ -3814,6 +3870,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         outputs,
         xwm: None,
         xdisplay: None,
+        xwayland_restart_available: true,
         xsettings: None,
         xewmh: None,
         ui_scale: scale,
@@ -3830,8 +3887,10 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         layer_shell,
         session_lock,
         focus_grab,
+        global_shortcuts,
         idle,
         _virtual_keyboard: virtual_keyboard,
+        _virtual_pointer: virtual_pointer,
         pointer_location: (0.0, 0.0).into(),
         cursor_status: CursorImageStatus::default_named(),
         cursors: CursorSet::build(scale),

--- a/crates/wm-wayland/src/virtual_pointer.rs
+++ b/crates/wm-wayland/src/virtual_pointer.rs
@@ -1,0 +1,395 @@
+//! `wlr-virtual-pointer-unstable-v1`: pointer injection for assistive
+//! devices, automation, and the input half of remote-control stacks.
+//!
+//! Requests are accumulated until the protocol's `frame`, then lowered
+//! through `crate::input`'s physical-pointer helpers. That shared path
+//! is intentional: virtual motion obeys confinement and active grabs,
+//! clicks drive shell and wm-core hit-testing, scroll reaches dock
+//! widgets, and every event counts as idle activity. A synthetic
+//! pointer is user activity when it represents an eye tracker or switch
+//! device; a runaway client can therefore keep the session awake, just
+//! as a virtual keyboard can.
+
+use std::sync::Mutex;
+
+use smithay::backend::input::AxisSource as BackendAxisSource;
+use smithay::output::Output;
+use smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_manager_v1::{
+    self, ZwlrVirtualPointerManagerV1,
+};
+use smithay::reexports::wayland_protocols_wlr::virtual_pointer::v1::server::zwlr_virtual_pointer_v1::{
+    self, ZwlrVirtualPointerV1,
+};
+use smithay::reexports::wayland_server::protocol::{wl_output::WlOutput, wl_pointer};
+use smithay::reexports::wayland_server::{
+    backend::GlobalId, Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, WEnum,
+};
+use smithay::utils::{Logical, Point as LogicalPoint};
+
+use crate::state::Compositor;
+
+const VERSION: u32 = 2;
+
+/// Held for the global's lifetime. The policy seam deliberately has
+/// the same shape as virtual-keyboard's; every client on this socket is
+/// currently a full user-session peer, and this is where a future
+/// security-context restriction belongs.
+pub(crate) struct VirtualPointerState {
+    _global: GlobalId,
+}
+
+#[derive(Default)]
+struct Pending {
+    events: Vec<PointerEvent>,
+    horizontal: Option<f64>,
+    vertical: Option<f64>,
+    horizontal_discrete: Option<i32>,
+    vertical_discrete: Option<i32>,
+    stop_horizontal: bool,
+    stop_vertical: bool,
+    axis_time: u32,
+    axis_source: Option<BackendAxisSource>,
+}
+
+enum PointerEvent {
+    Motion {
+        time: u32,
+        dx: f64,
+        dy: f64,
+    },
+    MotionAbsolute {
+        time: u32,
+        x: u32,
+        y: u32,
+        x_extent: u32,
+        y_extent: u32,
+    },
+    Button {
+        time: u32,
+        button: u32,
+        pressed: bool,
+    },
+}
+
+struct PointerData {
+    output: Option<WlOutput>,
+    pending: Mutex<Pending>,
+}
+
+pub(crate) fn init(display_handle: &DisplayHandle) -> VirtualPointerState {
+    let global =
+        display_handle.create_global::<Compositor, ZwlrVirtualPointerManagerV1, ()>(VERSION, ());
+    tracing::info!(version = VERSION, "virtual-pointer advertised");
+    VirtualPointerState { _global: global }
+}
+
+fn may_create_virtual_pointer(_client: &Client) -> bool {
+    true
+}
+
+fn map_absolute_axis(value: u32, extent: u32, size: u32) -> f64 {
+    if extent == 0 || size <= 1 {
+        0.0
+    } else {
+        (f64::from(value.min(extent)) / f64::from(extent)) * f64::from(size - 1)
+    }
+}
+
+fn absolute_position(
+    comp: &Compositor,
+    output: Option<&WlOutput>,
+    x: u32,
+    y: u32,
+    x_extent: u32,
+    y_extent: u32,
+) -> LogicalPoint<f64, Logical> {
+    let output = output.and_then(Output::from_resource);
+    let (origin_x, origin_y, width, height) = output
+        .as_ref()
+        .and_then(|wanted| {
+            comp.outputs
+                .iter()
+                .find(|entry| &entry.output == wanted)
+                .map(|entry| {
+                    (
+                        entry.position.x,
+                        entry.position.y,
+                        entry.size.w,
+                        entry.size.h,
+                    )
+                })
+        })
+        .unwrap_or((
+            0,
+            0,
+            comp.wm.backend().output_size.w,
+            comp.wm.backend().output_size.h,
+        ));
+    (
+        f64::from(origin_x) + map_absolute_axis(x, x_extent, width),
+        f64::from(origin_y) + map_absolute_axis(y, y_extent, height),
+    )
+        .into()
+}
+
+fn flush(comp: &mut Compositor, data: &PointerData) {
+    let pending = std::mem::take(&mut *data.pending.lock().unwrap());
+    for event in pending.events {
+        match event {
+            PointerEvent::Motion { time, dx, dy } => {
+                crate::input::inject_pointer_motion(comp, dx, dy, time)
+            }
+            PointerEvent::MotionAbsolute {
+                time,
+                x,
+                y,
+                x_extent,
+                y_extent,
+            } => {
+                let position =
+                    absolute_position(comp, data.output.as_ref(), x, y, x_extent, y_extent);
+                crate::input::inject_pointer_motion_absolute(comp, position, time);
+            }
+            PointerEvent::Button {
+                time,
+                button,
+                pressed,
+            } => crate::input::inject_pointer_button(comp, time, button, pressed),
+        }
+    }
+    let has_axis = pending.horizontal.is_some()
+        || pending.vertical.is_some()
+        || pending.horizontal_discrete.is_some()
+        || pending.vertical_discrete.is_some()
+        || pending.stop_horizontal
+        || pending.stop_vertical;
+    if has_axis {
+        crate::input::inject_pointer_axis(
+            comp,
+            pending.axis_time,
+            pending.horizontal,
+            pending.vertical,
+            pending.horizontal_discrete,
+            pending.vertical_discrete,
+            pending.axis_source.unwrap_or(BackendAxisSource::Wheel),
+            pending.stop_horizontal,
+            pending.stop_vertical,
+        );
+    }
+}
+
+impl GlobalDispatch<ZwlrVirtualPointerManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwlrVirtualPointerManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        may_create_virtual_pointer(&client)
+    }
+}
+
+impl Dispatch<ZwlrVirtualPointerManagerV1, ()> for Compositor {
+    fn request(
+        _state: &mut Self,
+        client: &Client,
+        _resource: &ZwlrVirtualPointerManagerV1,
+        request: zwlr_virtual_pointer_manager_v1::Request,
+        _data: &(),
+        _display: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        use zwlr_virtual_pointer_manager_v1::Request;
+        match request {
+            Request::CreateVirtualPointer { seat: _, id } => {
+                if may_create_virtual_pointer(client) {
+                    data_init.init(
+                        id,
+                        PointerData {
+                            output: None,
+                            pending: Mutex::new(Pending::default()),
+                        },
+                    );
+                }
+            }
+            Request::CreateVirtualPointerWithOutput {
+                seat: _,
+                output,
+                id,
+            } => {
+                if may_create_virtual_pointer(client) {
+                    data_init.init(
+                        id,
+                        PointerData {
+                            output,
+                            pending: Mutex::new(Pending::default()),
+                        },
+                    );
+                }
+            }
+            Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+impl Dispatch<ZwlrVirtualPointerV1, PointerData> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ZwlrVirtualPointerV1,
+        request: zwlr_virtual_pointer_v1::Request,
+        data: &PointerData,
+        _display: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        use zwlr_virtual_pointer_v1::{Error, Request};
+        let mut pending = data.pending.lock().unwrap();
+        match request {
+            Request::Motion { time, dx, dy } => {
+                pending.events.push(PointerEvent::Motion { time, dx, dy })
+            }
+            Request::MotionAbsolute {
+                time,
+                x,
+                y,
+                x_extent,
+                y_extent,
+            } => pending.events.push(PointerEvent::MotionAbsolute {
+                time,
+                x,
+                y,
+                x_extent,
+                y_extent,
+            }),
+            Request::Button {
+                time,
+                button,
+                state,
+            } => match state {
+                WEnum::Value(wl_pointer::ButtonState::Pressed) => {
+                    pending.events.push(PointerEvent::Button {
+                        time,
+                        button,
+                        pressed: true,
+                    })
+                }
+                WEnum::Value(wl_pointer::ButtonState::Released) => {
+                    pending.events.push(PointerEvent::Button {
+                        time,
+                        button,
+                        pressed: false,
+                    })
+                }
+                WEnum::Unknown(raw) => {
+                    tracing::warn!(raw, "ignoring virtual-pointer button with unknown state")
+                }
+                _ => {}
+            },
+            Request::Axis { time, axis, value } => {
+                pending.axis_time = time;
+                match axis {
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => {
+                        pending.horizontal = Some(value)
+                    }
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => {
+                        pending.vertical = Some(value)
+                    }
+                    WEnum::Unknown(_) => resource.post_error(Error::InvalidAxis, "invalid axis"),
+                    _ => {}
+                }
+            }
+            Request::AxisDiscrete {
+                time,
+                axis,
+                value,
+                discrete,
+            } => {
+                pending.axis_time = time;
+                match axis {
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => {
+                        pending.horizontal = Some(value);
+                        pending.horizontal_discrete = Some(discrete);
+                    }
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => {
+                        pending.vertical = Some(value);
+                        pending.vertical_discrete = Some(discrete);
+                    }
+                    WEnum::Unknown(_) => resource.post_error(Error::InvalidAxis, "invalid axis"),
+                    _ => {}
+                }
+            }
+            Request::AxisSource { axis_source } => {
+                pending.axis_source = match axis_source {
+                    WEnum::Value(wl_pointer::AxisSource::Wheel) => Some(BackendAxisSource::Wheel),
+                    WEnum::Value(wl_pointer::AxisSource::Finger) => Some(BackendAxisSource::Finger),
+                    WEnum::Value(wl_pointer::AxisSource::Continuous) => {
+                        Some(BackendAxisSource::Continuous)
+                    }
+                    WEnum::Value(wl_pointer::AxisSource::WheelTilt) => {
+                        Some(BackendAxisSource::WheelTilt)
+                    }
+                    WEnum::Unknown(_) => {
+                        resource.post_error(Error::InvalidAxisSource, "invalid axis source");
+                        None
+                    }
+                    _ => None,
+                };
+            }
+            Request::AxisStop { time, axis } => {
+                pending.axis_time = time;
+                match axis {
+                    WEnum::Value(wl_pointer::Axis::HorizontalScroll) => {
+                        pending.stop_horizontal = true
+                    }
+                    WEnum::Value(wl_pointer::Axis::VerticalScroll) => pending.stop_vertical = true,
+                    WEnum::Unknown(_) => resource.post_error(Error::InvalidAxis, "invalid axis"),
+                    _ => {}
+                }
+            }
+            Request::Frame => {
+                drop(pending);
+                flush(state, data);
+            }
+            Request::Destroy => {}
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use smithay::reexports::wayland_server::Display;
+
+    #[test]
+    fn absolute_coordinates_cover_the_target_and_clamp_untrusted_values() {
+        assert_eq!(map_absolute_axis(0, 1000, 1920), 0.0);
+        assert_eq!(map_absolute_axis(1000, 1000, 1920), 1919.0);
+        assert_eq!(map_absolute_axis(5000, 1000, 1920), 1919.0);
+        assert_eq!(map_absolute_axis(500, 1000, 1), 0.0);
+        assert_eq!(map_absolute_axis(500, 0, 1920), 0.0);
+    }
+
+    #[test]
+    fn every_session_peer_may_create_a_virtual_pointer() {
+        let display = Display::<Compositor>::new().expect("wayland display");
+        let mut display_handle = display.handle();
+        let (compositor_end, _client_end) =
+            std::os::unix::net::UnixStream::pair().expect("socketpair");
+        let client = display_handle
+            .insert_client(
+                compositor_end,
+                std::sync::Arc::new(crate::state::ClientState::default()),
+            )
+            .expect("admit a client");
+
+        assert!(may_create_virtual_pointer(&client));
+    }
+}

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -992,6 +992,19 @@ impl Compositor {
             with_renderer_surface_state(&root, |state| state.buffer().is_some()).unwrap_or(false);
         let was_mapped = mapped_marker(&root);
         let backend = self.wm.backend_mut();
+        let parent = toplevel
+            .parent()
+            .and_then(|surface| backend.window_for_surface(&surface));
+        let parent_changed = backend
+            .windows
+            .get(&id)
+            .is_some_and(|record| record.parent != parent);
+        if parent_changed {
+            if let Some(record) = backend.windows.get_mut(&id) {
+                record.parent = parent;
+            }
+            backend.queue(WmEvent::ParentChanged(id));
+        }
         // The factor everything below measures by: the client's own
         // committed statement (viewport ratio or integer buffer scale),
         // corrected for the integral-fallback case on this window's

--- a/crates/wm-wayland/src/xewmh.rs
+++ b/crates/wm-wayland/src/xewmh.rs
@@ -199,6 +199,11 @@ pub(crate) struct EwmhLedger {
     /// X connection publishes the protocol state without destroying
     /// the restorable window.
     window_iconic: HashMap<WlWindowId, bool>,
+    /// Pending `_NET_WM_STATE_MODAL` truth for XWayland windows. Smithay
+    /// exposes the initial bit but has no public modal setter, so the
+    /// auxiliary EWMH connection changes only this atom while preserving
+    /// the rest of the state property.
+    window_modal: HashMap<WlWindowId, bool>,
 }
 
 impl EwmhLedger {
@@ -287,6 +292,10 @@ impl EwmhLedger {
         self.window_iconic.insert(window, iconic);
     }
 
+    pub(crate) fn note_window_modal(&mut self, window: WlWindowId, modal: bool) {
+        self.window_modal.insert(window, modal);
+    }
+
     /// Re-flags the client list without new content — the fix for the
     /// one interleaving with smithay's XWM that does NOT converge on
     /// its own. Smithay APPENDs every freshly mapped window to
@@ -310,6 +319,7 @@ impl EwmhLedger {
         self.window_desktops.remove(&window);
         self.frame_extents.remove(&window);
         self.window_iconic.remove(&window);
+        self.window_modal.remove(&window);
     }
 
     /// Re-dirties every root property, so a connection arriving late
@@ -343,11 +353,12 @@ struct WriteAtoms {
     net_wm_desktop: Atom,
     net_workarea: Atom,
     net_frame_extents: Atom,
+    net_wm_state: Atom,
+    net_wm_state_modal: Atom,
     wm_state: Atom,
     /// Inbound only — this connection never writes these. See
     /// [`drain_inbound`].
     net_close_window: Atom,
-    net_wm_state: Atom,
     net_wm_state_above: Atom,
     net_wm_state_sticky: Atom,
     net_wm_state_demands_attention: Atom,
@@ -366,10 +377,17 @@ impl WriteAtoms {
             net_current_desktop: conn.intern_atom(false, b"_NET_CURRENT_DESKTOP")?.reply()?.atom,
             net_wm_desktop: conn.intern_atom(false, b"_NET_WM_DESKTOP")?.reply()?.atom,
             net_workarea: conn.intern_atom(false, b"_NET_WORKAREA")?.reply()?.atom,
-            net_frame_extents: conn.intern_atom(false, b"_NET_FRAME_EXTENTS")?.reply()?.atom,
+            net_frame_extents: conn
+                .intern_atom(false, b"_NET_FRAME_EXTENTS")?
+                .reply()?
+                .atom,
+            net_wm_state: conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom,
+            net_wm_state_modal: conn
+                .intern_atom(false, b"_NET_WM_STATE_MODAL")?
+                .reply()?
+                .atom,
             wm_state: conn.intern_atom(false, b"WM_STATE")?.reply()?.atom,
             net_close_window: conn.intern_atom(false, b"_NET_CLOSE_WINDOW")?.reply()?.atom,
-            net_wm_state: conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom,
             net_wm_state_above: conn.intern_atom(false, b"_NET_WM_STATE_ABOVE")?.reply()?.atom,
             net_wm_state_sticky: conn.intern_atom(false, b"_NET_WM_STATE_STICKY")?.reply()?.atom,
             net_wm_state_demands_attention: conn
@@ -475,8 +493,56 @@ impl XEwmh {
             // (None because this WM uses its own shell tile).
             self.conn.change_property32(PropMode::REPLACE, window, self.atoms.wm_state, self.atoms.wm_state, &[state, 0])?;
         }
+        for &(window, modal) in &writes.window_modal {
+            let reply = self
+                .conn
+                .get_property(
+                    false,
+                    window,
+                    self.atoms.net_wm_state,
+                    AtomEnum::ATOM,
+                    0,
+                    u32::MAX,
+                )?
+                .reply()?;
+            let mut states: Vec<_> = reply
+                .value32()
+                .into_iter()
+                .flatten()
+                .filter(|&atom| atom != self.atoms.net_wm_state_modal)
+                .collect();
+            if modal {
+                states.push(self.atoms.net_wm_state_modal);
+            }
+            self.conn.change_property32(
+                PropMode::REPLACE,
+                window,
+                self.atoms.net_wm_state,
+                AtomEnum::ATOM,
+                &states,
+            )?;
+        }
         self.conn.flush()?;
         Ok(())
+    }
+
+    pub(crate) fn window_is_modal(&self, window: XWindow) -> bool {
+        let Ok(cookie) = self.conn.get_property(
+            false,
+            window,
+            self.atoms.net_wm_state,
+            AtomEnum::ATOM,
+            0,
+            u32::MAX,
+        ) else {
+            return false;
+        };
+        let Ok(reply) = cookie.reply() else {
+            return false;
+        };
+        reply
+            .value32()
+            .is_some_and(|mut states| states.any(|atom| atom == self.atoms.net_wm_state_modal))
     }
 }
 
@@ -492,6 +558,7 @@ struct Writes {
     window_desktops: Vec<(XWindow, u32)>,
     frame_extents: Vec<(XWindow, [u32; 4])>,
     window_states: Vec<(XWindow, u32)>,
+    window_modal: Vec<(XWindow, bool)>,
 }
 
 impl Writes {
@@ -503,6 +570,7 @@ impl Writes {
             && self.window_desktops.is_empty()
             && self.frame_extents.is_empty()
             && self.window_states.is_empty()
+            && self.window_modal.is_empty()
     }
 }
 
@@ -580,6 +648,11 @@ fn take_writes(backend: &mut WaylandBackend) -> Writes {
             .drain()
             .filter_map(|(id, iconic)| Some((x11_id(windows, id)?, icccm_wm_state(iconic))))
             .collect(),
+        window_modal: ledger
+            .window_modal
+            .drain()
+            .filter_map(|(id, modal)| Some((x11_id(windows, id)?, modal)))
+            .collect(),
     }
 }
 
@@ -638,8 +711,8 @@ pub(crate) fn flush(comp: &mut Compositor) {
 }
 
 /// Drains this connection's event queue (non-blocking) and translates
-/// the two control messages a pager sends — activate this window,
-/// switch to this desktop — into the same `BackendEvent`s the
+/// control messages a pager or X11 client sends — activate this window,
+/// switch to this desktop, or change modality — into the same `BackendEvent`s the
 /// Wayland-native request paths queue, so both kinds of tool drive
 /// one `wm-core` behavior. Every other event SubstructureNotify
 /// delivers is dropped here; this connection redirects nothing and
@@ -738,7 +811,7 @@ fn net_state_action(action: u32) -> Option<NetStateAction> {
     }
 }
 
-/// The three `_NET_WM_STATE` atoms this module decodes. The maximized
+/// The four `_NET_WM_STATE` atoms this module decodes. The maximized
 /// pair and fullscreen are deliberately absent: smithay's XWM already
 /// decodes those from its own connection, and decoding them here too
 /// would apply every such request twice.
@@ -747,6 +820,8 @@ fn net_state_from_atom(atoms: &WriteAtoms, atom: Atom) -> Option<NetState> {
         Some(NetState::Pinned)
     } else if atom == atoms.net_wm_state_demands_attention {
         Some(NetState::DemandsAttention)
+    } else if atom == atoms.net_wm_state_modal {
+        Some(NetState::Modal)
     } else {
         None
     }
@@ -947,9 +1022,11 @@ mod tests {
         ledger.note_window_desktop(WlWindowId(7), 1);
         ledger.note_frame_extents(WlWindowId(7), 1, 1, 24, 1);
         ledger.note_window_iconic(WlWindowId(7), true);
+        ledger.note_window_modal(WlWindowId(7), true);
         ledger.prune_window(WlWindowId(7));
         assert!(ledger.window_desktops.is_empty());
         assert!(ledger.frame_extents.is_empty());
         assert!(ledger.window_iconic.is_empty());
+        assert!(ledger.window_modal.is_empty());
     }
 }

--- a/crates/wm-wayland/src/xwayland.rs
+++ b/crates/wm-wayland/src/xwayland.rs
@@ -179,6 +179,10 @@ impl XwmHandler for Compositor {
         self.xwm.as_mut().expect("XWM event before start_wm")
     }
 
+    fn disconnected(&mut self, _xwm: XwmId) {
+        self.handle_xwayland_loss("running XWM connection closed");
+    }
+
     fn new_window(&mut self, _xwm: XwmId, _window: X11Surface) {
         // Creation is not management — X11 clients create windows long
         // before mapping (some never map). The record is made at map
@@ -196,6 +200,11 @@ impl XwmHandler for Compositor {
         if let Err(error) = window.set_mapped(true) {
             tracing::warn!(?error, "X11 map_window_request set_mapped failed");
         }
+        let modal = window.is_popup()
+            || self
+                .xewmh
+                .as_ref()
+                .is_some_and(|xewmh| xewmh.window_is_modal(window.window_id()));
         let backend = self.wm.backend_mut();
         let id = ensure_x11_record(backend, &window);
         // Refresh the pre-map geometry — the client may have configured
@@ -203,6 +212,7 @@ impl XwmHandler for Compositor {
         let geometry = wm_rect(window.geometry(), backend.output_size);
         if let Some(record) = backend.windows.get_mut(&id) {
             record.content = geometry;
+            record.modal = modal;
         }
         backend.queue(WmEvent::MapRequest(id));
         // `WM_HINTS` read once here as well as on change: a client that
@@ -229,11 +239,17 @@ impl XwmHandler for Compositor {
         // backend reports override-redirect as such) and maps them
         // as-is with no frame — the exact path `wm-x11` takes for
         // these window types.
+        let modal = window.is_popup()
+            || self
+                .xewmh
+                .as_ref()
+                .is_some_and(|xewmh| xewmh.window_is_modal(window.window_id()));
         let backend = self.wm.backend_mut();
         let id = ensure_x11_record(backend, &window);
         let geometry = wm_rect(window.geometry(), backend.output_size);
         if let Some(record) = backend.windows.get_mut(&id) {
             record.content = geometry;
+            record.modal = modal;
         }
         backend.queue(WmEvent::MapRequest(id));
     }
@@ -431,6 +447,9 @@ impl XwmHandler for Compositor {
                     first: NetState::DemandsAttention,
                     second: None,
                 });
+            }
+            WmWindowProperty::TransientFor => {
+                backend.queue(WmEvent::ParentChanged(id));
             }
             _ => {}
         }

--- a/crates/wm-x11/src/backend.rs
+++ b/crates/wm-x11/src/backend.rs
@@ -1243,6 +1243,15 @@ impl X11Backend {
                 if e.atom == self.motif_wm_hints {
                     return Some(BackendEvent::ChromeChanged(XWindow(e.window)));
                 }
+                if e.atom == u32::from(AtomEnum::WM_TRANSIENT_FOR) {
+                    return Some(BackendEvent::ParentChanged(XWindow(e.window)));
+                }
+                if e.atom == self.ewmh.net_wm_state {
+                    return Some(BackendEvent::ModalChanged {
+                        window: XWindow(e.window),
+                        modal: self.window_is_modal(XWindow(e.window)),
+                    });
+                }
                 None
             }
             Event::RandrScreenChangeNotify(e) => {
@@ -1392,6 +1401,8 @@ impl X11Backend {
                     Some(NetState::MaximizedHorz)
                 } else if atom == self.ewmh.net_wm_state_maximized_vert {
                     Some(NetState::MaximizedVert)
+                } else if atom == self.ewmh.net_wm_state_modal {
+                    Some(NetState::Modal)
                 } else {
                     // Unrecognized property atoms are skipped, not
                     // rejected — EWMH wants the rest of the message
@@ -1434,6 +1445,7 @@ struct EwmhAtoms {
     net_wm_state_fullscreen: Atom,
     net_wm_state_maximized_horz: Atom,
     net_wm_state_maximized_vert: Atom,
+    net_wm_state_modal: Atom,
     net_wm_state_shaded: Atom,
     net_wm_state_hidden: Atom,
     net_wm_window_type: Atom,
@@ -1468,28 +1480,98 @@ impl EwmhAtoms {
             net_client_list: conn.intern_atom(false, b"_NET_CLIENT_LIST")?.reply()?.atom,
             net_close_window: conn.intern_atom(false, b"_NET_CLOSE_WINDOW")?.reply()?.atom,
             net_wm_state: conn.intern_atom(false, b"_NET_WM_STATE")?.reply()?.atom,
-            net_wm_state_fullscreen: conn.intern_atom(false, b"_NET_WM_STATE_FULLSCREEN")?.reply()?.atom,
-            net_wm_state_maximized_horz: conn.intern_atom(false, b"_NET_WM_STATE_MAXIMIZED_HORZ")?.reply()?.atom,
-            net_wm_state_maximized_vert: conn.intern_atom(false, b"_NET_WM_STATE_MAXIMIZED_VERT")?.reply()?.atom,
-            net_wm_state_shaded: conn.intern_atom(false, b"_NET_WM_STATE_SHADED")?.reply()?.atom,
-            net_wm_state_hidden: conn.intern_atom(false, b"_NET_WM_STATE_HIDDEN")?.reply()?.atom,
-            net_wm_window_type: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE")?.reply()?.atom,
-            net_wm_window_type_normal: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_NORMAL")?.reply()?.atom,
-            net_wm_window_type_dialog: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DIALOG")?.reply()?.atom,
-            net_wm_window_type_desktop: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DESKTOP")?.reply()?.atom,
-            net_wm_window_type_dock: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DOCK")?.reply()?.atom,
-            net_wm_window_type_toolbar: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_TOOLBAR")?.reply()?.atom,
-            net_wm_window_type_menu: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_MENU")?.reply()?.atom,
-            net_wm_window_type_utility: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_UTILITY")?.reply()?.atom,
-            net_wm_window_type_splash: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_SPLASH")?.reply()?.atom,
-            net_wm_window_type_dropdown_menu: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU")?.reply()?.atom,
-            net_wm_window_type_popup_menu: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_POPUP_MENU")?.reply()?.atom,
-            net_wm_window_type_tooltip: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_TOOLTIP")?.reply()?.atom,
-            net_wm_window_type_notification: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_NOTIFICATION")?.reply()?.atom,
-            net_wm_window_type_combo: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_COMBO")?.reply()?.atom,
-            net_wm_window_type_dnd: conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_DND")?.reply()?.atom,
-            net_number_of_desktops: conn.intern_atom(false, b"_NET_NUMBER_OF_DESKTOPS")?.reply()?.atom,
-            net_current_desktop: conn.intern_atom(false, b"_NET_CURRENT_DESKTOP")?.reply()?.atom,
+            net_wm_state_fullscreen: conn
+                .intern_atom(false, b"_NET_WM_STATE_FULLSCREEN")?
+                .reply()?
+                .atom,
+            net_wm_state_maximized_horz: conn
+                .intern_atom(false, b"_NET_WM_STATE_MAXIMIZED_HORZ")?
+                .reply()?
+                .atom,
+            net_wm_state_maximized_vert: conn
+                .intern_atom(false, b"_NET_WM_STATE_MAXIMIZED_VERT")?
+                .reply()?
+                .atom,
+            net_wm_state_modal: conn
+                .intern_atom(false, b"_NET_WM_STATE_MODAL")?
+                .reply()?
+                .atom,
+            net_wm_state_shaded: conn
+                .intern_atom(false, b"_NET_WM_STATE_SHADED")?
+                .reply()?
+                .atom,
+            net_wm_state_hidden: conn
+                .intern_atom(false, b"_NET_WM_STATE_HIDDEN")?
+                .reply()?
+                .atom,
+            net_wm_window_type: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE")?
+                .reply()?
+                .atom,
+            net_wm_window_type_normal: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_NORMAL")?
+                .reply()?
+                .atom,
+            net_wm_window_type_dialog: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DIALOG")?
+                .reply()?
+                .atom,
+            net_wm_window_type_desktop: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DESKTOP")?
+                .reply()?
+                .atom,
+            net_wm_window_type_dock: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DOCK")?
+                .reply()?
+                .atom,
+            net_wm_window_type_toolbar: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_TOOLBAR")?
+                .reply()?
+                .atom,
+            net_wm_window_type_menu: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_MENU")?
+                .reply()?
+                .atom,
+            net_wm_window_type_utility: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_UTILITY")?
+                .reply()?
+                .atom,
+            net_wm_window_type_splash: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_SPLASH")?
+                .reply()?
+                .atom,
+            net_wm_window_type_dropdown_menu: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU")?
+                .reply()?
+                .atom,
+            net_wm_window_type_popup_menu: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_POPUP_MENU")?
+                .reply()?
+                .atom,
+            net_wm_window_type_tooltip: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_TOOLTIP")?
+                .reply()?
+                .atom,
+            net_wm_window_type_notification: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_NOTIFICATION")?
+                .reply()?
+                .atom,
+            net_wm_window_type_combo: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_COMBO")?
+                .reply()?
+                .atom,
+            net_wm_window_type_dnd: conn
+                .intern_atom(false, b"_NET_WM_WINDOW_TYPE_DND")?
+                .reply()?
+                .atom,
+            net_number_of_desktops: conn
+                .intern_atom(false, b"_NET_NUMBER_OF_DESKTOPS")?
+                .reply()?
+                .atom,
+            net_current_desktop: conn
+                .intern_atom(false, b"_NET_CURRENT_DESKTOP")?
+                .reply()?
+                .atom,
             net_wm_desktop: conn.intern_atom(false, b"_NET_WM_DESKTOP")?.reply()?.atom,
             net_workarea: conn.intern_atom(false, b"_NET_WORKAREA")?.reply()?.atom,
             net_frame_extents: conn.intern_atom(false, b"_NET_FRAME_EXTENTS")?.reply()?.atom,
@@ -1515,6 +1597,7 @@ impl EwmhAtoms {
             self.net_wm_state_fullscreen,
             self.net_wm_state_maximized_horz,
             self.net_wm_state_maximized_vert,
+            self.net_wm_state_modal,
             self.net_wm_state_shaded,
             self.net_wm_state_hidden,
             self.net_wm_window_type,
@@ -2376,6 +2459,25 @@ impl Backend for X11Backend {
         Some(XWindow(parent))
     }
 
+    fn window_is_modal(&self, window: Self::WindowId) -> bool {
+        let Ok(cookie) = self.conn.get_property(
+            false,
+            window.0,
+            self.ewmh.net_wm_state,
+            AtomEnum::ATOM,
+            0,
+            u32::MAX,
+        ) else {
+            return false;
+        };
+        let Ok(reply) = cookie.reply() else {
+            return false;
+        };
+        reply
+            .value32()
+            .is_some_and(|mut atoms| atoms.any(|atom| atom == self.ewmh.net_wm_state_modal))
+    }
+
     fn set_decoration_rules(&mut self, rules: wm_core::DecorationRules) {
         self.decoration_rules = rules;
     }
@@ -3119,8 +3221,16 @@ impl Backend for X11Backend {
         let _ = self.conn.flush();
     }
 
-    fn publish_net_state(&mut self, window: Self::WindowId, fullscreen: bool, max_h: bool, max_v: bool, shaded: bool, hidden: bool) {
-        let mut atoms = Vec::with_capacity(5);
+    fn publish_net_state(&mut self, window: Self::WindowId, state: wm_core::NetStateSnapshot) {
+        let wm_core::NetStateSnapshot {
+            fullscreen,
+            maximized_horizontally: max_h,
+            maximized_vertically: max_v,
+            shaded,
+            hidden,
+            modal,
+        } = state;
+        let mut atoms = Vec::with_capacity(6);
         if fullscreen {
             atoms.push(self.ewmh.net_wm_state_fullscreen);
         }
@@ -3135,6 +3245,9 @@ impl Backend for X11Backend {
         }
         if hidden {
             atoms.push(self.ewmh.net_wm_state_hidden);
+        }
+        if modal {
+            atoms.push(self.ewmh.net_wm_state_modal);
         }
         // On the client's own window, not the frame: pagers/taskbars
         // look the state up by the client id they got from
@@ -3182,6 +3295,14 @@ impl wm_theme_api::PopupHost for X11Backend {
 
     fn ungrab_pointer(&mut self, grab: wm_theme_api::PopupGrab) {
         X11Backend::ungrab_pointer(self, DragHandle(grab.0));
+    }
+
+    fn grab_keyboard(&mut self) {
+        <Self as Backend>::grab_keyboard(self);
+    }
+
+    fn ungrab_keyboard(&mut self) {
+        <Self as Backend>::ungrab_keyboard(self);
     }
 }
 

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -91,7 +91,8 @@ start with `[[BATCH]]` and use `;` separators.
 | `devices` | Seat keyboards and pointers; keyboards include `name`, `active_keymap`, `layout`, and `active_layout_index` |
 | `binds` | The live chonkstep keymap in Hyprland's plain bind-block format (or JSON) |
 | `getoption` | A complete, explicitly unset option shape; no fabricated Hyprland style value |
-| `version`, `configerrors`, `splash` | Supported |
+| `version`, `splash` | Supported |
+| `configerrors` | Retained live-Hyprland refusals, one per line or as JSON `{"error": "…"}` objects |
 
 The nested backend has no libinput device records, so it reports one
 logical keyboard and pointer. A hardware session reports its libinput

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -39,6 +39,22 @@ Window-targeted actions (`close`, `toggle-maximize`, `toggle-shade`,
 `miniaturize`, `toggle-fullscreen`, `window-menu`) act on the focused
 window and do nothing when no window is focused.
 
+Every root, window, and dock-tile menu is keyboard-modal while open.
+Up/Down changes the highlighted row, Right or Enter opens a submenu,
+Left returns to its parent, Enter/Space activates an action, and Escape
+closes the chain. The root menu itself is bindable as `root-menu`; for
+example:
+
+```toml
+[keybindings]
+"control+space" = "root-menu"
+```
+
+The Dock remains intentionally a pointer affordance rather than a
+second keyboard launcher. Its application-launching function is fully
+available from the root menu's keyboard-operable Applications cascade;
+`toggle-dock` only controls whether the pointer strip is visible.
+
 Three more verbs exist and are unbound in this keymap, because the
 NeXTSTEP vocabulary reaches workspaces by stepping through them rather
 than by number: `workspace <n>` goes to workspace *n*, and

--- a/docs/screen-sharing.md
+++ b/docs/screen-sharing.md
@@ -114,6 +114,8 @@ managers — both spellings installed by `scripts/install.sh`), and
     org.freedesktop.impl.portal.Inhibit=chonkstep
     org.freedesktop.impl.portal.ScreenCast=wlr
     org.freedesktop.impl.portal.Screenshot=wlr
+    org.freedesktop.impl.portal.Secret=gnome-keyring;kwallet
+    org.freedesktop.impl.portal.GlobalShortcuts=hyprland
 
 A user override can live at
 `~/.config/xdg-desktop-portal/chonkstep-portals.conf`.
@@ -148,8 +150,13 @@ Checked against the frontend with the chonkstep config active:
 | ScreenCast | wlr | **Works** — verified end to end; node id returned, frames flowing, pixels correct |
 | Screenshot | wlr | **Works** — `Screenshot()` returned a real PNG of the session (xdg-desktop-portal-wlr shells out to `grim`, which is also installed) |
 | Inhibit | chonkstep | Idle requests feed the compositor's own timers and are released on request close or caller disconnect |
-| FileChooser, Notification, Settings, and the rest | gtk | **Backend activates and answers** (D-Bus ping + interface version 4 confirmed); the dialogs themselves are ordinary windows and were not driven headlessly |
+| Account, Camera, DynamicLauncher, Email, FileChooser, Location, Notification, OpenURI, Print, Settings | gtk | Toolkit portal surface; the backend activates and answers |
+| GameMode, MemoryMonitor, NetworkMonitor, PowerProfileMonitor, ProxyResolver, Realtime, Trash | frontend/fallback services | Exported by the portal frontend on the tested session |
+| Secret | gnome-keyring, then kwallet | Explicitly routed; the first installed secret provider answers sandboxed credential storage |
+| GlobalShortcuts | hyprland | The backend registers `hyprland_global_shortcuts_v1` objects; chords configured with Hyprland's `global, app:id` dispatcher send pressed/released events |
 | Window/toplevel capture (`types=2` in SelectSources) | wlr | **Supported** — ext image-copy-capture advertises both output and foreign-toplevel sources; compatible portal backends expose `AvailableSourceTypes=3` |
+| Background, Wallpaper | none installed | Not exported; no installed backend declares these interfaces |
+| RemoteDesktop, InputCapture, Clipboard | none installed | Not exported. The compositor now serves virtual keyboard and virtual pointer injection, but an implementation portal backend is still required |
 
 Backend matrix:
 

--- a/docs/xwayland-compatibility.md
+++ b/docs/xwayland-compatibility.md
@@ -75,6 +75,15 @@ desktop-switch events every other input path queues (proven by an
 x11rb pager round-tripping a workspace switch in the end-to-end
 suite), so `wmctrl -l` reads and `wmctrl -a` / `wmctrl -s` command.
 
+XWayland is supervised after it becomes ready. If its live XWM connection
+closes, chonkstep removes every X11 window, frame, stacking slot, XSETTINGS
+handle and EWMH connection from that generation, withdraws the dead `DISPLAY`
+from future launches, and attempts one restart. A replacement that reaches
+ready republishes all session settings; a second crash stands down instead of
+looping. The nested end-to-end suite SIGKILLs the real Xwayland process,
+asserts the old window leaves the compositor ledger, and maps a new window
+through the replacement ([#58](https://github.com/iconidentify/chonkstep/issues/58)).
+
 ## Decorations
 
 The rule is one sentence: a client that says it draws its own titlebar is

--- a/packaging/portal/chonkstep-portals.conf
+++ b/packaging/portal/chonkstep-portals.conf
@@ -19,3 +19,5 @@ default=gtk
 org.freedesktop.impl.portal.Inhibit=chonkstep
 org.freedesktop.impl.portal.ScreenCast=wlr
 org.freedesktop.impl.portal.Screenshot=wlr
+org.freedesktop.impl.portal.Secret=gnome-keyring;kwallet
+org.freedesktop.impl.portal.GlobalShortcuts=hyprland


### PR DESCRIPTION
## Summary

- model transient families and modality across Wayland/X11, including parent-centred placement and family lifecycle behavior
- supervise XWayland after a live crash, retire ghost windows, clear stale session state, and attempt one bounded restart
- add effective-config inspection/checking, IPC diagnostics, keyboard-complete menus, and root-menu bindings
- expose trusted global-shortcut and virtual-pointer protocols, complete portal routing, and mark compositor-owned opaque buffers

## Validation

- `cargo test --workspace --quiet`
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks`
- `RUSTDOCFLAGS="-D warnings -A rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps --locked --document-private-items`

Closes #55
Closes #58
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64