### PR TITLE
Wayland: compositor reliability, stable outputs, and live diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
             packaging/arch/PKGBUILD \
             packaging/arch/PKGBUILD-release \
             scripts/install.sh \
+            scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \
             scripts/omarchy-remove-desktop-chonkstep \
             scripts/test-omarchy-install.sh \
@@ -67,6 +68,7 @@ jobs:
             scripts/verify-install.sh \
             scripts/wayland-session.sh
           shellcheck \
+            scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \
             scripts/omarchy-remove-desktop-chonkstep \
             scripts/test-omarchy-install.sh \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3313,6 +3313,7 @@ name = "wm-wayland"
 version = "0.2.0"
 dependencies = [
  "calloop 0.14.4",
+ "chonk-build-info",
  "chonk-hyprland-ipc",
  "chonk-shell",
  "chonk-xsettings",

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ and the release history in [CHANGELOG.md](CHANGELOG.md).
   the Wayland session script supervises: abnormal exits restart the
   compositor with the recorded layout (a crash loop trips a brake
   instead), and with `lock_command` set the recovered session comes
-  back locked. Restore never resurrects a window you closed.
+  back locked. On Wayland, EDID identity plus monitor-relative geometry
+  keeps each window on the same physical display even if connector
+  names or plug order change. Restore never resurrects a window you
+  closed.
 - **The Instrument Platform.** Every dock tile is a separate process
   that pushes finished pixels over a private socket and gets theme,
   scale, input and supervision in return - so a widget that crashes,
@@ -525,17 +528,19 @@ What the session backend does not do yet, stated plainly:
 - **One GPU, every connector on it.** The session drives every display
   plugged into the primary DRM device, each with its own mode, page
   flips, and place in the desktop layout; a second GPU's outputs stay
-  dark. Nothing hot-plugs: a monitor or GPU that appears mid-session is
-  logged and ignored, so docking a laptop means restarting the session.
+  dark, but connected desktop outputs on those omitted devices are
+  named in the log with the `CHONKSTEP_DRM_DEVICE` override. Connectors
+  on the selected GPU hot-plug live; adding another GPU still requires
+  a new session because device selection is a startup decision.
   Arrangement is configurable now, not compiled in: the compositor
   speaks wlr-output-management, so `wlr-randr` and `kanshi` list and
-  configure outputs - position, mode, and per-output scale (fractional
-  included), applied live. What the backend cannot honor - disabling
-  an output, transforms - is refused with a named log line rather than
-  accepted and botched. Stated honestly: the multi-output plumbing has
-  been driven end to end on the nested backend and over the protocol,
-  but a many-monitor DRM session has not yet been proven on physical
-  hardware.
+  configure outputs - position, mode, rotation, and per-output scale
+  (fractional included), applied live. What the backend cannot honor -
+  disabling an output or adaptive sync - is refused with a named log
+  line rather than accepted and botched. Stated honestly: the
+  multi-output plumbing has been driven end to end on the nested
+  backend and over the protocol, but a many-monitor DRM session has
+  not yet been proven on physical hardware.
 - **The hardware cursor depends on your driver.** The pointer is asked
   for the display controller's cursor plane, which is what makes it
   track the hand instead of the frame rate. Whether it gets one is the

--- a/crates/chonk-hyprland-ipc/src/dispatch.rs
+++ b/crates/chonk-hyprland-ipc/src/dispatch.rs
@@ -80,7 +80,13 @@ pub enum Action {
     /// Scale in protocol units (120 == 1.0), avoiding floating-point
     /// equality in an action that is compared in conformance tests.
     SetMonitorScale { output: String, scale_120: u32 },
+    /// Hide or restore the compositor-owned pointer image. This is a
+    /// live session property used by Omarchy's screensaver, not a
+    /// persisted Hyprland configuration mutation.
+    SetCursorHidden(bool),
     ReloadConfig,
+    SetDiagnostic { name: String, enabled: bool },
+    SetLogFilter(String),
     /// The requested window is already floating; applying this still
     /// validates that the target survived until the action ran.
     ConfirmFloating(u64),
@@ -396,7 +402,17 @@ pub fn parse_eval(source: &str, snapshot: &Snapshot) -> Outcome {
         }
         return Outcome::Run(Action::SetMonitorScale { output, scale_120: (scale * 120.0).round() as u32 });
     }
-    if source.starts_with("hl.config(") {
+    if let Some(body) = source.strip_prefix("hl.config(").and_then(|value| value.strip_suffix(')')) {
+        if let Some(cursor) = lua_table_field(body, "cursor") {
+            if let Some(value) = lua_field(cursor, "invisible") {
+                return match parse_bool(&value) {
+                    Some(hidden) => Outcome::Run(Action::SetCursorHidden(hidden)),
+                    None => Outcome::Unsupported(
+                        "hl.config cursor.invisible requires true or false".to_string(),
+                    ),
+                };
+            }
+        }
         return Outcome::Unsupported("hl.config property mutation is not supported by chonkstep".to_string());
     }
     if source.starts_with("hl.device(") {
@@ -406,6 +422,29 @@ pub fn parse_eval(source: &str, snapshot: &Snapshot) -> Outcome {
         return Outcome::Unsupported("chonkstep is floating-only and cannot apply a tiled workspace layout".to_string());
     }
     Outcome::Unknown(format!("unknown eval expression {source:?}"))
+}
+
+/// Parse the one live `keyword` mutation chonkstep deliberately
+/// supports. The broad namespace remains a refusal; this exception is
+/// the exact fallback shipped by Omarchy's screensaver.
+pub fn parse_keyword(source: &str) -> Outcome {
+    let mut fields = source.split_whitespace();
+    match (fields.next(), fields.next(), fields.next()) {
+        (Some("cursor:invisible"), Some(value), None) => match parse_bool(value) {
+            Some(hidden) => Outcome::Run(Action::SetCursorHidden(hidden)),
+            None => Outcome::Unsupported(
+                "keyword cursor:invisible requires true or false".to_string(),
+            ),
+        },
+        _ => Outcome::Unsupported(
+            "keyword does not mutate chonkstep's configuration. \
+             chonkstep reads ~/.config/hypr and re-reads it within a second of an edit, \
+             so edit the file instead, or use `hyprctl eval hl.monitor({...})` for a live \
+             scale change. `keyword monitor NAME,disable` cannot work at all: chonkstep \
+             drives every connected output and has no disable path."
+                .to_string(),
+        ),
+    }
 }
 
 fn selected_window<'a>(selector: &str, snapshot: &'a Snapshot) -> Option<&'a Window> {
@@ -506,6 +545,53 @@ fn lua_field(body: &str, key: &str) -> Option<String> {
         });
     }
     None
+}
+
+/// Pull the contents of `key = { ... }` out of a Lua table literal.
+/// Only balanced braces are recognized; malformed or non-table fields
+/// are left to the caller's named refusal.
+fn lua_table_field<'a>(body: &'a str, key: &str) -> Option<&'a str> {
+    for (at, _) in body.match_indices(key) {
+        if at > 0 {
+            let before = body[..at].chars().next_back().unwrap_or(' ');
+            if before.is_alphanumeric() || before == '_' || before == '.' {
+                continue;
+            }
+        }
+        let after_key = &body[at + key.len()..];
+        if after_key.chars().next().is_some_and(|after| after.is_alphanumeric() || after == '_') {
+            continue;
+        }
+        let Some(rest) = after_key.trim_start().strip_prefix('=') else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(table) = rest.strip_prefix('{') else {
+            continue;
+        };
+        let mut depth = 1_u32;
+        for (index, character) in table.char_indices() {
+            match character {
+                '{' => depth = depth.saturating_add(1),
+                '}' => {
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        return Some(&table[..index]);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim() {
+        "true" | "1" | "on" | "yes" => Some(true),
+        "false" | "0" | "off" | "no" => Some(false),
+        _ => None,
+    }
 }
 
 /// The first bare string literal in a Lua argument list.

--- a/crates/chonk-hyprland-ipc/src/server.rs
+++ b/crates/chonk-hyprland-ipc/src/server.rs
@@ -202,6 +202,35 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
                 (format!("chonkstep {}\n", env!("CARGO_PKG_VERSION")), None)
             }
         }
+        "systeminfo" => (snapshot.system_info.clone(), None),
+        "rollinglog" => (
+            "ChonkStep writes the current Wayland session log under $XDG_STATE_HOME/chonkstep/wayland-session.log; use `hyprctl log-filter DIRECTIVE` to change live verbosity.\n".to_string(),
+            None,
+        ),
+        "debug-set" => {
+            let mut args = request.args.split_whitespace();
+            let name = args.next().unwrap_or_default();
+            let enabled = match args.next() {
+                Some("1" | "true" | "on" | "yes") => Some(true),
+                Some("0" | "false" | "off" | "no") => Some(false),
+                _ => None,
+            };
+            match (name.is_empty(), enabled, args.next()) {
+                (false, Some(enabled), None) => (
+                    "ok".to_string(),
+                    Some(Action::SetDiagnostic { name: name.to_string(), enabled }),
+                ),
+                _ => ("Invalid dispatcher: usage: debug-set KNOB BOOL".to_string(), None),
+            }
+        }
+        "log-filter" => {
+            let directive = request.args.trim();
+            if directive.is_empty() {
+                ("Invalid dispatcher: usage: log-filter DIRECTIVE".to_string(), None)
+            } else {
+                ("ok".to_string(), Some(Action::SetLogFilter(directive.to_string())))
+            }
+        }
         "cursorpos" => {
             // Plain text even under `-j`, matching Hyprland, and read by
             // `omarchy-capture-region` as `${pos%,*}` / `${pos#*, }` —
@@ -252,22 +281,19 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
             },
             None,
         ),
-        // A refusal, and it stays one: `keyword` is Hyprland's whole
-        // configuration namespace, and answering `ok` for all of it
-        // would be worse than saying no. But the refusal has to be
-        // *true* — chonkstep does read a Hyprland config, and the old
-        // sentence pointed a user reading it away from the one route
-        // that works. `hyprctl` exits zero either way (see the module
-        // docs), so this string is the only diagnostic there is.
-        "keyword" => (
-            "Invalid dispatcher: keyword does not mutate chonkstep's configuration. \
-             chonkstep reads ~/.config/hypr and re-reads it within a second of an edit, \
-             so edit the file instead, or use `hyprctl eval hl.monitor({...})` for a live \
-             scale change. `keyword monitor NAME,disable` cannot work at all: chonkstep \
-             drives every connected output and has no disable path."
-                .to_string(),
-            None,
-        ),
+        // `keyword` stays a refusal for Hyprland's broad configuration
+        // namespace. `cursor:invisible` is the one named exception:
+        // Omarchy's screensaver ships it as the fallback for the
+        // equivalent `hl.config` property, and the compositor can
+        // honour it exactly.
+        "keyword" => {
+            let outcome = dispatch::parse_keyword(&request.args);
+            let response = outcome.response();
+            match outcome {
+                Outcome::Run(action) => (response, Some(action)),
+                _ => (response, None),
+            }
+        }
         "reload" => ("ok".to_string(), Some(Action::ReloadConfig)),
         "binds" => (if json { json_bindings(snapshot) } else { plain_bindings(snapshot) }, None),
         "devices" => (json_devices(snapshot), None),

--- a/crates/chonk-hyprland-ipc/src/state.rs
+++ b/crates/chonk-hyprland-ipc/src/state.rs
@@ -67,6 +67,9 @@ pub struct Monitor {
     /// period; the conversion to Hyprland's float belongs at the wire,
     /// not here.
     pub refresh_millihertz: u32,
+    /// wl_output transform number. ChonkStep currently exposes the
+    /// four rotations (0 through 3).
+    pub transform: i32,
     /// Every mode this output can drive, current first — the same list
     /// `zwlr_output_management` enumerates for the same head.
     pub modes: Vec<MonitorMode>,
@@ -215,6 +218,9 @@ pub struct Snapshot {
     /// Effective configuration refusals, one actionable message each.
     pub config_errors: Vec<String>,
     pub devices: Devices,
+    /// Human-readable live compositor/build summary served by
+    /// `hyprctl systeminfo`.
+    pub system_info: String,
 }
 
 /// One keybinding in the subset `hyprctl binds` exposes to menus.
@@ -450,7 +456,7 @@ impl Snapshot {
                     special_workspace: WorkspaceRef { id: 0, name: String::new() },
                     reserved: [0, 0, 0, 0],
                     scale: monitor.scale,
-                    transform: 0,
+                    transform: monitor.transform,
                     focused: monitor.focused,
                     dpms_status: true,
                     vrr: false,

--- a/crates/chonk-hyprland-ipc/tests/protocol.rs
+++ b/crates/chonk-hyprland-ipc/tests/protocol.rs
@@ -29,11 +29,12 @@ fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monit
         active_workspace,
         make: "Sharp".to_string(),
         model: name.to_string(),
-        serial: String::new(),
+        serial: "0x01020304".to_string(),
         // 120 Hz on purpose: the value this used to report was a
         // conventional 60 for every panel, so a fixture that is also
         // 60 would pass either way.
         refresh_millihertz: 120_000,
+        transform: 0,
         modes: vec![
             MonitorMode { width: 2560, height: 1600, refresh_millihertz: 120_000 },
             MonitorMode { width: 2560, height: 1600, refresh_millihertz: 60_000 },
@@ -81,6 +82,7 @@ fn desktop() -> Snapshot {
         bindings: Vec::new(),
         config_errors: Vec::new(),
         devices: Devices::default(),
+        system_info: "test system".into(),
     }
 }
 
@@ -372,6 +374,26 @@ fn cursorpos_is_plain_text_with_comma_space() {
     assert!(response.contains(", "), "got {response:?}");
     let (x, y) = response.split_once(", ").expect("comma-space separated");
     assert!(x.parse::<i32>().is_ok() && y.parse::<i32>().is_ok(), "got {response:?}");
+}
+
+#[test]
+fn live_diagnostic_commands_have_truthful_wire_shapes() {
+    assert_eq!(ask("/systeminfo", &desktop()), "test system");
+
+    let (response, actions) = answer_payload(b"/debug-set damage-log on", &desktop());
+    assert_eq!(response, "ok");
+    assert_eq!(
+        actions,
+        vec![Action::SetDiagnostic { name: "damage-log".into(), enabled: true }]
+    );
+
+    let (response, actions) = answer_payload(b"/log-filter info,wm_wayland::session=debug", &desktop());
+    assert_eq!(response, "ok");
+    assert_eq!(actions, vec![Action::SetLogFilter("info,wm_wayland::session=debug".into())]);
+
+    let (response, actions) = answer_payload(b"/debug-set damage-log perhaps", &desktop());
+    assert!(response.starts_with("Invalid dispatcher"));
+    assert!(actions.is_empty());
 }
 
 // ---------------------------------------------------------------------
@@ -853,7 +875,7 @@ fn a_monitors_mode_list_is_the_connectors_modes_in_hyprlands_spelling() {
     );
     assert_eq!(monitors[0]["make"], "Sharp", "make comes from the same EDID wl_output advertises");
     assert_eq!(monitors[0]["model"], "eDP-1");
-    assert_eq!(monitors[0]["serial"], "", "no serial reaches this compositor; empty beats invented");
+    assert_eq!(monitors[0]["serial"], "0x01020304", "serial is the connector EDID value, not an invention");
 }
 
 /// The refusal is the only diagnostic `keyword` has — `hyprctl` exits
@@ -874,4 +896,29 @@ fn the_keyword_refusal_is_true_and_names_the_routes_that_work() {
         answer.contains("disable"),
         "the one shipped caller toggles a monitor off; say why that cannot work: {answer}"
     );
+}
+
+#[test]
+fn the_two_screensaver_spellings_reach_one_cursor_visibility_action() {
+    for (request, hidden) in [
+        ("eval hl.config({ cursor = { invisible = true } })", true),
+        ("eval hl.config({ cursor = { invisible = false } })", false),
+        ("keyword cursor:invisible true", true),
+        ("keyword cursor:invisible false", false),
+    ] {
+        let (response, actions) = answer_payload(request.as_bytes(), &desktop());
+        assert_eq!(response.trim(), "ok", "{request}");
+        assert_eq!(actions, vec![Action::SetCursorHidden(hidden)], "{request}");
+    }
+}
+
+#[test]
+fn cursor_visibility_does_not_turn_keyword_into_a_general_config_backdoor() {
+    let (response, actions) = answer_payload(b"keyword general:border_size 99", &desktop());
+    assert!(response.starts_with("Invalid dispatcher:"), "got {response:?}");
+    assert!(actions.is_empty());
+
+    let (response, actions) = answer_payload(b"eval hl.config({ cursor = { invisible = maybe } })", &desktop());
+    assert!(response.contains("requires true or false"), "got {response:?}");
+    assert!(actions.is_empty());
 }

--- a/crates/chonk-shell/src/control.rs
+++ b/crates/chonk-shell/src/control.rs
@@ -82,7 +82,7 @@ use wm_theme_api::Point;
 use crate::spawn;
 
 /// The integer version of `docs/control-socket.md` this build speaks.
-pub(crate) const PROTOCOL: u32 = 1;
+pub(crate) const PROTOCOL: u32 = 2;
 
 /// The longest line a client may send, newline included (spec §1). A
 /// client whose pending bytes cross this without a newline is
@@ -124,7 +124,14 @@ pub(crate) enum Event {
     Outputs(OutputsEvent),
     Focus(FocusEvent),
     Theme(ThemeEvent),
+    Debug(DebugEvent),
     Error(ErrorEvent),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct DebugEvent {
+    pub topic: String,
+    pub data: String,
 }
 
 /// §3.1. Always the first line a client reads.
@@ -219,6 +226,7 @@ pub(crate) struct ErrorEvent {
 pub(crate) enum Request {
     Snapshot,
     FocusWorkspace { index: usize },
+    Debug { topic: String },
 }
 
 /// Everything the shell publishes, as the four facet events it is
@@ -399,7 +407,7 @@ pub(crate) fn parse_request(bytes: &[u8]) -> Result<Request, ErrorEvent> {
 /// `WindowManager`, can do. Handed back from [`ControlSocket::service`]
 /// rather than done inside it because this module never holds a
 /// mutable window manager — it reads a snapshot and writes lines.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Command {
     /// `focus-workspace`, already validated against the workspace list
     /// in the snapshot the request was serviced with. The shell applies
@@ -407,6 +415,9 @@ pub(crate) enum Command {
     /// workspace at an index that already exists — so the validation
     /// here is what keeps the spec's "a switch, never a create".
     FocusWorkspace(usize),
+    /// A live inspection request, tagged with the one connection owed
+    /// the answer so diagnostics are never broadcast to every bar.
+    Debug { client: u64, topic: String },
 }
 
 // ---------------------------------------------------------------------
@@ -414,6 +425,7 @@ pub(crate) enum Command {
 // ---------------------------------------------------------------------
 
 struct ControlClient {
+    id: u64,
     stream: Stream,
     /// Bytes received and not yet terminated by a newline.
     inbound: Vec<u8>,
@@ -449,8 +461,9 @@ enum Farewell {
 }
 
 impl ControlClient {
-    fn new(stream: Stream) -> Self {
+    fn new(id: u64, stream: Stream) -> Self {
         Self {
+            id,
             stream,
             inbound: Vec::new(),
             outbound: Vec::new(),
@@ -604,6 +617,16 @@ impl ControlClient {
                     }));
                 }
             }
+            Ok(Request::Debug { topic }) => {
+                if matches!(topic.as_str(), "scene" | "focus" | "clients") {
+                    commands.push(Command::Debug { client: self.id, topic });
+                } else {
+                    self.queue(&Event::Error(ErrorEvent {
+                        request: Some("debug".to_string()),
+                        message: "topic must be scene, focus, or clients".to_string(),
+                    }));
+                }
+            }
             Err(error) => self.queue(&Event::Error(error)),
         }
     }
@@ -678,6 +701,7 @@ pub(crate) struct ControlSocket {
     /// slot opens so a later leak episode is visible again.
     cap_refusing: bool,
     capacity_refusals: u64,
+    next_client_id: u64,
 }
 
 impl ControlSocket {
@@ -718,6 +742,7 @@ impl ControlSocket {
                     read_cursor: 0,
                     cap_refusing: false,
                     capacity_refusals: 0,
+                    next_client_id: 1,
                 }
             }
             Err(error) => {
@@ -738,6 +763,7 @@ impl ControlSocket {
             read_cursor: 0,
             cap_refusing: false,
             capacity_refusals: 0,
+            next_client_id: 1,
         }
     }
 
@@ -837,7 +863,9 @@ impl ControlSocket {
                         // would make a well-behaved reconnect hang.
                         continue;
                     }
-                    let mut client = ControlClient::new(stream);
+                    let id = self.next_client_id;
+                    self.next_client_id = self.next_client_id.wrapping_add(1).max(1);
+                    let mut client = ControlClient::new(id, stream);
                     client.queue(&self.hello);
                     self.clients.push(client);
                 }
@@ -860,9 +888,21 @@ impl ControlSocket {
     /// second thread. Same treatment as an accepted one.
     #[cfg(test)]
     fn admit(&mut self, stream: Stream) {
-        let mut client = ControlClient::new(stream);
+        let id = self.next_client_id;
+        self.next_client_id = self.next_client_id.wrapping_add(1).max(1);
+        let mut client = ControlClient::new(id, stream);
         client.queue(&self.hello);
         self.clients.push(client);
+    }
+
+    /// Queues one diagnostic answer on the exact connection that
+    /// requested it. The shell builds `data` only after seeing this
+    /// command, keeping scene and client enumeration off ordinary bar
+    /// snapshot paths.
+    pub(crate) fn answer_debug(&mut self, client: u64, topic: String, data: String) {
+        if let Some(peer) = self.clients.iter_mut().find(|peer| peer.id == client) {
+            peer.queue(&Event::Debug(DebugEvent { topic, data }));
+        }
     }
 
     /// One full servicing pass against the current state. Per client,
@@ -1360,9 +1400,13 @@ mod tests {
     // -----------------------------------------------------------------
 
     #[test]
-    fn the_two_requests_parse_and_extra_keys_are_ignored() {
+    fn every_request_parses_and_extra_keys_are_ignored() {
         assert_eq!(parse_request(br#"{"request":"snapshot"}"#), Ok(Request::Snapshot));
         assert_eq!(parse_request(br#"{"request":"focus-workspace","index":2}"#), Ok(Request::FocusWorkspace { index: 2 }));
+        assert_eq!(
+            parse_request(br#"{"request":"debug","topic":"scene"}"#),
+            Ok(Request::Debug { topic: "scene".to_string() })
+        );
         assert_eq!(
             parse_request(br#"{"request":"snapshot","because":"a future client may say why"}"#),
             Ok(Request::Snapshot),
@@ -1403,7 +1447,7 @@ mod tests {
         let lines = bar.lines(5);
         let events: Vec<&str> = lines.iter().map(|l| l["event"].as_str().unwrap()).collect();
         assert_eq!(events, ["hello", "workspaces", "outputs", "focus", "theme"]);
-        assert_eq!(lines[0]["protocol"], 1);
+        assert_eq!(lines[0]["protocol"], 2);
         assert_eq!(lines[0]["pid"], std::process::id());
         assert!(matches!(lines[0]["session"].as_str(), Some("wayland" | "x11")));
     }
@@ -1450,6 +1494,24 @@ mod tests {
         assert!(service_after_request(&mut socket, &snapshot).is_empty());
         let events: Vec<String> = bar.lines(4).iter().map(|l| l["event"].as_str().unwrap().to_string()).collect();
         assert_eq!(events, ["workspaces", "outputs", "focus", "theme"]);
+    }
+
+    #[test]
+    fn a_debug_request_answers_only_the_asking_client() {
+        let snapshot = sample_snapshot();
+        let (_scratch, mut socket, mut bar) = connected(&snapshot);
+        bar.lines(5);
+        bar.send("{\"request\":\"debug\",\"topic\":\"scene\"}\n");
+        let commands = service_after_request(&mut socket, &snapshot);
+        let [Command::Debug { client, topic }] = commands.as_slice() else {
+            panic!("debug request was not returned to the shell")
+        };
+        socket.answer_debug(*client, topic.clone(), "scene=test".to_string());
+        socket.flush_pending();
+        let event = bar.lines(1).remove(0);
+        assert_eq!(event["event"], "debug");
+        assert_eq!(event["topic"], "scene");
+        assert_eq!(event["data"], "scene=test");
     }
 
     #[test]
@@ -1809,8 +1871,18 @@ mod tests {
     fn outputs_come_from_the_monitor_list_with_the_pointers_output_focused() {
         let mut backend = FakeBackend::new();
         backend.set_monitors(vec![
-            MonitorInfo { geometry: Rect::new(Point::new(0, 0), Size::new(2560, 1600)), name: "eDP-1".to_string(), primary: true },
-            MonitorInfo { geometry: Rect::new(Point::new(2560, 0), Size::new(1920, 1080)), name: "HDMI-A-1".to_string(), primary: false },
+            MonitorInfo {
+                geometry: Rect::new(Point::new(0, 0), Size::new(2560, 1600)),
+                name: "eDP-1".to_string(),
+                identity: None,
+                primary: true,
+            },
+            MonitorInfo {
+                geometry: Rect::new(Point::new(2560, 0), Size::new(1920, 1080)),
+                name: "HDMI-A-1".to_string(),
+                identity: None,
+                primary: false,
+            },
         ]);
         let wm = manager(backend);
         let theme = theme();
@@ -1877,7 +1949,9 @@ mod tests {
         bar.send("{\"request\":\"focus-workspace\",\"index\":1}\n");
         let commands = service_after_request(&mut socket, &first);
         for command in commands {
-            let Command::FocusWorkspace(index) = command;
+            let Command::FocusWorkspace(index) = command else {
+                panic!("workspace request returned a diagnostic command")
+            };
             wm.switch_workspace(index);
         }
         socket.publish(&snapshot(&wm, &surroundings(&theme)));

--- a/crates/chonk-shell/src/session_layout.rs
+++ b/crates/chonk-shell/src/session_layout.rs
@@ -48,6 +48,7 @@
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use wm_core::MonitorInfo;
 use wm_theme_api::{Point, Rect, Size};
 
 use crate::apps::{match_window_class, AppEntry};
@@ -77,11 +78,17 @@ pub struct WindowRecord {
     /// index changing shape between sessions — the id is looked up
     /// again at restore and falls back to a fresh class match.
     pub app: Option<String>,
-    /// Root-relative *content* geometry. For a maximized window this
-    /// is the pre-maximize geometry (the one worth restoring — the
+    /// Monitor-relative *content* geometry when `monitor_identity` is
+    /// present, root-relative geometry for legacy records or backends
+    /// without stable output identity. For a maximized window this is
+    /// the pre-maximize geometry (the one worth restoring — the
     /// maximize itself is re-derived from the flag against whatever
     /// workarea the new session has).
     pub geometry: Rect,
+    /// EDID `make model serial` of the physical monitor containing the
+    /// window. Unlike a connector name, this follows the display when
+    /// it is plugged into a different dock port.
+    pub monitor_identity: Option<String>,
     pub workspace: usize,
     pub maximized: bool,
     pub shaded: bool,
@@ -102,6 +109,42 @@ pub enum RelaunchPlan {
     /// An ordinary `.desktop` application, through the shell's launch
     /// fixups (scale env, platform args) like any menu launch.
     App(AppEntry),
+}
+
+/// Converts global geometry to a stable monitor-relative record. The
+/// caller supplies the monitor selected by the window manager's normal
+/// nearest-monitor policy so persistence cannot invent a second idea
+/// of monitor ownership.
+pub(crate) fn relative_to_monitor(monitor: Option<&MonitorInfo>, mut geometry: Rect) -> (Rect, Option<&str>) {
+    let identity = monitor.and_then(|monitor| monitor.identity.as_deref());
+    if let (Some(monitor), Some(_)) = (monitor, identity) {
+        geometry.pos.x = geometry.pos.x.saturating_sub(monitor.geometry.pos.x);
+        geometry.pos.y = geometry.pos.y.saturating_sub(monitor.geometry.pos.y);
+    }
+    (geometry, identity)
+}
+
+/// Resolves a remembered monitor-relative record against the current
+/// output order. If that physical monitor is absent, keep the window
+/// visible by using the current primary (or first) output while
+/// preserving its within-monitor offset. Eight-field legacy records
+/// have no identity and remain absolute exactly as before.
+pub(crate) fn restored_geometry(monitors: &[MonitorInfo], record: &WindowRecord) -> Rect {
+    let Some(identity) = record.monitor_identity.as_deref() else {
+        return record.geometry;
+    };
+    let target = monitors
+        .iter()
+        .find(|monitor| monitor.identity.as_deref() == Some(identity))
+        .or_else(|| monitors.iter().find(|monitor| monitor.primary))
+        .or_else(|| monitors.first());
+    let Some(target) = target else {
+        return record.geometry;
+    };
+    let mut geometry = record.geometry;
+    geometry.pos.x = geometry.pos.x.saturating_add(target.geometry.pos.x);
+    geometry.pos.y = geometry.pos.y.saturating_add(target.geometry.pos.y);
+    geometry
 }
 
 /// The store: what has been recorded, what is waiting to be restored,
@@ -307,7 +350,7 @@ fn relaunch_plan(record: &WindowRecord, apps: &[AppEntry]) -> Option<RelaunchPla
 /// theme/wallpaper/dock files beside it:
 ///
 /// ```text
-/// class \t app-or-'-' \t x \t y \t w \t h \t workspace \t flags-or-'-'
+/// class \t app-or-'-' \t x \t y \t w \t h \t workspace \t flags-or-'-' \t monitor-or-'-'
 /// ```
 ///
 /// Tabs because a class is free text that may contain spaces; flags
@@ -329,7 +372,7 @@ fn serialize(records: &[WindowRecord]) -> String {
         }
         let flags = if flags.is_empty() { "-".to_string() } else { flags.join(",") };
         text.push_str(&format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
             record.class,
             record.app.as_deref().unwrap_or("-"),
             record.geometry.pos.x,
@@ -338,6 +381,7 @@ fn serialize(records: &[WindowRecord]) -> String {
             record.geometry.size.h,
             record.workspace,
             flags,
+            record.monitor_identity.as_deref().unwrap_or("-"),
         ));
     }
     text
@@ -350,9 +394,12 @@ fn parse(text: &str) -> Vec<WindowRecord> {
 fn parse_line(line: &str) -> Option<WindowRecord> {
     let fields: Vec<&str> = line.split('\t').collect();
     let parsed = (|| -> Option<WindowRecord> {
-        let [class, app, x, y, w, h, workspace, flags] = fields.as_slice() else {
+        let [class, app, x, y, w, h, workspace, flags, monitor @ ..] = fields.as_slice() else {
             return None;
         };
+        if monitor.len() > 1 {
+            return None;
+        }
         if class.is_empty() {
             return None;
         }
@@ -370,6 +417,9 @@ fn parse_line(line: &str) -> Option<WindowRecord> {
                 pos: Point::new(x.parse().ok()?, y.parse().ok()?),
                 size: Size::new(w, h),
             },
+            monitor_identity: monitor
+                .first()
+                .and_then(|identity| (!identity.is_empty() && *identity != "-").then(|| (*identity).to_string())),
             workspace: workspace.parse().ok()?,
             maximized: flags.split(',').any(|f| f == "maximized"),
             shaded: flags.split(',').any(|f| f == "shaded"),
@@ -405,6 +455,7 @@ mod tests {
             class: class.to_string(),
             app: None,
             geometry: Rect { pos: Point::new(x, 40), size: Size::new(500, 400) },
+            monitor_identity: None,
             workspace: 0,
             maximized: false,
             shaded: false,
@@ -434,6 +485,7 @@ mod tests {
                 class: "Navigator".to_string(),
                 app: Some("org.mozilla.firefox".to_string()),
                 geometry: Rect { pos: Point::new(-40, 12), size: Size::new(1280, 900) },
+                monitor_identity: Some("Dell Inc. DELL U2720Q ABC123".to_string()),
                 workspace: 2,
                 maximized: true,
                 shaded: false,
@@ -442,6 +494,58 @@ mod tests {
             record("foot", 100),
         ];
         assert_eq!(parse(&serialize(&records)), records);
+    }
+
+    #[test]
+    fn old_absolute_records_still_parse_without_a_monitor_field() {
+        let parsed = parse("foot\t-\t100\t40\t500\t400\t0\t-\n");
+        assert_eq!(parsed, vec![record("foot", 100)]);
+    }
+
+    #[test]
+    fn monitor_relative_geometry_survives_connector_and_output_reorder() {
+        let dell = "Dell Inc. DELL U2720Q ABC123";
+        let first_layout = MonitorInfo {
+            geometry: Rect::new(Point::new(1920, 0), Size::new(3840, 2160)),
+            name: "DP-3".to_string(),
+            identity: Some(dell.to_string()),
+            primary: false,
+        };
+        let root_geometry = Rect::new(Point::new(2040, 80), Size::new(900, 700));
+        let (relative, identity) = relative_to_monitor(Some(&first_layout), root_geometry);
+        assert_eq!(relative.pos, Point::new(120, 80));
+
+        let mut remembered = record("foot", relative.pos.x);
+        remembered.geometry = relative;
+        remembered.monitor_identity = identity.map(str::to_owned);
+        let reordered = [
+            MonitorInfo {
+                geometry: Rect::new(Point::new(3840, 0), Size::new(1920, 1080)),
+                name: "eDP-1".to_string(),
+                identity: Some("BOE CQ NE135FBM-N41 0x00000000".to_string()),
+                primary: false,
+            },
+            MonitorInfo {
+                geometry: Rect::new(Point::new(0, 0), Size::new(3840, 2160)),
+                name: "DP-1".to_string(),
+                identity: Some(dell.to_string()),
+                primary: true,
+            },
+        ];
+        assert_eq!(restored_geometry(&reordered, &remembered).pos, Point::new(120, 80));
+    }
+
+    #[test]
+    fn absent_remembered_monitor_falls_back_to_the_current_primary() {
+        let mut remembered = record("foot", 120);
+        remembered.monitor_identity = Some("missing display".to_string());
+        let primary = MonitorInfo {
+            geometry: Rect::new(Point::new(700, 200), Size::new(1920, 1080)),
+            name: "eDP-1".to_string(),
+            identity: Some("present display".to_string()),
+            primary: true,
+        };
+        assert_eq!(restored_geometry(&[primary], &remembered).pos, Point::new(820, 240));
     }
 
     #[test]

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -30,7 +30,7 @@ use crate::desktop::{
 use crate::dockapp::Farewell;
 use crate::launchdock::{LaunchDock, LaunchDockAction};
 use crate::overview::{OverviewHit, OverviewItem};
-use crate::session_layout::{RelaunchPlan, SessionLayout, WindowRecord};
+use crate::session_layout::{relative_to_monitor, restored_geometry, RelaunchPlan, SessionLayout, WindowRecord};
 use crate::startup::SessionState;
 use crate::widgets::DockInput;
 use crate::{spawn, theme_select, wallpaper};
@@ -842,10 +842,13 @@ fn layout_snapshot<B: Backend>(wm: &WindowManager<B>, apps: &[AppEntry]) -> Vec<
         .filter(|(_, client)| !client.class.is_empty())
         .map(|(_, client)| {
             let maximized = client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
+            let root_geometry = if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry };
+            let (geometry, monitor_identity) = layout_record_geometry(wm, root_geometry);
             WindowRecord {
                 class: client.class.clone(),
                 app: apps::match_window_class(apps, &client.class).map(|index| apps[index].id.clone()),
-                geometry: if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry },
+                geometry,
+                monitor_identity: monitor_identity.map(str::to_owned),
                 workspace: client.workspace,
                 maximized,
                 shaded: client.flags.contains(ClientFlags::SHADED),
@@ -853,6 +856,17 @@ fn layout_snapshot<B: Backend>(wm: &WindowManager<B>, apps: &[AppEntry]) -> Vec<
             }
         })
         .collect()
+}
+
+fn layout_record_geometry<B: Backend>(wm: &WindowManager<B>, geometry: Rect) -> (Rect, Option<&str>) {
+    let half_width = (geometry.size.w / 2).min(i32::MAX as u32) as i32;
+    let half_height = (geometry.size.h / 2).min(i32::MAX as u32) as i32;
+    let center = Point::new(
+        geometry.pos.x.saturating_add(half_width),
+        geometry.pos.y.saturating_add(half_height),
+    );
+    let monitor = wm.monitors_ref().get(wm.monitor_index_at(center));
+    relative_to_monitor(monitor, geometry)
 }
 
 /// Whether `records` still describe the live client set exactly,
@@ -875,9 +889,11 @@ fn layout_matches_clients<B: Backend>(wm: &WindowManager<B>, records: &[WindowRe
             return false;
         };
         let maximized = client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
-        let geometry = if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry };
+        let root_geometry = if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry };
+        let (geometry, monitor_identity) = layout_record_geometry(wm, root_geometry);
         if record.class != client.class
             || record.geometry != geometry
+            || record.monitor_identity.as_deref() != monitor_identity
             || record.workspace != client.workspace
             || record.maximized != maximized
             || record.shaded != client.flags.contains(ClientFlags::SHADED)
@@ -2695,8 +2711,15 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                 let Some(record) = self.layout.claim(&class, std::time::Instant::now()) else {
                     return;
                 };
-                tracing::info!(class = %record.class, ?record.geometry, workspace = record.workspace, "restoring a recorded window");
-                wm.set_client_content_geometry(id, record.geometry);
+                let geometry = restored_geometry(wm.monitors_ref(), &record);
+                tracing::info!(
+                    class = %record.class,
+                    ?geometry,
+                    monitor = ?record.monitor_identity,
+                    workspace = record.workspace,
+                    "restoring a recorded window"
+                );
+                wm.set_client_content_geometry(id, geometry);
                 if record.workspace != wm.current_workspace() {
                     wm.move_client_to_workspace(id, record.workspace);
                 }
@@ -2957,7 +2980,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         }
         let snapshot = self.control_snapshot(wm);
         let commands = self.control.service(&snapshot);
-        let publish_after_command = !commands.is_empty();
+        let mut publish_after_command = false;
         for command in commands {
             match command {
                 // A switch, never a create — `docs/control-socket.md`
@@ -2972,14 +2995,28 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                 // on that. Two protocols, two audiences, each honest
                 // to its own contract.)
                 control::Command::FocusWorkspace(index) => {
+                    publish_after_command = true;
                     if index < wm.workspace_count() {
                         wm.switch_workspace(index);
                     } else {
                         tracing::debug!(index, "control client asked for a workspace that does not exist; ignoring");
                     }
                 }
+                control::Command::Debug { client, topic } => {
+                    let data = format!(
+                        "workspace={} focused_window={:?} clients={}\n{}",
+                        wm.current_workspace(),
+                        wm.focused_client().map(|id| id.as_u64()),
+                        wm.iter_clients()
+                            .filter(|(_, client)| client.lifecycle != Lifecycle::Withdrawn)
+                            .count(),
+                        wm.backend().diagnostic_snapshot(),
+                    );
+                    self.control.answer_debug(client, topic, data);
+                }
             }
         }
+        self.control.flush_pending();
         // A command is always a workspace request and is owed a
         // post-command workspaces event even when it selected the already
         // active workspace. `service` leaves that acknowledgement parked;
@@ -3181,7 +3218,7 @@ mod tests {
     }
 
     fn monitor(geometry: Rect, primary: bool) -> MonitorInfo {
-        MonitorInfo { geometry, name: "test".to_string(), primary }
+        MonitorInfo { geometry, name: "test".to_string(), identity: None, primary }
     }
 
     #[test]

--- a/crates/chonk-testkit/src/bin/chonk-fullscreen-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-fullscreen-probe.rs
@@ -60,10 +60,11 @@
 //! answer granted: asked fullscreen=true, told fullscreen=true
 //! ```
 //!
-//! The optional `animate` mode independently damages and commits at about
-//! 60 Hz, without requesting a frame callback. It exists to test the other
-//! half of compositor pacing: a client on a parked workspace may continue on
-//! its own timer, but its invisible commits must not make the compositor draw.
+//! The optional `animate` mode independently reattaches, damages and commits
+//! its retained buffer at about 60 Hz, without requesting a frame callback. It
+//! exists to test the other half of compositor pacing: a client on a parked
+//! workspace may continue on its own timer, but its invisible commits must not
+//! make the compositor draw.
 //! Every thirtieth commit is reported as `animation frame=N`, giving the
 //! harness an observable clock that does not depend on compositor telemetry.
 //! The frame-driven mode reports every callback as `frame callback=N`, which
@@ -608,6 +609,7 @@ fn main() {
         .unwrap_or_else(|error| fatal(&format!("initial configure: {error}")));
 
     let mut attached = (0, 0);
+    let mut attached_buffer = None;
     let mut animation_frame = 0_u64;
     say(&format!("mapped title={title:?}"));
     while !probe.closed {
@@ -632,6 +634,7 @@ fn main() {
                 probe.frame_pending = true;
             }
             surface.commit();
+            attached_buffer = Some(buffer);
             if inhibit_idle && probe.idle_inhibitor.is_none() {
                 let manager = probe
                     .idle_inhibit_manager
@@ -677,12 +680,18 @@ fn main() {
         }
 
         if self_timed {
-            // A deliberately self-timed client: damage existing
-            // content and commit without a frame callback. A
-            // roundtrip makes each commit's server-side delivery
-            // observable before the next one, while the sleep is the
-            // producer's cadence (not a test wait).
+            // A deliberately self-timed client: reattach and damage
+            // its retained buffer, then commit without a frame
+            // callback. Reattaching is important here: a commit that
+            // carries only a frame request or surface damage but no
+            // new buffer may correctly produce no repaint, which is
+            // the empty-frame case this compositor must not turn into
+            // a presentation boundary. A roundtrip makes each real
+            // buffer commit's server-side delivery observable before
+            // the next one, while the sleep is the producer's cadence
+            // (not a test wait).
             let (width, height) = probe.size;
+            surface.attach(attached_buffer.as_ref(), 0, 0);
             surface.damage(0, 0, width.max(1), height.max(1));
             surface.commit();
             animation_frame += 1;
@@ -694,11 +703,13 @@ fn main() {
             }
             std::thread::sleep(Duration::from_millis(16));
         } else if frame_driven && probe.frame_ready {
-            // A conventional animation loop: one new buffer only when
-            // the compositor says the previous frame was presented,
-            // and one callback booked atomically with that commit.
+            // A conventional animation loop: one newly attached frame
+            // only when the compositor says the previous frame was
+            // presented, and one callback booked atomically with that
+            // commit.
             probe.frame_ready = false;
             let (width, height) = probe.size;
+            surface.attach(attached_buffer.as_ref(), 0, 0);
             surface.damage(0, 0, width.max(1), height.max(1));
             surface.frame(&qh, ());
             probe.frame_pending = true;

--- a/crates/chonk-testkit/src/bin/chonk-protocol-torture.rs
+++ b/crates/chonk-testkit/src/bin/chonk-protocol-torture.rs
@@ -32,6 +32,10 @@ use wayland_protocols::xdg::shell::client::{
     xdg_toplevel::XdgToplevel,
     xdg_wm_base::{self, XdgWmBase},
 };
+use wayland_protocols_wlr::layer_shell::v1::client::{
+    zwlr_layer_shell_v1::{Layer, ZwlrLayerShellV1},
+    zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
+};
 
 fn fatal(message: &str) -> ! {
     eprintln!("chonk-protocol-torture: {message}");
@@ -49,6 +53,7 @@ struct Probe {
     subcompositor: Option<WlSubcompositor>,
     shm: Option<wl_shm::WlShm>,
     wm_base: Option<XdgWmBase>,
+    layer_shell: Option<ZwlrLayerShellV1>,
     configured: bool,
 }
 
@@ -69,6 +74,9 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
                 }
                 "wl_shm" => probe.shm = Some(registry.bind(name, version.min(1), qh, ())),
                 "xdg_wm_base" => probe.wm_base = Some(registry.bind(name, version.min(3), qh, ())),
+                "zwlr_layer_shell_v1" => {
+                    probe.layer_shell = Some(registry.bind(name, version.min(4), qh, ()))
+                }
                 _ => {}
             }
         }
@@ -132,6 +140,8 @@ ignore_events!(
     wl_shm::WlShm,
     wl_shm_pool::WlShmPool,
     wl_buffer::WlBuffer,
+    ZwlrLayerShellV1,
+    ZwlrLayerSurfaceV1,
 );
 
 /// One opaque buffer, the honest part of every strategy.
@@ -257,6 +267,23 @@ fn main() {
                 surface.commit();
                 surface.destroy();
             }
+        }
+        // The protocol size is unsigned while Smithay's internal
+        // geometry is signed. This exact request used to wrap through
+        // a lossy cast and panic the compositor in a debug build.
+        "layer-size-overflow" => {
+            let layer_shell = probe.layer_shell.clone().unwrap_or_else(|| fatal("no zwlr_layer_shell_v1"));
+            let surface = compositor.create_surface(&qh, ());
+            let layer = layer_shell.get_layer_surface(
+                &surface,
+                None,
+                Layer::Top,
+                "torture-layer-size".to_string(),
+                &qh,
+                (),
+            );
+            layer.set_size(u32::MAX, u32::MAX);
+            surface.commit();
         }
         other => fatal(&format!("unknown strategy {other:?}")),
     }

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -670,9 +670,26 @@ impl Session {
     /// pixels. The barrier the caller ran beforehand is what makes
     /// this a picture of a settled scene rather than a race.
     pub fn screenshot(&mut self, label: &str) -> Result<Screenshot, String> {
+        self.capture_screenshot(label, false)
+    }
+
+    /// The same real screencopy path as [`Self::screenshot`], with the
+    /// protocol's overlay-cursor flag set. Kept separate because most
+    /// scene assertions should not acquire pointer-position noise,
+    /// while cursor visibility cannot be tested through a cursorless
+    /// capture by definition.
+    pub fn screenshot_with_cursor(&mut self, label: &str) -> Result<Screenshot, String> {
+        self.capture_screenshot(label, true)
+    }
+
+    fn capture_screenshot(&mut self, label: &str, overlay_cursor: bool) -> Result<Screenshot, String> {
         self.screenshot_serial += 1;
         let path = self.dir.join(format!("{:02}-{label}.png", self.screenshot_serial));
-        let mut grim = Command::new("grim")
+        let mut command = Command::new("grim");
+        if overlay_cursor {
+            command.arg("-c");
+        }
+        let mut grim = command
             .arg(&path)
             .env("WAYLAND_DISPLAY", &self.wayland_display)
             .stdout(Stdio::null())

--- a/crates/chonk-testkit/tests/control_socket.rs
+++ b/crates/chonk-testkit/tests/control_socket.rs
@@ -110,7 +110,7 @@ fn a_bar_sees_the_snapshot_the_windows_and_its_own_switches() {
     // §1.2 / §3: hello, then every facet in order, before anything else.
     let hello = bar.next();
     assert_eq!(hello["event"], "hello");
-    assert_eq!(hello["protocol"], 1);
+    assert_eq!(hello["protocol"], 2);
     assert_eq!(hello["session"], "wayland");
     assert!(hello["pid"].as_u64().unwrap() > 0);
     let workspaces = bar.next();

--- a/crates/chonk-testkit/tests/hyprland_ipc.rs
+++ b/crates/chonk-testkit/tests/hyprland_ipc.rs
@@ -313,6 +313,75 @@ fn the_live_keyword_refusal_does_not_deny_reading_a_hyprland_config() {
     assert!(answer.contains("~/.config/hypr"), "point at the route that works: {answer}");
 }
 
+fn changed_cursor_pixels(left: &chonk_testkit::Screenshot, right: &chonk_testkit::Screenshot, x: u32, y: u32) -> usize {
+    (y..y + 40)
+        .flat_map(|py| (x..x + 40).map(move |px| (px, py)))
+        .filter(|&(px, py)| {
+            left.pixel(px, py)
+                .iter()
+                .zip(right.pixel(px, py))
+                .take(3)
+                .any(|(a, b)| a.abs_diff(b) > 12)
+        })
+        .count()
+}
+
+/// Omarchy's screensaver uses the eval spelling first and the keyword
+/// spelling as its fallback. Both must alter pixels, and a screensaver
+/// killed before its cleanup command must give the cursor back.
+#[test]
+#[ignore = "needs a Wayland session to nest inside"]
+fn screensaver_cursor_visibility_is_live_and_owned() {
+    let mut session = boot("hypr-ipc-cursor-visibility");
+    let dir = socket_dir(&session);
+
+    session
+        .launch("zenity", &["--question", "--title", "cursor-owner", "--text", "hold still"])
+        .expect("launch a focused owner window");
+    session.wait_for_window("cursor-owner").expect("the owner maps");
+
+    let (x, y) = (48_u32, 48_u32);
+    session.door().motion(f64::from(x), f64::from(y)).unwrap();
+    session.door().barrier().unwrap();
+    let visible = session.screenshot_with_cursor("cursor-visible").unwrap();
+
+    assert_eq!(
+        request(&dir, "/eval hl.config({ cursor = { invisible = true } })").trim(),
+        "ok"
+    );
+    session.door().barrier().unwrap();
+    let hidden = session.screenshot_with_cursor("cursor-hidden-by-eval").unwrap();
+    assert!(
+        changed_cursor_pixels(&visible, &hidden, x, y) > 16,
+        "the eval request must remove cursor pixels ({} vs {})",
+        visible.path.display(),
+        hidden.path.display()
+    );
+
+    assert_eq!(request(&dir, "/keyword cursor:invisible false").trim(), "ok");
+    session.door().barrier().unwrap();
+    let restored = session.screenshot_with_cursor("cursor-restored-by-keyword").unwrap();
+    assert!(
+        changed_cursor_pixels(&visible, &restored, x, y) <= 4,
+        "the keyword fallback must restore the same cursor pixels ({} vs {})",
+        visible.path.display(),
+        restored.path.display()
+    );
+
+    assert_eq!(request(&dir, "/keyword cursor:invisible true").trim(), "ok");
+    session.door().barrier().unwrap();
+    session.kill_client("zenity");
+    session.wait_for_window_gone("cursor-owner").expect("the owner exits");
+    session.door().barrier().unwrap();
+    let after_owner_death = session.screenshot_with_cursor("cursor-restored-after-owner-death").unwrap();
+    assert!(
+        changed_cursor_pixels(&hidden, &after_owner_death, x, y) > 16,
+        "a dead owner must not strand the session cursorless ({} vs {})",
+        hidden.path.display(),
+        after_owner_death.path.display()
+    );
+}
+
 /// The mapping protocol has two requests, and both are a join: whether
 /// a caller holds the wlr manager's handle or the frozen
 /// `ext_foreign_toplevel_list_v1` handle, the address that comes back

--- a/crates/chonk-testkit/tests/protocol_torture.rs
+++ b/crates/chonk-testkit/tests/protocol_torture.rs
@@ -34,6 +34,7 @@ const STRATEGIES: &[(&str, &str)] = &[
     // The ledgers, and the role lifecycle that outlives its hooks.
     ("object-flood", "8192"),
     ("role-churn", "256"),
+    ("layer-size-overflow", "1"),
 ];
 
 /// The same strategies at a tenth of the size, for the soak.
@@ -50,6 +51,7 @@ const SOAK_STRATEGIES: &[(&str, &str)] = &[
     ("deep-subsurface", "256"),
     ("object-flood", "512"),
     ("role-churn", "64"),
+    ("layer-size-overflow", "1"),
 ];
 
 /// The compositor's resident set in kB, read the way `memory.rs` reads

--- a/crates/chonkstep-wayland/src/main.rs
+++ b/crates/chonkstep-wayland/src/main.rs
@@ -80,12 +80,24 @@ fn inspect_config_and_exit_if_asked() {
 
 #[cfg(target_os = "linux")]
 fn main() {
+    use tracing_subscriber::prelude::*;
     // Before the subscriber, so `--version` prints one clean line
     // rather than a line preceded by whatever RUST_LOG asked for.
     print_version_and_exit_if_asked();
     inspect_config_and_exit_if_asked();
     let allocator_policy_pinned = chonk_shell::startup::pin_glibc_large_allocation_policy();
-    tracing_subscriber::fmt().with_env_filter(tracing_subscriber::EnvFilter::from_default_env()).init();
+    let (filter, reload) = tracing_subscriber::reload::Layer::new(
+        tracing_subscriber::EnvFilter::from_default_env(),
+    );
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+    let _ = wm_wayland::install_log_filter_reloader(move |directive| {
+        let filter = tracing_subscriber::EnvFilter::try_new(directive)
+            .map_err(|error| format!("invalid tracing filter: {error}"))?;
+        reload.reload(filter).map_err(|error| format!("could not reload tracing filter: {error}"))
+    });
     if !allocator_policy_pinned {
         tracing::warn!("glibc rejected the fixed mmap/trim thresholds; transient buffers may raise the heap high-water mark");
     }

--- a/crates/wm-config/src/hyprland/directive.rs
+++ b/crates/wm-config/src/hyprland/directive.rs
@@ -142,7 +142,8 @@ pub enum Matcher {
 /// preferred-mode, position, and scale subset transactionally.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Monitor {
-    /// The output name, or empty for Hyprland's catch-all `monitor=,…`.
+    /// The connector name, stable `desc:make model serial` selector, or
+    /// empty for Hyprland's catch-all `monitor=,…`.
     pub output: String,
     pub mode: String,
     pub position: String,

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -95,9 +95,10 @@
 //! - **Unsupported input settings.** Keyboard xkb/repeat values are
 //!   carried. Whole-desktop behavior such as `follow_mouse`, touchpad
 //!   policy, and gestures belongs to chonkstep and is named and skipped.
-//! - **Unsupported `monitor =` lines.** Preferred mode, position and
-//!   scale are applied once outputs exist. Disable, mirror, transform,
-//!   extras and explicit modes refuse their whole line.
+//! - **Unsupported `monitor =` lines.** Preferred and explicit modes,
+//!   position, scale, and 0/90/180/270-degree transforms are applied
+//!   once outputs exist. Disable, mirror, and other extras refuse their
+//!   whole line.
 //! - **Anything that commands Hyprland.** `hyprctl` and the
 //!   `omarchy-hyprland-*` scripts talk to a compositor that is not
 //!   running; those bindings stay unbound, the same filter
@@ -298,8 +299,9 @@ pub struct Skipped {
 /// resolved after real outputs exist. `wm-wayland` consumes the list at
 /// output bootstrap, gives exact-name rules precedence over catch-all
 /// rules, and applies preferred mode, position, and scale as one
-/// transaction. A line containing disable, mirror, transform, another
-/// extra field, or an explicit mode is refused whole and logged.
+/// transaction. Explicit modes and 0/90/180/270-degree transforms are
+/// supported; a line containing disable, mirror, or another extra field
+/// is refused whole and logged.
 #[derive(Clone, Debug, Default)]
 pub struct Monitors {
     pub lines: Vec<directive::Monitor>,

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -1542,7 +1542,7 @@ fn drag_modifier_from_name(name: &str) -> Option<Option<Modifiers>> {
 /// than resolved against some accidental working directory. `None`
 /// only when `$HOME` is also missing — at which point there is nowhere
 /// sane to look and the defaults are the right answer.
-fn config_path() -> Option<PathBuf> {
+pub fn config_path() -> Option<PathBuf> {
     let base = match std::env::var_os("XDG_CONFIG_HOME") {
         Some(dir) if !dir.is_empty() && PathBuf::from(&dir).is_absolute() => PathBuf::from(dir),
         _ => PathBuf::from(std::env::var_os("HOME")?).join(".config"),

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -46,6 +46,27 @@ pub trait Backend {
     /// an index or a rectangle.
     fn monitors_ref(&self) -> &[MonitorInfo];
 
+    /// Read-only backend-specific state for a live diagnostic request.
+    /// Kept textual so the protocol-agnostic core does not learn a
+    /// compositor's surface vocabulary.
+    fn diagnostic_snapshot(&self) -> String {
+        format!("monitors={} screen={}x{}", self.monitors_ref().len(), self.screen_size().w, self.screen_size().h)
+    }
+
+    /// Changes a safe live diagnostic switch. Backends with no live
+    /// controls refuse explicitly.
+    fn set_diagnostic(&mut self, name: &str, enabled: bool) -> Result<(), String> {
+        let _ = (name, enabled);
+        Err("this backend has no live diagnostic switches".into())
+    }
+
+    /// Replaces the process tracing filter without restarting the
+    /// desktop. The binary must have installed a reload handle.
+    fn set_log_filter(&mut self, directive: &str) -> Result<(), String> {
+        let _ = directive;
+        Err("this backend has no reloadable tracing filter".into())
+    }
+
     /// The identity of a shell-owned surface — the dock, the Clip, the
     /// launcher strip, icon tiles, menu popups. The same id space
     /// `wm_theme_api::PopupHost` uses on this backend, so the desktop

--- a/crates/wm-core/src/client.rs
+++ b/crates/wm-core/src/client.rs
@@ -35,13 +35,18 @@ impl ClientId {
 /// `Client::monitor` already carries a `MonitorId` so per-client
 /// monitor ownership is additive later, not a rewrite.
 ///
-/// Identity is positional, not by name: `WindowManager::set_workareas`
-/// addresses monitors by their index in `Backend::monitors()`, which is
-/// why that method promises a stable order.
+/// The list position remains the live-layout address used by
+/// `WindowManager::set_workareas`, while `identity` is the stable
+/// hardware key a backend may provide for persistence across connector
+/// and enumeration-order changes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MonitorInfo {
     pub geometry: Rect,
     pub name: String,
+    /// Stable physical-display description (`make model serial`) when
+    /// the backend can read one. Connector names such as `DP-2` belong
+    /// to ports and deliberately do not stand in for this value.
+    pub identity: Option<String>,
     /// The output the desktop shell hangs its chrome on and that
     /// anything with no better anchor falls back to. At most one entry
     /// in a list may set this — see `Backend::monitors` for the full

--- a/crates/wm-core/src/fake_backend.rs
+++ b/crates/wm-core/src/fake_backend.rs
@@ -201,7 +201,12 @@ pub struct FakeBackend {
 impl FakeBackend {
     pub fn new() -> Self {
         Self {
-            monitors: vec![MonitorInfo { geometry: FAKE_SCREEN, name: "test-screen".to_string(), primary: true }],
+            monitors: vec![MonitorInfo {
+                geometry: FAKE_SCREEN,
+                name: "test-screen".to_string(),
+                identity: None,
+                primary: true,
+            }],
             ..Self::default()
         }
     }
@@ -231,7 +236,12 @@ impl FakeBackend {
     /// — how a test states the one screen it wants to measure against
     /// instead of the stock `FAKE_SCREEN`.
     pub fn set_monitor(&mut self, geometry: Rect) {
-        self.set_monitors(vec![MonitorInfo { geometry, name: "test-screen".to_string(), primary: true }]);
+        self.set_monitors(vec![MonitorInfo {
+            geometry,
+            name: "test-screen".to_string(),
+            identity: None,
+            primary: true,
+        }]);
     }
 
     /// Sets the whole monitor list, in the stable order

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -8269,8 +8269,8 @@ mod tests {
     /// arrangement every multi-monitor test below measures against.
     fn dual_monitors() -> Vec<MonitorInfo> {
         vec![
-            MonitorInfo { geometry: LEFT_HEAD, name: "left".to_string(), primary: true },
-            MonitorInfo { geometry: RIGHT_HEAD, name: "right".to_string(), primary: false },
+            MonitorInfo { geometry: LEFT_HEAD, name: "left".to_string(), identity: None, primary: true },
+            MonitorInfo { geometry: RIGHT_HEAD, name: "right".to_string(), identity: None, primary: false },
         ]
     }
 
@@ -8294,6 +8294,7 @@ mod tests {
         wm.backend_mut().set_monitors(vec![MonitorInfo {
             geometry: LEFT_HEAD,
             name: "left".to_string(),
+            identity: None,
             primary: true,
         }]);
         wm.rescue_clients_from_removed_monitor(RIGHT_HEAD);
@@ -8494,8 +8495,8 @@ mod tests {
         let bottom = Rect { pos: Point::new(0, 700), size: Size::new(800, 600) };
         let mut backend = FakeBackend::new();
         backend.set_monitors(vec![
-            MonitorInfo { geometry: top, name: "top".to_string(), primary: true },
-            MonitorInfo { geometry: bottom, name: "bottom".to_string(), primary: false },
+            MonitorInfo { geometry: top, name: "top".to_string(), identity: None, primary: true },
+            MonitorInfo { geometry: bottom, name: "bottom".to_string(), identity: None, primary: false },
         ]);
         let mut wm = wm(backend);
         let top_area = Rect { pos: Point::new(0, 0), size: Size::new(800, 560) };
@@ -8518,8 +8519,8 @@ mod tests {
         // assumption would reserve the dock strip on the wrong head.
         let mut backend = FakeBackend::new();
         backend.set_monitors(vec![
-            MonitorInfo { geometry: LEFT_HEAD, name: "aux".to_string(), primary: false },
-            MonitorInfo { geometry: RIGHT_HEAD, name: "main".to_string(), primary: true },
+            MonitorInfo { geometry: LEFT_HEAD, name: "aux".to_string(), identity: None, primary: false },
+            MonitorInfo { geometry: RIGHT_HEAD, name: "main".to_string(), identity: None, primary: true },
         ]);
         let mut wm = wm(backend);
         let reserved = Rect { pos: Point::new(800, 0), size: Size::new(800, 560) };

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -21,6 +21,7 @@ wm-theme = { path = "../wm-theme" }
 wm-theme-api = { path = "../wm-theme-api" }
 wm-config = { path = "../wm-config" }
 chonk-shell = { path = "../chonk-shell" }
+chonk-build-info = { path = "../chonk-build-info" }
 # The Hyprland IPC protocol, so Omarchy's unmodified shell and the real
 # `hyprctl` binary work against chonkstep. Deliberately a separate crate
 # with no dependency on `wm-core`: every JSON shape and parser in it is

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -37,8 +37,10 @@
 
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
+use smithay::backend::renderer::utils::with_renderer_surface_state;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::State as XdgToplevelState;
 use smithay::reexports::wayland_server::backend::protocol::ProtocolError;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::{Buffer, Logical, Rectangle as SmithayRect, Transform};
 use smithay::wayland::compositor::with_states;
@@ -165,6 +167,35 @@ fn set_combo_membership(combos: &mut Vec<KeyCombo>, combo: KeyCombo, enabled: bo
     }
 }
 
+impl WaylandBackend {
+    /// Cheap build/hardware half of `hyprctl systeminfo`. Kept apart
+    /// from the full diagnostic dump so routine compatibility queries
+    /// never walk every protocol object or `/proc` entry.
+    pub(crate) fn system_snapshot(&self) -> String {
+        use std::fmt::Write as _;
+
+        let mut report = format!("graphics {}\n", self.graphics_diagnostics);
+        for (index, monitor) in self.monitors.iter().enumerate() {
+            let scale = self.monitor_scales.get(index).copied().unwrap_or(1.0);
+            let hardware = self.monitor_outputs.get(index);
+            let _ = writeln!(
+                report,
+                "output index={} name={:?} x={} y={} w={} h={} scale={} refresh_millihertz={} transform={}",
+                index,
+                monitor.name,
+                monitor.geometry.pos.x,
+                monitor.geometry.pos.y,
+                monitor.geometry.size.w,
+                monitor.geometry.size.h,
+                scale,
+                hardware.map_or(0, |output| output.refresh_millihertz),
+                hardware.map_or(0, |output| output.transform),
+            );
+        }
+        report
+    }
+}
+
 impl Backend for WaylandBackend {
     type WindowId = WlWindowId;
     type FrameId = WlFrameId;
@@ -196,6 +227,173 @@ impl Backend for WaylandBackend {
         &self.monitors
     }
 
+    fn diagnostic_snapshot(&self) -> String {
+        use std::fmt::Write as _;
+
+        let mut report = String::new();
+        let last_damage = self
+            .last_damage_source
+            .map_or_else(|| "startup".to_string(), |location| format!("{}:{}", location.file(), location.line()));
+        let _ = writeln!(
+            report,
+            "state locked={} damage={} last_damage={} monitors={} windows={} frames={} layers={} shells={} ime_popups={}",
+            self.locked,
+            self.damage,
+            last_damage,
+            self.monitors.len(),
+            self.windows.len(),
+            self.frames.len(),
+            self.layers.len(),
+            self.shells.len(),
+            self.ime_popups.len(),
+        );
+        report.push_str(&self.system_snapshot());
+        let _ = writeln!(
+            report,
+            "focus pending={:?} pointer={:?} keyboard_grab={} pointer_grab={} pending_pointer_grab={}",
+            self.pending_focus,
+            self.pointer,
+            self.keyboard_grabbed,
+            self.pointer_grab.is_some(),
+            self.pending_pointer_grab.is_some(),
+        );
+        let _ = writeln!(report, "diagnostics {}", crate::diagnostics::describe());
+
+        report.push_str("scene bottom-to-top\n");
+        for entry in &self.stacking {
+            match entry {
+                StackEntry::Frame(id) => {
+                    let Some(frame) = self.frames.get(id) else { continue };
+                    let window = self.windows.get(&frame.window);
+                    let _ = writeln!(
+                        report,
+                        " frame id={} window={} x={} y={} w={} h={} mapped={} app={:?} title={:?}",
+                        id.0,
+                        frame.window.0,
+                        frame.geometry.pos.x,
+                        frame.geometry.pos.y,
+                        frame.geometry.size.w,
+                        frame.geometry.size.h,
+                        frame.mapped,
+                        window.and_then(|record| record.app_id.as_deref()).unwrap_or(""),
+                        window.and_then(|record| record.title.as_deref()).unwrap_or(""),
+                    );
+                }
+                StackEntry::Window(id) => {
+                    let Some(window) = self.windows.get(id) else { continue };
+                    let _ = writeln!(
+                        report,
+                        " window id={} x={} y={} w={} h={} mapped={} app={:?} title={:?}",
+                        id.0,
+                        window.content.pos.x,
+                        window.content.pos.y,
+                        window.content.size.w,
+                        window.content.size.h,
+                        window.mapped,
+                        window.app_id.as_deref().unwrap_or(""),
+                        window.title.as_deref().unwrap_or(""),
+                    );
+                }
+            }
+        }
+        for layer in &self.layers {
+            let _ = writeln!(
+                report,
+                " layer id={} output={} kind={:?} namespace={:?} x={} y={} w={} h={} mapped={} visible={}",
+                layer.id.0,
+                layer.output,
+                layer.layer,
+                layer.namespace,
+                layer.geometry.pos.x,
+                layer.geometry.pos.y,
+                layer.geometry.size.w,
+                layer.geometry.size.h,
+                layer.mapped,
+                self.layer_presented(layer),
+            );
+        }
+        for id in &self.shell_stacking {
+            let Some(shell) = self.shells.get(id) else { continue };
+            let _ = writeln!(
+                report,
+                " shell id={} x={} y={} w={} h={} mapped={} above={} buffer_bytes={}",
+                id.0,
+                shell.geometry.pos.x,
+                shell.geometry.pos.y,
+                shell.geometry.size.w,
+                shell.geometry.size.h,
+                shell.mapped,
+                shell.above,
+                shell.buffer_bytes,
+            );
+        }
+
+        let handle = self.display_handle.backend_handle();
+        let mut clients = Vec::new();
+        handle.with_all_clients(|client| clients.push(client));
+        clients.sort_by_key(|client| format!("{client:?}"));
+        report.push_str("clients\n");
+        for client_id in clients {
+            let credentials = handle.get_client_credentials(client_id.clone()).ok();
+            let pid = credentials.map(|credentials| credentials.pid);
+            let executable = pid
+                .and_then(|pid| std::fs::read_link(format!("/proc/{pid}/exe")).ok())
+                .and_then(|path| path.file_name().map(|name| name.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| "unknown".to_string());
+            let mut objects = Vec::new();
+            let _ = handle.with_all_objects_for(client_id.clone(), |object| objects.push(object));
+            let mut surfaces = 0usize;
+            let mut buffer_bytes = 0usize;
+            for object in objects {
+                if object.interface().name != "wl_surface" {
+                    continue;
+                }
+                surfaces = surfaces.saturating_add(1);
+                let Ok(surface) = WlSurface::from_id(&self.display_handle, object) else {
+                    continue;
+                };
+                let bytes = with_renderer_surface_state(&surface, |state| {
+                    if state.buffer().is_none() {
+                        return 0;
+                    }
+                    let Some(size) = state.buffer_size() else { return 0 };
+                    let scale = usize::try_from(state.buffer_scale()).unwrap_or(0);
+                    usize::try_from(size.w)
+                        .unwrap_or(0)
+                        .saturating_mul(usize::try_from(size.h).unwrap_or(0))
+                        .saturating_mul(scale)
+                        .saturating_mul(scale)
+                        .saturating_mul(4)
+                })
+                .unwrap_or(0);
+                buffer_bytes = buffer_bytes.saturating_add(bytes);
+            }
+            let _ = writeln!(
+                report,
+                " client id={:?} pid={} uid={} executable={:?} surfaces={} buffer_bytes_estimate={}",
+                client_id,
+                pid.map_or_else(|| "unknown".to_string(), |pid| pid.to_string()),
+                credentials.map_or_else(|| "unknown".to_string(), |credentials| credentials.uid.to_string()),
+                executable,
+                surfaces,
+                buffer_bytes,
+            );
+        }
+        report
+    }
+
+    fn set_diagnostic(&mut self, name: &str, enabled: bool) -> Result<(), String> {
+        crate::diagnostics::set(name, enabled)?;
+        // Plane-path and full-damage changes need one frame to take
+        // effect even when the desktop was otherwise idle.
+        self.mark_damaged();
+        Ok(())
+    }
+
+    fn set_log_filter(&mut self, directive: &str) -> Result<(), String> {
+        crate::diagnostics::set_log_filter(directive)
+    }
+
     // -- shell surfaces ---------------------------------------------------
     // On X11 these were override-redirect windows; here they are pure
     // scene records the renderer draws directly — creation cannot fail,
@@ -223,21 +421,21 @@ impl Backend for WaylandBackend {
     fn map_shell_surface(&mut self, id: Self::ShellId) {
         if let Some(shell) = self.shells.get_mut(&id) {
             shell.mapped = true;
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
     fn unmap_shell_surface(&mut self, id: Self::ShellId) {
         if let Some(shell) = self.shells.get_mut(&id) {
             shell.mapped = false;
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
     fn destroy_shell_surface(&mut self, id: Self::ShellId) {
         if self.shells.remove(&id).is_some() {
             self.shell_stacking.retain(|shell| *shell != id);
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -247,13 +445,13 @@ impl Backend for WaylandBackend {
         };
         let shell = self.shell_stacking.remove(index);
         self.shell_stacking.push(shell);
-        self.damage = true;
+        self.mark_damaged();
     }
 
     fn configure_shell_surface(&mut self, id: Self::ShellId, geometry: Rect) {
         if let Some(shell) = self.shells.get_mut(&id) {
             shell.geometry = geometry;
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -262,7 +460,7 @@ impl Backend for WaylandBackend {
             if let Some(imported) = import_buffer(buffer, false) {
                 shell.buffer = Some(imported);
                 shell.buffer_bytes = buffer.pixels.len();
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
@@ -271,14 +469,14 @@ impl Backend for WaylandBackend {
         if let Some(shell) = self.shells.get_mut(&id) {
             if shell.buffer.take().is_some() {
                 shell.buffer_bytes = 0;
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
 
     fn paint_root_color(&mut self, rgb: (u8, u8, u8)) {
         self.root_background = RootBackground::Color(rgb);
-        self.damage = true;
+        self.mark_damaged();
     }
 
     fn set_layer_surface_hidden(&mut self, namespace: &str, hidden: bool) {
@@ -293,7 +491,7 @@ impl Backend for WaylandBackend {
             // to poke.
             self.layer_layout_dirty = true;
             self.idle_policy_dirty = true;
-            self.damage = true;
+            self.mark_damaged();
             tracing::info!(namespace, hidden, "layer surface visibility changed");
         }
     }
@@ -303,7 +501,7 @@ impl Backend for WaylandBackend {
         // installing a zero-sized image nothing can render.
         if let Some(imported) = import_buffer(buffer, true) {
             self.root_background = RootBackground::Image(imported);
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -627,7 +825,7 @@ impl Backend for WaylandBackend {
         if let Some(record) = self.frames.remove(&frame) {
             self.stacking.retain(|entry| !matches!(entry, StackEntry::Frame(f) if *f == frame));
             self.sync_managed_scene_index(record.window);
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -666,14 +864,14 @@ impl Backend for WaylandBackend {
             }
         }
         self.sync_managed_scene_index(window);
-        self.damage = true;
+        self.mark_damaged();
     }
 
     fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
         if let Some(record) = self.frames.get_mut(&frame) {
             if let Some(imported) = import_buffer(buffer, true) {
                 record.buffer = Some(imported);
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
@@ -700,7 +898,7 @@ impl Backend for WaylandBackend {
         // still (a keybinding resize ending under it), and without the
         // flag the old cursor would linger until something else moved.
         if changed {
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -746,7 +944,7 @@ impl Backend for WaylandBackend {
                 }
             }
         }
-        self.damage = true;
+        self.mark_damaged();
     }
 
     fn resize_client(&mut self, window: Self::WindowId, size: Size) {
@@ -844,7 +1042,7 @@ impl Backend for WaylandBackend {
             // allocator churn after the first resize.
             self.note_popup_parent_resize(root);
         }
-        self.damage = true;
+        self.mark_damaged();
     }
 
     fn configure_unmanaged(&mut self, window: Self::WindowId, geometry: Rect) {
@@ -892,7 +1090,7 @@ impl Backend for WaylandBackend {
             self.note_configure(window);
         }
         if mapped {
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -906,7 +1104,7 @@ impl Backend for WaylandBackend {
             self.sync_managed_scene_index(window);
             if changed {
                 self.idle_policy_dirty = true;
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
@@ -921,7 +1119,7 @@ impl Backend for WaylandBackend {
             self.sync_managed_scene_index(window);
             if changed {
                 self.idle_policy_dirty = true;
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
@@ -954,7 +1152,7 @@ impl Backend for WaylandBackend {
         self.sync_managed_scene_index(window);
         if changed {
             self.idle_policy_dirty = true;
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -971,7 +1169,7 @@ impl Backend for WaylandBackend {
             self.sync_managed_scene_index(window);
             if changed {
                 self.idle_policy_dirty = true;
-                self.damage = true;
+                self.mark_damaged();
             }
         }
     }
@@ -989,7 +1187,7 @@ impl Backend for WaylandBackend {
         self.sync_managed_scene_index(window);
         if changed {
             self.idle_policy_dirty = true;
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -997,7 +1195,7 @@ impl Backend for WaylandBackend {
 
     fn raise(&mut self, frame: Self::FrameId) {
         if raise_stack_entry(&mut self.stacking, StackEntry::Frame(frame)) {
-            self.damage = true;
+            self.mark_damaged();
             self.stacking_dirty = true;
         }
     }
@@ -1017,7 +1215,7 @@ impl Backend for WaylandBackend {
     /// for the whole life of the window.
     fn raise_frameless(&mut self, window: Self::WindowId) {
         if raise_stack_entry(&mut self.stacking, StackEntry::Window(window)) {
-            self.damage = true;
+            self.mark_damaged();
             self.stacking_dirty = true;
         }
     }
@@ -1039,7 +1237,7 @@ impl Backend for WaylandBackend {
         let before = self.stacking.clone();
         self.stacking.retain(|entry| !matches!(entry, StackEntry::Frame(f) if order_back_to_front.contains(f)));
         self.stacking.extend(listed);
-        self.damage = true;
+        self.mark_damaged();
         // Compared rather than assumed: `restack` is called from the
         // workspace-switch and Alt-Tab paths on every pass they run,
         // and a "dirty" that meant "mentioned" would grab the X server
@@ -1213,7 +1411,7 @@ impl Backend for WaylandBackend {
         // discards content the way an unmapped X11 window loses its
         // pixels, so there is nothing to ask the client to repaint;
         // redrawing our own scene from the retained buffers suffices.
-        self.damage = true;
+        self.mark_damaged();
     }
 
     // -- EWMH-shaped policy reads/acts ------------------------------------
@@ -1404,7 +1602,7 @@ impl Backend for WaylandBackend {
             // but band occlusion is independently visible policy. Its
             // own damage edge keeps a same-sized fullscreen transition
             // (and its inverse) from waiting for unrelated damage.
-            self.damage = true;
+            self.mark_damaged();
         }
     }
 
@@ -1561,7 +1759,7 @@ impl Backend for WaylandBackend {
                 }
             }
         }
-        self.damage = true;
+        self.mark_damaged();
         if kind == WindowType::Unmanaged {
             self.scene_index.mark_unmanaged(window);
         } else {
@@ -1601,7 +1799,7 @@ impl Backend for WaylandBackend {
                 }
             }
         }
-        self.damage = true;
+        self.mark_damaged();
     }
 
     // A compositor sees every click before any client does, so there is

--- a/crates/wm-wayland/src/diagnostics.rs
+++ b/crates/wm-wayland/src/diagnostics.rs
@@ -1,0 +1,82 @@
+//! Live diagnostic controls shared by the control socket and hot paths.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Once, OnceLock};
+
+static INIT: Once = Once::new();
+static DAMAGE_LOG: AtomicBool = AtomicBool::new(false);
+static IDLE_LOG: AtomicBool = AtomicBool::new(false);
+static FULL_DAMAGE: AtomicBool = AtomicBool::new(false);
+static NO_DIRECT_SCANOUT: AtomicBool = AtomicBool::new(false);
+static NO_CURSOR_PLANE: AtomicBool = AtomicBool::new(false);
+
+type ReloadFilter = dyn Fn(&str) -> Result<(), String> + Send + Sync;
+static LOG_FILTER: OnceLock<Box<ReloadFilter>> = OnceLock::new();
+
+fn env_enabled(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| value != "0")
+}
+
+pub(crate) fn init() {
+    INIT.call_once(|| {
+        DAMAGE_LOG.store(env_enabled("CHONKSTEP_DAMAGE_LOG"), Ordering::Relaxed);
+        IDLE_LOG.store(env_enabled("CHONKSTEP_IDLE_LOG"), Ordering::Relaxed);
+        FULL_DAMAGE.store(env_enabled("CHONKSTEP_FULL_DAMAGE"), Ordering::Relaxed);
+        NO_DIRECT_SCANOUT.store(env_enabled("CHONKSTEP_NO_DIRECT_SCANOUT"), Ordering::Relaxed);
+        NO_CURSOR_PLANE.store(env_enabled("CHONKSTEP_NO_CURSOR_PLANE"), Ordering::Relaxed);
+    });
+}
+
+fn value(name: &str) -> Option<&'static AtomicBool> {
+    init();
+    match name {
+        "damage-log" => Some(&DAMAGE_LOG),
+        "idle-log" => Some(&IDLE_LOG),
+        "full-damage" => Some(&FULL_DAMAGE),
+        "no-direct-scanout" => Some(&NO_DIRECT_SCANOUT),
+        "no-cursor-plane" => Some(&NO_CURSOR_PLANE),
+        _ => None,
+    }
+}
+
+pub(crate) fn enabled(name: &str) -> bool {
+    value(name).is_some_and(|value| value.load(Ordering::Relaxed))
+}
+
+pub(crate) fn set(name: &str, enabled: bool) -> Result<(), String> {
+    let value = value(name).ok_or_else(|| {
+        format!(
+            "unknown diagnostic {name}; expected damage-log, idle-log, full-damage, no-direct-scanout or no-cursor-plane"
+        )
+    })?;
+    value.store(enabled, Ordering::Relaxed);
+    tracing::info!(diagnostic = name, enabled, "live diagnostic changed");
+    Ok(())
+}
+
+pub(crate) fn describe() -> String {
+    [
+        "damage-log",
+        "idle-log",
+        "full-damage",
+        "no-direct-scanout",
+        "no-cursor-plane",
+    ]
+    .into_iter()
+    .map(|name| format!("{name}={}", enabled(name)))
+    .collect::<Vec<_>>()
+    .join(" ")
+}
+
+pub fn install_log_filter_reloader(
+    reload: impl Fn(&str) -> Result<(), String> + Send + Sync + 'static,
+) -> Result<(), &'static str> {
+    LOG_FILTER.set(Box::new(reload)).map_err(|_| "a log-filter reloader is already installed")
+}
+
+pub(crate) fn set_log_filter(directive: &str) -> Result<(), String> {
+    let reload = LOG_FILTER.get().ok_or_else(|| "this binary did not install a reloadable tracing filter".to_string())?;
+    reload(directive)?;
+    tracing::info!(filter = directive, "live tracing filter changed");
+    Ok(())
+}

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -134,7 +134,7 @@ fn build_snapshot(
         .map(|(index, info)| Monitor {
             id: i32::try_from(index).unwrap_or(i32::MAX),
             name: info.name.clone(),
-            description: info.name.clone(),
+            description: info.identity.clone().unwrap_or_else(|| info.name.clone()),
             x: info.geometry.pos.x,
             y: info.geometry.pos.y,
             width: i32::try_from(info.geometry.size.w).unwrap_or(i32::MAX),
@@ -156,6 +156,7 @@ fn build_snapshot(
             model: hardware(wm, index).map(|out| out.model.clone()).unwrap_or_default(),
             serial: hardware(wm, index).map(|out| out.serial.clone()).unwrap_or_default(),
             refresh_millihertz: hardware(wm, index).map_or(0, |out| out.refresh_millihertz),
+            transform: hardware(wm, index).map_or(0, |out| out.transform),
             modes: hardware(wm, index).map(|out| out.modes.clone()).unwrap_or_default(),
         })
         .collect();
@@ -333,6 +334,23 @@ fn build_snapshot(
         bindings,
         config_errors: session.config_diagnostics.clone(),
         devices,
+        system_info: if include_bindings {
+            format!(
+                "ChonkStep {}\nsource: {}\nconfig: {}\nworkspace: {}\noutputs: {}\n{}",
+                env!("CARGO_PKG_VERSION"),
+                chonk_build_info::SOURCE_ID,
+                wm_config::config_path()
+                    .map_or_else(|| "defaults (HOME unavailable)".to_string(), |path| path.display().to_string()),
+                wm.current_workspace() + 1,
+                monitors_info.len(),
+                wm.backend().system_snapshot(),
+            )
+        } else {
+            // Event clients never receive this request-only field.
+            // Leaving it empty keeps /proc and protocol-object walks
+            // off ordinary state publication.
+            String::new()
+        },
     }
 }
 
@@ -563,10 +581,45 @@ pub(crate) fn apply(comp: &mut Compositor, action: Action) -> bool {
         Action::SetTag { window, tag, present } => client_of(wm, window).is_some_and(|id| wm.set_client_tag(id, &tag, present)),
         Action::ConfirmFloating(window) => client_of(wm, window).is_some(),
         Action::SetMonitorScale { output, scale_120 } => comp.set_output_scale(&output, scale_120 as f64 / 120.0),
+        Action::SetCursorHidden(hidden) => {
+            let owner = hidden.then(|| {
+                comp.seat
+                    .get_keyboard()
+                    .and_then(|keyboard| keyboard.current_focus())
+                    .or_else(|| comp.seat.get_pointer().and_then(|pointer| pointer.current_focus()))
+            });
+            let owner = owner.flatten();
+            let backend = comp.wm.backend_mut();
+            let changed = backend.cursor_hidden != hidden;
+            backend.cursor_hidden = hidden;
+            backend.cursor_hidden_owner = if hidden {
+                owner.or_else(|| backend.cursor_hidden_owner.clone())
+            } else {
+                None
+            };
+            if changed {
+                backend.mark_damaged();
+            }
+            true
+        }
         Action::ReloadConfig => {
             comp.shell.reload_config(&mut comp.wm);
             true
         }
+        Action::SetDiagnostic { name, enabled } => match wm.backend_mut().set_diagnostic(&name, enabled) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(%error, diagnostic = name, "live diagnostic request refused");
+                false
+            }
+        },
+        Action::SetLogFilter(directive) => match wm.backend_mut().set_log_filter(&directive) {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!(%error, filter = directive, "live log-filter request refused");
+                false
+            }
+        },
         Action::ExecShell(command) => chonk_shell::spawn::spawn_detached("sh", &["-c", &command]).is_some(),
         Action::ExecArgv(argv) => {
             let Some((program, args)) = argv.split_first() else {

--- a/crates/wm-wayland/src/idle.rs
+++ b/crates/wm-wayland/src/idle.rs
@@ -247,8 +247,7 @@ pub(crate) fn refresh(comp: &mut Compositor) {
 }
 
 fn idle_log_enabled() -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ENABLED.get_or_init(|| std::env::var_os("CHONKSTEP_IDLE_LOG").is_some_and(|value| value != "0"))
+    crate::diagnostics::enabled("idle-log")
 }
 
 /// Whether the window or layer surface owning `surface` is mapped.

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -3530,6 +3530,7 @@ mod tests {
         MonitorInfo {
             geometry: Rect { pos: Point::new(x, y), size: Size::new(w, h) },
             name: format!("test-{x}x{y}"),
+            identity: None,
             primary: x == 0 && y == 0,
         }
     }

--- a/crates/wm-wayland/src/layers.rs
+++ b/crates/wm-wayland/src/layers.rs
@@ -76,15 +76,22 @@
 
 use smithay::backend::renderer::utils::with_renderer_surface_state;
 use smithay::desktop::{find_popup_root_surface, PopupKind};
-use smithay::delegate_layer_shell;
 use smithay::output::Output;
+use smithay::reexports::wayland_protocols_wlr::layer_shell::v1::server::{
+    zwlr_layer_shell_v1::ZwlrLayerShellV1,
+    zwlr_layer_surface_v1::{self, ZwlrLayerSurfaceV1},
+};
+use smithay::reexports::wayland_server::{
+    backend::ClientId, Client, DataInit, Dispatch, DisplayHandle, Resource,
+};
 use smithay::reexports::wayland_server::protocol::wl_output::WlOutput;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::SERIAL_COUNTER;
 use smithay::wayland::compositor::{add_pre_commit_hook, with_states};
 use smithay::wayland::shell::wlr_layer::{
     Anchor, ExclusiveZone, KeyboardInteractivity, Layer, LayerSurface, LayerSurfaceCachedState, Margins,
-    WlrLayerShellHandler, WlrLayerShellState, LAYER_SURFACE_ROLE,
+    WlrLayerShellGlobalData, WlrLayerShellHandler, WlrLayerShellState,
+    WlrLayerSurfaceUserData, LAYER_SURFACE_ROLE,
 };
 use smithay::wayland::shell::xdg::PopupSurface;
 
@@ -249,10 +256,19 @@ pub(crate) fn exclusive_edge(anchor: Anchor) -> Option<Anchor> {
 pub(crate) fn shrink(area: Rect, insets: EdgeInsets) -> Rect {
     let left = insets.left.max(0);
     let top = insets.top.max(0);
-    let width = (area.size.w as i32 - left - insets.right.max(0)).max(0);
-    let height = (area.size.h as i32 - top - insets.bottom.max(0)).max(0);
+    let width = (area.size.w as i32)
+        .saturating_sub(left)
+        .saturating_sub(insets.right.max(0))
+        .max(0);
+    let height = (area.size.h as i32)
+        .saturating_sub(top)
+        .saturating_sub(insets.bottom.max(0))
+        .max(0);
     Rect::new(
-        Point::new(area.pos.x + left.min(area.size.w as i32), area.pos.y + top.min(area.size.h as i32)),
+        Point::new(
+            area.pos.x.saturating_add(left.min(area.size.w as i32)),
+            area.pos.y.saturating_add(top.min(area.size.h as i32)),
+        ),
         Size::new(width as u32, height as u32),
     )
 }
@@ -273,9 +289,12 @@ fn axis_place(
     margin_far: i32,
 ) -> i32 {
     match (near, far) {
-        (true, false) => area_start + margin_near,
-        (false, true) => area_start + area_len - margin_far - len,
-        _ => area_start + (area_len - len) / 2,
+        (true, false) => area_start.saturating_add(margin_near),
+        (false, true) => area_start
+            .saturating_add(area_len)
+            .saturating_sub(margin_far)
+            .saturating_sub(len),
+        _ => area_start.saturating_add(area_len.saturating_sub(len) / 2),
     }
 }
 
@@ -288,7 +307,10 @@ fn axis_size(requested: i32, area_len: i32, margin_near: i32, margin_far: i32) -
     if requested > 0 {
         requested
     } else {
-        (area_len - margin_near - margin_far).max(1)
+        area_len
+            .saturating_sub(margin_near)
+            .saturating_sub(margin_far)
+            .max(1)
     }
 }
 
@@ -296,10 +318,12 @@ fn axis_size(requested: i32, area_len: i32, margin_near: i32, margin_far: i32) -
 /// size (stretch axes filled from the area), then anchors it. `size`
 /// and `margins` are already physical.
 pub(crate) fn anchored_rect(area: Rect, size: Size, anchor: Anchor, margins: EdgeInsets) -> Rect {
+    let width = i32::try_from(size.w).unwrap_or(i32::MAX);
+    let height = i32::try_from(size.h).unwrap_or(i32::MAX);
     let x = axis_place(
         area.pos.x,
         area.size.w as i32,
-        size.w as i32,
+        width,
         anchor.contains(Anchor::LEFT),
         anchor.contains(Anchor::RIGHT),
         margins.left,
@@ -308,7 +332,7 @@ pub(crate) fn anchored_rect(area: Rect, size: Size, anchor: Anchor, margins: Edg
     let y = axis_place(
         area.pos.y,
         area.size.h as i32,
-        size.h as i32,
+        height,
         anchor.contains(Anchor::TOP),
         anchor.contains(Anchor::BOTTOM),
         margins.top,
@@ -335,10 +359,14 @@ pub(crate) fn resolved_size(requested: Size, area: Rect, margins: EdgeInsets) ->
 pub(crate) fn reserve(insets: &mut EdgeInsets, edge: Anchor, zone: i32, margins: EdgeInsets) {
     let zone = zone.max(0);
     match edge {
-        Anchor::TOP => insets.top += zone + margins.top.max(0),
-        Anchor::BOTTOM => insets.bottom += zone + margins.bottom.max(0),
-        Anchor::LEFT => insets.left += zone + margins.left.max(0),
-        Anchor::RIGHT => insets.right += zone + margins.right.max(0),
+        Anchor::TOP => insets.top = insets.top.saturating_add(zone.saturating_add(margins.top.max(0))),
+        Anchor::BOTTOM => {
+            insets.bottom = insets.bottom.saturating_add(zone.saturating_add(margins.bottom.max(0)))
+        }
+        Anchor::LEFT => insets.left = insets.left.saturating_add(zone.saturating_add(margins.left.max(0))),
+        Anchor::RIGHT => {
+            insets.right = insets.right.saturating_add(zone.saturating_add(margins.right.max(0)))
+        }
         _ => {}
     }
 }
@@ -350,8 +378,16 @@ pub(crate) fn reserve(insets: &mut EdgeInsets, edge: Anchor, zone: i32, margins:
 fn intersect(a: Rect, b: Rect) -> Option<Rect> {
     let left = a.pos.x.max(b.pos.x);
     let top = a.pos.y.max(b.pos.y);
-    let right = (a.pos.x + a.size.w as i32).min(b.pos.x + b.size.w as i32);
-    let bottom = (a.pos.y + a.size.h as i32).min(b.pos.y + b.size.h as i32);
+    let right = a
+        .pos
+        .x
+        .saturating_add(a.size.w as i32)
+        .min(b.pos.x.saturating_add(b.size.w as i32));
+    let bottom = a
+        .pos
+        .y
+        .saturating_add(a.size.h as i32)
+        .min(b.pos.y.saturating_add(b.size.h as i32));
     if right <= left || bottom <= top {
         return None;
     }
@@ -575,7 +611,7 @@ fn plan_surface(
     record.interactivity = cached.keyboard_interactivity;
     if record.geometry != geometry {
         record.geometry = geometry;
-        backend.damage = true;
+        backend.mark_damaged();
     }
     if layer_changed {
         // `declined` is a function of layer + namespace, so a client
@@ -954,6 +990,7 @@ impl WlrLayerShellHandler for Compositor {
         &mut self.layer_shell.state
     }
 
+    #[tracing::instrument(name = "new_layer_surface", skip_all)]
     fn new_layer_surface(
         &mut self,
         surface: LayerSurface,
@@ -1022,7 +1059,59 @@ impl WlrLayerShellHandler for Compositor {
     }
 }
 
-delegate_layer_shell!(Compositor);
+// Smithay 0.7 casts the protocol's unsigned size directly to `i32`
+// before constructing its geometry type. Values above `i32::MAX`
+// therefore become negative and trip a compositor-side debug assert.
+// Keep Smithay's implementation for the complete protocol, but guard
+// that one lossy conversion at the wire boundary and kill only the
+// offending client with the protocol's own `invalid_size` error.
+impl Dispatch<ZwlrLayerSurfaceV1, WlrLayerSurfaceUserData> for Compositor {
+    fn request(
+        state: &mut Self,
+        client: &Client,
+        resource: &ZwlrLayerSurfaceV1,
+        request: zwlr_layer_surface_v1::Request,
+        data: &WlrLayerSurfaceUserData,
+        display_handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        match request {
+            zwlr_layer_surface_v1::Request::SetSize { width, height }
+                if width > i32::MAX as u32 || height > i32::MAX as u32 =>
+            {
+                resource.post_error(
+                    zwlr_layer_surface_v1::Error::InvalidSize,
+                    format!("layer surface size {width}x{height} exceeds the compositor geometry limit"),
+                );
+            }
+            request => <WlrLayerShellState as Dispatch<
+                ZwlrLayerSurfaceV1,
+                WlrLayerSurfaceUserData,
+                Compositor,
+            >>::request(state, client, resource, request, data, display_handle, data_init),
+        }
+    }
+
+    fn destroyed(
+        state: &mut Self,
+        client_id: ClientId,
+        resource: &ZwlrLayerSurfaceV1,
+        data: &WlrLayerSurfaceUserData,
+    ) {
+        <WlrLayerShellState as Dispatch<
+            ZwlrLayerSurfaceV1,
+            WlrLayerSurfaceUserData,
+            Compositor,
+        >>::destroyed(state, client_id, resource, data);
+    }
+}
+
+smithay::reexports::wayland_server::delegate_dispatch!(Compositor: [
+    ZwlrLayerShellV1: ()
+] => WlrLayerShellState);
+smithay::reexports::wayland_server::delegate_global_dispatch!(Compositor: [
+    ZwlrLayerShellV1: WlrLayerShellGlobalData
+] => WlrLayerShellState);
 
 #[cfg(test)]
 mod tests {

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -29,6 +29,7 @@ mod core_protocols;
 mod ctm;
 mod data_control;
 mod decoration;
+mod diagnostics;
 mod dmabuf;
 // hyprland-focus-grab-v1: click-outside-to-dismiss for shells that ask
 // for it (Omarchy's Quickshell asks on every popup). The one module
@@ -65,3 +66,4 @@ mod xewmh;
 mod xwayland;
 
 pub use state::{run, Compositor, WaylandBackend, WlFrameId, WlShellId, WlWindowId};
+pub use diagnostics::install_log_filter_reloader;

--- a/crates/wm-wayland/src/output_mgmt.rs
+++ b/crates/wm-wayland/src/output_mgmt.rs
@@ -29,13 +29,15 @@
 //!   (`session::apply_mode` re-programs the crtc); the nested backend's
 //!   one output is the host window and honestly refuses any mode but
 //!   the current one — a window cannot modeset its host desktop.
-//! - **Disable, transform, adaptive sync** are refused with `failed()`
-//!   and a log line naming the gap. Disabling means tearing an output
+//! - **Transform** applies on the DRM session backend for the four
+//!   non-flipped rotations; the nested backend truthfully refuses it
+//!   because its one output is the host window.
+//! - **Disable and adaptive sync** are refused with `failed()` and a
+//!   log line naming the gap. Disabling means tearing an output
 //!   out of three index-aligned lists (`Compositor::outputs`, the
 //!   ledger's monitors, the session's crtcs) that the lock module and
-//!   the shell hold indices into; transforms would be the first
-//!   non-`Normal`/`Flipped180` transform in the compositor. Both are
-//!   real work, and a truthful `failed` beats a lying `succeeded`.
+//!   the shell hold indices into. A truthful `failed` beats a lying
+//!   `succeeded`.
 //!
 //! When no output manager is bound, publication is an immediate fast
 //! path. Once one binds, retained snapshots keep unchanged passes both
@@ -74,6 +76,7 @@ use smithay::reexports::wayland_protocols_wlr::output_management::v1::server::zw
 use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, WEnum,
 };
+use smithay::utils::Transform;
 
 use wm_theme_api::{Point, Size};
 
@@ -133,6 +136,7 @@ struct HeadSnapshot {
     position: Point,
     scale: f64,
     current_mode: usize,
+    transform: Transform,
 }
 
 /// What one configuration asked for on one head.
@@ -307,6 +311,7 @@ fn head_snapshot(entry: &crate::state::OutputEntry) -> HeadSnapshot {
         position: entry.position,
         scale: entry.scale,
         current_mode: current_mode_index(entry),
+        transform: entry.transform,
     }
 }
 
@@ -322,6 +327,44 @@ fn current_mode_index(entry: &crate::state::OutputEntry) -> usize {
         .iter()
         .position(|mode| mode.size == current.size && mode.refresh == current.refresh)
         .unwrap_or(0)
+}
+
+fn protocol_transform(transform: Transform) -> smithay::reexports::wayland_server::protocol::wl_output::Transform {
+    use smithay::reexports::wayland_server::protocol::wl_output::Transform as WlTransform;
+    match transform {
+        Transform::Normal => WlTransform::Normal,
+        Transform::_90 => WlTransform::_90,
+        Transform::_180 => WlTransform::_180,
+        Transform::_270 => WlTransform::_270,
+        Transform::Flipped => WlTransform::Flipped,
+        Transform::Flipped90 => WlTransform::Flipped90,
+        Transform::Flipped180 => WlTransform::Flipped180,
+        Transform::Flipped270 => WlTransform::Flipped270,
+    }
+}
+
+fn requested_transform(value: i32) -> Option<Transform> {
+    match value {
+        0 => Some(Transform::Normal),
+        1 => Some(Transform::_90),
+        2 => Some(Transform::_180),
+        3 => Some(Transform::_270),
+        _ => None,
+    }
+}
+
+fn matching_mode_index(entry: &crate::state::OutputEntry, width: i32, height: i32, refresh: i32) -> Option<usize> {
+    entry
+        .modes
+        .iter()
+        .enumerate()
+        .filter(|(_, mode)| {
+            mode.size.w == width
+                && mode.size.h == height
+                && crate::state::refresh_matches(mode.refresh, refresh)
+        })
+        .min_by_key(|(_, mode)| if refresh == 0 { i32::MAX - mode.refresh } else { mode.refresh.abs_diff(refresh) as i32 })
+        .map(|(index, _)| index)
 }
 
 /// Creates one head (and its modes) on one manager and sends its
@@ -349,7 +392,9 @@ fn announce_head(
     };
     manager.resource.head(&head);
     head.name(entry.output.name());
-    head.description(format!("{} ({})", entry.output.name(), entry.output.physical_properties().model));
+    head.description(entry.identity.clone().unwrap_or_else(|| {
+        format!("{} ({})", entry.output.name(), entry.output.physical_properties().model)
+    }));
     let physical = entry.output.physical_properties().size;
     if physical.w > 0 && physical.h > 0 {
         head.physical_size(physical.w, physical.h);
@@ -391,11 +436,7 @@ fn announce_head(
         head.current_mode(mode);
     }
     head.position(entry.position.x, entry.position.y);
-    // Every output is composed un-transformed; the nested backend's
-    // Flipped180 is an EGL-surface correction, not a user-visible
-    // orientation, and reporting it would make wlr-randr claim the
-    // desktop is upside down.
-    head.transform(smithay::reexports::wayland_server::protocol::wl_output::Transform::Normal);
+    head.transform(protocol_transform(entry.transform));
     head.scale(entry.scale);
     if version >= 4 {
         head.adaptive_sync(AdaptiveSyncState::Disabled);
@@ -410,6 +451,9 @@ fn update_head(head: &HeadInstance, entry: &crate::state::OutputEntry, previous:
     }
     if (entry.scale - previous.scale).abs() > f64::EPSILON {
         head.resource.scale(entry.scale);
+    }
+    if entry.transform != previous.transform {
+        head.resource.transform(protocol_transform(entry.transform));
     }
     let current = current_mode_index(entry);
     if current != previous.current_mode {
@@ -442,9 +486,11 @@ fn validate(comp: &Compositor, config: &ConfigState) -> Result<Vec<(usize, HeadC
             ));
         }
         if let Some(transform) = head.transform {
-            // wl_output.transform normal = 0.
-            if transform != 0 {
-                return Err(format!("rotating {name}: output transforms are not supported yet"));
+            let Some(transform) = requested_transform(transform) else {
+                return Err(format!("transform {transform} on {name}: only rotations 0, 90, 180 and 270 are supported"));
+            };
+            if matches!(comp.graphics, crate::state::Graphics::Winit(_)) && transform != Transform::Normal {
+                return Err(format!("rotating {name}: the nested backend reserves its transform for the host surface"));
             }
         }
         if head.adaptive_sync == Some(true) {
@@ -470,11 +516,7 @@ fn validate(comp: &Compositor, config: &ConfigState) -> Result<Vec<(usize, HeadC
             // hardware actually advertises — a mode the display never
             // offered is a mode it will refuse, and the nested output
             // has no modes to set at all.
-            let matched = entry.modes.iter().position(|mode| {
-                mode.size.w == w
-                    && mode.size.h == h
-                    && (refresh == 0 || mode.refresh == refresh)
-            });
+            let matched = matching_mode_index(entry, w, h, refresh);
             match matched {
                 Some(mode) if crate::session::mode_is_applicable(&comp.graphics, index, mode) => {}
                 _ => {
@@ -500,6 +542,7 @@ fn perform_pending_apply(comp: &mut Compositor) {
     };
     let mut scaled_any = false;
     let mut moved_any = false;
+    let mut first_error: Option<String> = None;
     for (index, head) in &pending.heads {
         if let Some(scale) = head.scale {
             let entry = &mut comp.outputs[*index];
@@ -518,15 +561,29 @@ fn perform_pending_apply(comp: &mut Compositor) {
         }
         let mode = head.mode.or_else(|| {
             head.custom_mode.and_then(|(w, h, refresh)| {
-                comp.outputs[*index].modes.iter().position(|mode| {
-                    mode.size.w == w && mode.size.h == h && (refresh == 0 || mode.refresh == refresh)
-                })
+                matching_mode_index(&comp.outputs[*index], w, h, refresh)
             })
         });
         if let Some(mode_index) = mode {
             if mode_index != current_mode_index(&comp.outputs[*index]) {
-                apply_mode(comp, *index, mode_index);
-                moved_any = true; // sizes changed; re-layout below.
+                match apply_mode(comp, *index, mode_index) {
+                    Ok(()) => moved_any = true, // sizes changed; re-layout below.
+                    Err(error) => {
+                        tracing::warn!(%error, output = %comp.outputs[*index].output.name(), "modeset failed; publishing the unchanged real mode");
+                        first_error.get_or_insert(error);
+                    }
+                }
+            }
+        }
+        if let Some(transform) = head.transform.and_then(requested_transform) {
+            if transform != comp.outputs[*index].transform {
+                match apply_transform(comp, *index, transform) {
+                    Ok(()) => moved_any = true,
+                    Err(error) => {
+                        tracing::warn!(%error, output = %comp.outputs[*index].output.name(), "output rotation failed; publishing the unchanged real transform");
+                        first_error.get_or_insert(error);
+                    }
+                }
             }
         }
         if let Some((x, y)) = head.position {
@@ -547,27 +604,48 @@ fn perform_pending_apply(comp: &mut Compositor) {
         relayout_ledger(comp);
         comp.layer_shell.needs_arrange = true;
     }
-    pending.resource.succeeded();
+    if let Some(error) = first_error {
+        tracing::warn!(%error, "wlr-output-management configuration was only partially applied");
+        pending.resource.failed();
+    } else {
+        pending.resource.succeeded();
+    }
 }
 
 /// Applies one mode change to one output: the crtc (session backend),
 /// the advertised `wl_output` mode, the entry's size, and the damage
 /// tracker sized to it.
-fn apply_mode(comp: &mut Compositor, index: usize, mode_index: usize) {
+fn apply_mode(comp: &mut Compositor, index: usize, mode_index: usize) -> Result<(), String> {
     let mode = comp.outputs[index].modes[mode_index];
-    if let Err(error) = crate::session::apply_mode(&mut comp.graphics, index, mode_index) {
-        tracing::warn!(%error, output = %comp.outputs[index].output.name(), "modeset failed; the output keeps its mode");
-        return;
-    }
+    crate::session::apply_mode(&mut comp.graphics, index, mode_index)?;
     let entry = &mut comp.outputs[index];
     entry.output.change_current_state(Some(mode), None, None, None);
-    entry.size = Size::new(mode.size.w.max(0) as u32, mode.size.h.max(0) as u32);
+    let transformed = entry.transform.transform_size(mode.size);
+    entry.size = Size::new(transformed.w.max(0) as u32, transformed.h.max(0) as u32);
     entry.damage_tracker = crate::state::physical_damage_tracker(&entry.output, entry.size);
     tracing::info!(
         output = %entry.output.name(),
         mode = %format!("{}x{}@{}", mode.size.w, mode.size.h, mode.refresh),
         "mode set via wlr-output-management"
     );
+    Ok(())
+}
+
+fn apply_transform(comp: &mut Compositor, index: usize, transform: Transform) -> Result<(), String> {
+    crate::session::apply_transform(&mut comp.graphics, index, transform)?;
+    let entry = &mut comp.outputs[index];
+    let mode = entry.output.current_mode().ok_or_else(|| format!("{} has no current mode", entry.output.name()))?;
+    entry.transform = transform;
+    entry.output.change_current_state(None, Some(transform), None, None);
+    let transformed = transform.transform_size(mode.size);
+    entry.size = Size::new(transformed.w.max(0) as u32, transformed.h.max(0) as u32);
+    entry.damage_tracker = crate::state::physical_damage_tracker(&entry.output, entry.size);
+    tracing::info!(
+        output = %entry.output.name(),
+        transform = crate::state::transform_number(transform),
+        "output rotated via wlr-output-management"
+    );
+    Ok(())
 }
 
 /// Translates the whole layout so its bounding box starts at the global
@@ -917,7 +995,7 @@ fn relayout_ledger(comp: &mut Compositor) {
     }
     backend.output_size = crate::state::union_size(&backend.monitors);
     backend.pending_resize = Some(backend.output_size);
-    backend.damage = true;
+    backend.mark_damaged();
 }
 
 #[cfg(test)]

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -87,22 +87,22 @@ use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement
 use smithay::backend::renderer::element::solid::SolidColorRenderElement;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::RescaleRenderElement;
-use smithay::backend::renderer::element::Kind;
+use smithay::backend::renderer::element::{Kind, RenderElementStates};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::utils::{CommitCounter, RendererSurfaceStateUserData};
 use smithay::backend::renderer::{Color32F, ImportAll, ImportMem};
 use smithay::desktop::utils::{
     bbox_from_surface_tree, send_frames_surface_tree, take_presentation_feedback_surface_tree,
-    OutputPresentationFeedback,
+    surface_presentation_feedback_flags_from_states, OutputPresentationFeedback,
 };
 use smithay::input::pointer::{CursorImageAttributes, CursorImageStatus};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Resource;
 use smithay::render_elements;
-use smithay::utils::{IsAlive, Physical, Point as SPoint, Rectangle as SRect, Scale};
+use smithay::utils::{IsAlive, Logical, Physical, Point as SPoint, Rectangle as SRect, Scale};
 use smithay::wayland::compositor::{self, with_states, TraversalAction};
 use smithay::wayland::shell::wlr_layer::Layer as WlrLayer;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use wm_theme_api::{Point, Rect};
 
@@ -384,17 +384,21 @@ pub(crate) fn build_scene_into(
 /// surface must hear them while a parked window or policy-hidden layer
 /// should sleep. Shared by both backends for exactly that reason.
 ///
-/// Called once per frame with a single `output`, even when several were
-/// drawn: a surface is told about the frame, and which output's clock
-/// that frame belongs to is the pacing question `session.rs` answers
-/// (the primary's) rather than a per-surface one this could answer
-/// better without knowing which screens each window is actually on.
+/// Called from one output's completed presentation boundary. Only
+/// surfaces whose owning rectangle selects that output receive the
+/// callback, so mixed-refresh heads pace independently.
 pub(crate) fn send_frame_callbacks(
     backend: &WaylandBackend,
     output: &smithay::output::Output,
+    output_rect: Rect,
     cursor_status: &CursorImageStatus,
+    pointer_location: SPoint<f64, Logical>,
     elapsed: Duration,
 ) {
+    let throttle = frame_interval(output);
+    let send_tree = |surface: &WlSurface| {
+        send_frames_surface_tree(surface, output, elapsed, throttle, |_, _| Some(output.clone()));
+    };
     // While locked, ONLY lock surfaces hear about frames: withholding
     // callbacks from everything else freezes those clients for the
     // duration, which the spec explicitly sanctions and which stops a
@@ -403,10 +407,13 @@ pub(crate) fn send_frame_callbacks(
     // refused, only unanswered.)
     if backend.locked {
         for entry in &backend.lock_surfaces {
-            if entry.surface.alive() {
-                send_frames_surface_tree(entry.surface.wl_surface(), output, elapsed, Some(Duration::ZERO), |_, _| {
-                    Some(output.clone())
-                });
+            if entry.surface.alive()
+                && backend
+                    .monitors
+                    .get(entry.output)
+                    .is_some_and(|monitor| monitor.geometry == output_rect)
+            {
+                send_tree(entry.surface.wl_surface());
             }
         }
         return;
@@ -416,15 +423,15 @@ pub(crate) fn send_frame_callbacks(
     // namespace policy stay mapped but are absent from the scene, so
     // withholding callbacks is what makes them actually idle.
     for record in &backend.layers {
-        if !backend.layer_presented(record) {
+        if !backend.layer_presented(record)
+            || !is_primary_rect(backend, record.geometry, output_rect)
+        {
             continue;
         }
         let surface = record.surface.wl_surface();
-        send_frames_surface_tree(surface, output, elapsed, Some(Duration::ZERO), |_, _| Some(output.clone()));
+        send_tree(surface);
         for (popup, _) in backend.popups_for_surface(surface) {
-            send_frames_surface_tree(popup.wl_surface(), output, elapsed, Some(Duration::ZERO), |_, _| {
-                Some(output.clone())
-            });
+            send_tree(popup.wl_surface());
         }
     }
     // A window parked on another workspace is protocol-mapped but did
@@ -433,23 +440,34 @@ pub(crate) fn send_frame_callbacks(
     // client produced a frame. The workspace transition frame supplies
     // the first callback when it becomes exposed again.
     for_each_presented_window(backend, |record| {
-        if let Some(surface) = record.surface.wl_surface() {
-            send_frames_surface_tree(&surface, output, elapsed, Some(Duration::ZERO), |_, _| Some(output.clone()));
-            for (popup, _) in backend.popups_for_surface(&surface) {
-                send_frames_surface_tree(popup.wl_surface(), output, elapsed, Some(Duration::ZERO), |_, _| {
-                    Some(output.clone())
-                });
+        if is_primary_rect(backend, record.content, output_rect) {
+            if let Some(surface) = record.surface.wl_surface() {
+                send_tree(&surface);
+                for (popup, _) in backend.popups_for_surface(&surface) {
+                    send_tree(popup.wl_surface());
+                }
             }
         }
     });
-    if let CursorImageStatus::Surface(surface) = cursor_status {
-        send_frames_surface_tree(surface, output, elapsed, Some(Duration::ZERO), |_, _| Some(output.clone()));
+    let pointer_location = Point::new(pointer_location.x.floor() as i32, pointer_location.y.floor() as i32);
+    if output_rect.contains(pointer_location) {
+        if let CursorImageStatus::Surface(surface) = cursor_status {
+            send_tree(surface);
+        }
     }
     for popup in &backend.ime_popups {
-        if popup.alive() {
-            send_frames_surface_tree(popup.wl_surface(), output, elapsed, Some(Duration::ZERO), |_, _| {
-                Some(output.clone())
-            });
+        let Some(parent) = popup.get_parent() else {
+            continue;
+        };
+        let parent_rect = Rect::new(
+            Point::new(parent.location.loc.x, parent.location.loc.y),
+            wm_theme_api::Size::new(
+                parent.location.size.w.max(0) as u32,
+                parent.location.size.h.max(0) as u32,
+            ),
+        );
+        if popup.alive() && is_primary_rect(backend, parent_rect, output_rect) {
+            send_tree(popup.wl_surface());
         }
     }
 }
@@ -462,6 +480,7 @@ pub(crate) fn take_presentation_feedback(
     backend: &WaylandBackend,
     output: &smithay::output::Output,
     output_rect: Rect,
+    render_states: Option<&RenderElementStates>,
 ) -> OutputPresentationFeedback {
     let mut feedback = OutputPresentationFeedback::new(output);
     let mut take_tree = |surface: &WlSurface| {
@@ -469,7 +488,12 @@ pub(crate) fn take_presentation_feedback(
             surface,
             &mut feedback,
             |_, _| Some(output.clone()),
-            |_, _| smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::empty(),
+            |surface, _| {
+                render_states.map_or_else(
+                    smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::empty,
+                    |states| surface_presentation_feedback_flags_from_states(surface, states),
+                )
+            },
         );
     };
 
@@ -592,18 +616,35 @@ pub(crate) fn presentation_refresh(output: &smithay::output::Output) -> smithay:
     )
 }
 
+fn frame_interval(output: &smithay::output::Output) -> Option<Duration> {
+    output
+        .current_mode()
+        .and_then(|mode| u64::try_from(mode.refresh).ok())
+        .filter(|rate| *rate > 0)
+        .map(|millihertz| Duration::from_nanos(1_000_000_000_000 / millihertz))
+}
+
 pub(crate) fn present_now(
     feedback: &mut OutputPresentationFeedback,
     refresh: smithay::wayland::presentation::Refresh,
     flags: smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind,
 ) {
-    static SEQUENCE: AtomicU64 = AtomicU64::new(1);
     feedback.presented(
         smithay::utils::Clock::<smithay::utils::Monotonic>::new().now(),
         refresh,
-        SEQUENCE.fetch_add(1, Ordering::Relaxed),
+        0,
         flags,
     );
+}
+
+pub(crate) fn present_at(
+    feedback: &mut OutputPresentationFeedback,
+    at: Duration,
+    refresh: smithay::wayland::presentation::Refresh,
+    sequence: u64,
+    flags: smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind,
+) {
+    feedback.presented::<_, smithay::utils::Monotonic>(at, refresh, sequence, flags);
 }
 
 /// How many consecutive failed frames are reported before the warning
@@ -696,7 +737,7 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
     // silently assumed. `CHONKSTEP_FULL_DAMAGE=1` forces 0 for the same
     // escape-hatch reason `session.rs` documents.
     let age = if crate::session::full_damage_forced() { 0 } else { winit_backend.buffer_age().unwrap_or(0) };
-    let drew = {
+    let render_states = {
         let (renderer, mut framebuffer) = match winit_backend.bind() {
             Ok(bound) => bound,
             Err(error) => {
@@ -720,7 +761,7 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
         match damage_tracker.render_output(renderer, &mut framebuffer, age, scene_scratch, clear_color) {
             Ok(result) => {
                 log_damage(age, result.damage.map(Vec::as_slice));
-                result.damage.is_some()
+                result.damage.is_some().then_some(result.states)
             }
             Err(error) => {
                 if note_frame_failure() {
@@ -740,7 +781,7 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
     // the old per-frame vector was dropped.
     scene_scratch.clear();
 
-    if drew {
+    if render_states.is_some() {
         // The buffer holds a complete frame either way (the tracker
         // repainted every stale pixel for this buffer's age), so the
         // full-window swap rect is correct; the damage rects computed
@@ -759,15 +800,27 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
         }
     }
 
+    let Some(render_states) = render_states else {
+        wm.backend_mut().damage = false;
+        return false;
+    };
+
     note_frame_success();
     let output_rect = wm.backend().monitors.first().map(|monitor| monitor.geometry).unwrap_or_default();
-    let mut feedback = take_presentation_feedback(wm.backend(), output, output_rect);
+    let mut feedback = take_presentation_feedback(wm.backend(), output, output_rect, Some(&render_states));
     present_now(
         &mut feedback,
         presentation_refresh(output),
         smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync,
     );
-    send_frame_callbacks(wm.backend(), output, cursor_status, start_time.elapsed());
+    send_frame_callbacks(
+        wm.backend(),
+        output,
+        output_rect,
+        cursor_status,
+        *pointer_location,
+        start_time.elapsed(),
+    );
     wm.backend_mut().damage = false;
     true
 }
@@ -779,9 +832,7 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
 /// must log nothing (no frame at all), a blinking cursor a few hundred
 /// square pixels, a fullscreen video the video's rectangle.
 pub(crate) fn log_damage(age: usize, damage: Option<&[SRect<i32, Physical>]>) {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let enabled = *ENABLED.get_or_init(|| std::env::var_os("CHONKSTEP_DAMAGE_LOG").is_some_and(|value| value != "0"));
-    if !enabled {
+    if !crate::diagnostics::enabled("damage-log") {
         return;
     }
     match damage {
@@ -1280,6 +1331,9 @@ pub(crate) fn push_cursor_elements(
     cursors: &crate::state::CursorSet,
     viewport: Rect,
 ) {
+    if backend.cursor_hidden {
+        return;
+    }
     // The pointer has one position in global space. Build it in each
     // output's local coordinates, then retain it only where its pixels
     // intersect; including an off-screen cursor could otherwise defeat

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -58,8 +58,10 @@
 //! - **No DRM leasing.** A crtc is never handed to another process,
 //!   so a VR headset cannot take one over.
 
+use std::collections::BTreeMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use smithay::backend::allocator::format::FormatSet;
@@ -191,6 +193,139 @@ fn plane_kind(drm: &DrmDeviceFd, plane: plane::Handle) -> Option<PlaneType> {
     None
 }
 
+/// Whether the kernel explicitly marks a connector as unsuitable for
+/// a desktop. HMDs commonly expose this property; consuming a crtc for
+/// one both creates an invisible desktop region and can evict a real
+/// monitor. Missing/unreadable properties retain the kernel's historic
+/// desktop default.
+fn connector_is_non_desktop(drm: &DrmDeviceFd, connector: connector::Handle) -> bool {
+    let Ok(props) = drm.get_properties(connector) else {
+        return false;
+    };
+    let (ids, values) = props.as_props_and_values();
+    ids.iter().zip(values.iter()).any(|(&id, &value)| {
+        value != 0
+            && drm
+                .get_property(id)
+                .ok()
+                .and_then(|property| property.name().to_str().ok().map(str::to_owned))
+                .as_deref()
+                == Some("non-desktop")
+    })
+}
+
+/// The stable, user-facing portion of a connector's EDID. This is the
+/// same three-part description Hyprland prints and accepts after a
+/// `desc:` monitor selector; the connector name is intentionally not
+/// part of it because that identifies the port rather than the panel.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DisplayIdentity {
+    make: String,
+    model: String,
+    serial: String,
+}
+
+impl DisplayIdentity {
+    fn description(&self) -> String {
+        [&self.make, &self.model, &self.serial]
+            .into_iter()
+            .filter(|part| !part.is_empty())
+            .map(String::as_str)
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+/// Reads just the EDID facts needed for output identity. A compact
+/// in-crate reader keeps the hardware build free of a new native
+/// libdisplay-info dependency while still using the kernel's canonical
+/// EDID property and the host's same `hwdata` PNP names as Hyprland.
+fn connector_identity(drm: &DrmDeviceFd, connector: connector::Handle) -> Option<DisplayIdentity> {
+    let props = drm.get_properties(connector).ok()?;
+    let (ids, values) = props.as_props_and_values();
+    let blob = ids.iter().zip(values.iter()).find_map(|(&id, &raw)| {
+        let property = drm.get_property(id).ok()?;
+        (property.name().to_str() == Ok("EDID"))
+            .then(|| property.value_type().convert_value(raw).as_blob())
+            .flatten()
+    })?;
+    let data = drm.get_property_blob(blob).ok()?;
+    parse_edid_identity(&data)
+}
+
+fn parse_edid_identity(data: &[u8]) -> Option<DisplayIdentity> {
+    const HEADER: [u8; 8] = [0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00];
+    if data.len() < 128 || data[..8] != HEADER {
+        return None;
+    }
+    let encoded_make = u16::from_be_bytes([data[8], data[9]]);
+    let mut pnp = String::with_capacity(3);
+    for shift in [10, 5, 0] {
+        let letter = ((encoded_make >> shift) & 0x1f) as u8;
+        if !(1..=26).contains(&letter) {
+            return None;
+        }
+        pnp.push(char::from(b'A' + letter - 1));
+    }
+
+    let product = u16::from_le_bytes([data[10], data[11]]);
+    let numeric_serial = u32::from_le_bytes([data[12], data[13], data[14], data[15]]);
+    let model = edid_descriptor_text(data, 0xfc).unwrap_or_else(|| format!("0x{product:04X}"));
+    let serial = edid_descriptor_text(data, 0xff).unwrap_or_else(|| {
+        if numeric_serial == 0 {
+            String::new()
+        } else {
+            format!("0x{numeric_serial:08X}")
+        }
+    });
+    Some(DisplayIdentity { make: pnp_name(&pnp), model, serial })
+}
+
+/// EDID base-block display descriptors occupy four fixed 18-byte
+/// slots. Product-name (0xfc) and serial-string (0xff) descriptors use
+/// bytes 5..18 as newline-padded ASCII.
+fn edid_descriptor_text(data: &[u8], tag: u8) -> Option<String> {
+    (54..126).step_by(18).find_map(|offset| {
+        let descriptor = data.get(offset..offset + 18)?;
+        if descriptor[..3] != [0, 0, 0] || descriptor[3] != tag {
+            return None;
+        }
+        let text: String = descriptor[5..]
+            .iter()
+            .copied()
+            .take_while(|byte| *byte != b'\n' && *byte != 0)
+            .filter(|byte| !byte.is_ascii_control())
+            .map(char::from)
+            .collect();
+        let text = text.trim().to_string();
+        (!text.is_empty()).then_some(text)
+    })
+}
+
+/// Aquamarine/Hyprland expands the three-letter PNP code through the
+/// system hwdata table. Use that same source when present and retain
+/// the true PNP code as the deterministic fallback.
+fn pnp_name(code: &str) -> String {
+    static NAMES: OnceLock<BTreeMap<String, String>> = OnceLock::new();
+    NAMES
+        .get_or_init(|| {
+            ["/usr/share/hwdata/pnp.ids", "/usr/share/misc/pnp.ids"]
+                .into_iter()
+                .find_map(|path| std::fs::read_to_string(path).ok())
+                .map(|contents| {
+                    contents
+                        .lines()
+                        .filter_map(|line| line.split_once('\t'))
+                        .map(|(id, name)| (id.to_string(), name.trim().to_string()))
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+        .get(code)
+        .cloned()
+        .unwrap_or_else(|| code.to_string())
+}
+
 /// The cursor may use the hardware cursor plane, and a lone eligible
 /// fullscreen client may use the primary plane directly. Everything
 /// else is composited into the swapchain and page-flipped from there.
@@ -244,30 +379,20 @@ const FRAME_FLAGS: FrameFlags =
 /// the culprit and the default deserves revisiting; if it stays, that
 /// hypothesis is dead and the switch cost one experiment.
 pub(crate) fn frame_flags() -> FrameFlags {
-    static FLAGS: std::sync::OnceLock<FrameFlags> = std::sync::OnceLock::new();
-    *FLAGS.get_or_init(|| {
-        let flags = configured_frame_flags(
-            std::env::var_os("CHONKSTEP_NO_CURSOR_PLANE"),
-            std::env::var_os("CHONKSTEP_NO_DIRECT_SCANOUT"),
-        );
-        if !flags.contains(FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT) {
-            tracing::info!(
-                "CHONKSTEP_NO_CURSOR_PLANE is set; compositing the pointer instead of using \
-                 the DRM cursor plane"
-            );
-        }
-        if !flags.contains(FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT) {
-            tracing::info!(
-                "CHONKSTEP_NO_DIRECT_SCANOUT is set; compositing fullscreen clients through GLES"
-            );
-        }
-        flags
-    })
+    let mut flags = FRAME_FLAGS;
+    if crate::diagnostics::enabled("no-cursor-plane") {
+        flags.remove(FrameFlags::ALLOW_CURSOR_PLANE_SCANOUT);
+    }
+    if crate::diagnostics::enabled("no-direct-scanout") {
+        flags.remove(FrameFlags::ALLOW_PRIMARY_PLANE_SCANOUT);
+    }
+    flags
 }
 
 /// The pure half of [`frame_flags`], split out so both environment
 /// switches are testable without mutating process-global state. Unset
 /// or `0` keeps that plane; anything else removes only its own flag.
+#[cfg(test)]
 fn configured_frame_flags(
     no_cursor: Option<std::ffi::OsString>,
     no_direct_scanout: Option<std::ffi::OsString>,
@@ -430,14 +555,7 @@ const LOOP_BLOCK_GRACE: Duration = Duration::from_millis(250);
 /// per-frame environment lookup is exactly the kind of small syscall
 /// that this file has spent its recent history removing.
 pub(crate) fn full_damage_forced() -> bool {
-    static FORCED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *FORCED.get_or_init(|| {
-        let forced = std::env::var_os("CHONKSTEP_FULL_DAMAGE").is_some_and(|value| value != "0");
-        if forced {
-            tracing::info!("CHONKSTEP_FULL_DAMAGE is set; forcing full-output damage on every frame");
-        }
-        forced
-    })
+    crate::diagnostics::enabled("full-damage")
 }
 
 /// Everything the session backend owns while it runs: the seat, the
@@ -450,6 +568,12 @@ pub(crate) fn full_damage_forced() -> bool {
 /// hands every callback `&mut Compositor` and nothing else. That is
 /// also the path [`change_vt`] takes on behalf of `input.rs`.
 pub(crate) struct SessionGraphics {
+    /// Primary KMS node selected for this session, retained for live
+    /// system information instead of forcing a user to reconstruct it
+    /// from startup-only logs.
+    device_path: PathBuf,
+    /// Kernel DRM driver name for the selected node.
+    driver_name: String,
     /// Seat handle for opening devices and for [`change_vt`]. Cloned
     /// from the notifier that calloop owns; if that notifier were ever
     /// dropped this handle's inner `Weak` would go dangling and every
@@ -532,12 +656,17 @@ struct SessionOutput {
     /// viewport offset the renderer subtracts from every element to put
     /// the shared scene into this output's framebuffer.
     position: Point,
+    /// User-visible scanout orientation. The framebuffer remains at
+    /// the connector mode's physical pixel size.
+    transform: Transform,
     /// Swapchain, mode setting, and page flips for this output.
     drm_compositor: SessionDrmCompositor,
     /// The kernel modes behind the wayland modes this output advertises,
     /// index-aligned with `OutputEntry::modes` for the same output —
     /// what a wlr-output-management `set_mode` resolves against.
     drm_modes: Vec<DrmMode>,
+    /// Index of the mode currently programmed from `drm_modes`.
+    mode_index: usize,
     /// The page flip in flight, if any — set on a successful
     /// `queue_frame`, cleared by the completion event that answers it.
     /// While it is `Some`, [`render_frame_session`] refuses to draw this
@@ -593,6 +722,10 @@ struct SessionOutput {
     /// They are completed with the kernel's vblank timestamp, never
     /// merely when rendering finished.
     presentation: Option<OutputPresentationFeedback>,
+    /// Most recent kernel vblank metadata for this crtc. An atomic
+    /// commit that produces no flip can still complete presentation
+    /// requests against this boundary without inventing a sequence.
+    last_vblank: Option<(Duration, u64)>,
     refresh: Refresh,
     /// Predicts the next vblank and learns how much of the interval
     /// composition actually consumes. Rendering is armed late enough
@@ -871,6 +1004,24 @@ impl SessionGraphics {
     }
 }
 
+/// Stable, user-facing identity of the graphics backend currently
+/// driving the compositor. Renderer details that Smithay does not
+/// expose remain in its startup log; the KMS node, kernel driver and
+/// render node are retained here for live bug reports.
+pub(crate) fn graphics_diagnostics(graphics: &Graphics) -> String {
+    match graphics {
+        Graphics::Winit(_) => "backend=nested-winit renderer=GLES host_output=true".to_string(),
+        Graphics::Session(session) => format!(
+            "backend=drm-session kms_device={} drm_driver={} render_node={}",
+            session.device_path.display(),
+            session.driver_name,
+            session
+                .render_node
+                .map_or_else(|| "unknown".to_string(), |node| node.to_string()),
+        ),
+    }
+}
+
 /// Intersects exact format/modifier pairs across outputs for global
 /// linux-dmabuf feedback. Kept pure both for tests and to make the
 /// deliberately conservative multi-monitor promise unmistakable.
@@ -1042,7 +1193,16 @@ pub(crate) fn init(
     // the same rule — "damage, then draw".
     loop_handle
         .insert_source(drm_notifier, |event, metadata, comp: &mut Compositor| {
-            let Graphics::Session(session) = &mut comp.graphics else {
+            let Compositor {
+                graphics,
+                wm,
+                outputs,
+                cursor_status,
+                pointer_location,
+                start_time,
+                ..
+            } = comp;
+            let Graphics::Session(session) = graphics else {
                 return;
             };
             match event {
@@ -1050,60 +1210,86 @@ pub(crate) fn init(
                     // Per crtc: the device hands every output's flip
                     // completion through this one source, and only the
                     // output that owns that crtc is free to draw again.
-                    let Some(output) = session.outputs.iter_mut().find(|output| output.crtc == crtc)
+                    let Some(output_index) = session.outputs.iter().position(|output| output.crtc == crtc)
                     else {
                         tracing::debug!(?crtc, "page flip completed on a crtc we do not drive");
                         return;
                     };
-                    let vblank_at = match metadata.map(|meta| meta.time) {
-                        Some(DrmEventTime::Monotonic(time)) => drm_monotonic_instant(time),
-                        _ => Instant::now(),
-                    };
-                    output.frame_clock.note_vblank(vblank_at);
-                    let pending = output.frame_pending.take();
-                    if let Some(mut feedback) = output.presentation.take() {
-                        let flags = smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync
-                            | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwClock
-                            | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwCompletion;
-                        match metadata {
-                            Some(meta) if matches!(meta.time, DrmEventTime::Monotonic(_)) => {
-                                let DrmEventTime::Monotonic(time) = meta.time else { unreachable!() };
-                                feedback.presented::<_, smithay::utils::Monotonic>(
-                                    time,
+                    let completed_frame = {
+                        let output = &mut session.outputs[output_index];
+                        let vblank_at = match metadata.map(|meta| meta.time) {
+                            Some(DrmEventTime::Monotonic(time)) => drm_monotonic_instant(time),
+                            _ => Instant::now(),
+                        };
+                        output.frame_clock.note_vblank(vblank_at);
+                        let pending = output.frame_pending.take();
+                        let completed_frame = pending.is_some();
+                        let monotonic_metadata = metadata.and_then(|meta| match meta.time {
+                            DrmEventTime::Monotonic(time) => Some((time, meta.sequence as u64)),
+                            _ => None,
+                        });
+                        if let Some(last_vblank) = monotonic_metadata {
+                            output.last_vblank = Some(last_vblank);
+                        }
+                        if let Some(mut feedback) = output.presentation.take() {
+                            let hw_flags = smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync
+                                | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwClock
+                                | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwCompletion;
+                            match monotonic_metadata {
+                                Some((time, sequence)) => {
+                                    crate::renderer::present_at(
+                                        &mut feedback,
+                                        time,
+                                        output.refresh,
+                                        sequence,
+                                        hw_flags,
+                                    );
+                                }
+                                _ => crate::renderer::present_now(
+                                    &mut feedback,
                                     output.refresh,
-                                    meta.sequence as u64,
-                                    flags,
+                                    smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync
+                                        | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwCompletion,
+                                ),
+                            }
+                        }
+                        // A composited frame can release its sampled
+                        // buffers now. A direct-scanout frame cannot:
+                        // this vblank made its client buffer current.
+                        if let Some(pending) = pending {
+                            let changed = complete_scene_flip(
+                                &mut output.pending_scene,
+                                &mut output.scanout_scene,
+                                &mut output.direct_scanout_active,
+                                pending.direct_scanout,
+                            );
+                            if changed {
+                                tracing::info!(
+                                    output = %output.name,
+                                    active = pending.direct_scanout,
+                                    "DRM primary-plane direct scanout changed"
                                 );
                             }
-                            _ => crate::renderer::present_now(&mut feedback, output.refresh, flags),
                         }
-                    }
-                    // A composited frame can release its sampled
-                    // buffers now. A direct-scanout frame cannot: this
-                    // vblank made its client buffer current, and the
-                    // display engine continues reading it until a later
-                    // flip replaces it. See `complete_scene_flip`.
-                    if let Some(pending) = pending {
-                        let changed = complete_scene_flip(
-                            &mut output.pending_scene,
-                            &mut output.scanout_scene,
-                            &mut output.direct_scanout_active,
-                            pending.direct_scanout,
-                        );
-                        if changed {
-                            tracing::info!(
-                                output = %output.name,
-                                active = pending.direct_scanout,
-                                "DRM primary-plane direct scanout changed"
+                        if let Err(error) = output.drm_compositor.frame_submitted() {
+                            tracing::warn!(?error, output = %output.name, "page-flip completion was rejected by the DRM compositor");
+                        }
+                        completed_frame
+                    };
+                    if completed_frame {
+                        crate::renderer::note_frame_success();
+                        if let (Some(entry), Some(monitor)) =
+                            (outputs.get(output_index), wm.backend().monitors.get(output_index))
+                        {
+                            crate::renderer::send_frame_callbacks(
+                                wm.backend(),
+                                &entry.output,
+                                monitor.geometry,
+                                cursor_status,
+                                *pointer_location,
+                                start_time.elapsed(),
                             );
                         }
-                    }
-                    if let Err(error) = output.drm_compositor.frame_submitted() {
-                        // The swapchain slot could not be recycled.
-                        // Rendering continues; if this repeats the next
-                        // frame will fail with `NoFreeSlotsError`, which
-                        // is the loud version of the same problem.
-                        tracing::warn!(?error, output = %output.name, "page-flip completion was rejected by the DRM compositor");
                     }
                 }
                 DrmEvent::Error(error) => {
@@ -1174,6 +1360,7 @@ pub(crate) fn init(
                     // preempted whatever sampling was still queued.
                     for output in session.outputs.iter_mut() {
                         output.frame_pending = None;
+                        output.last_vblank = None;
                         output.frame_clock.disarm();
                         clear_scene_holds(
                             &mut output.pending_scene,
@@ -1226,6 +1413,7 @@ pub(crate) fn init(
                         // session painted over the screen.
                         output.drm_compositor.reset_buffers();
                         output.frame_pending = None;
+                        output.last_vblank = None;
                         clear_scene_holds(
                             &mut output.pending_scene,
                             &mut output.scanout_scene,
@@ -1259,6 +1447,13 @@ pub(crate) fn init(
         std::env::var_os("CHONKSTEP_STRICT_BUFFER_RELEASE"),
         driver_is_nvidia(drm.device_fd()),
     );
+    let driver_name = {
+        use smithay::reexports::drm::Device as _;
+        drm.device_fd()
+            .get_driver()
+            .map(|driver| driver.name().to_string_lossy().into_owned())
+            .unwrap_or_else(|_| "unknown".to_string())
+    };
     tracing::info!(
         enabled = strict_release,
         "strict buffer release (hold client buffers until their page flip completes; \
@@ -1266,6 +1461,8 @@ pub(crate) fn init(
     );
     Ok(SessionInit {
         graphics: Graphics::Session(Box::new(SessionGraphics {
+            device_path,
+            driver_name,
             seat_session,
             drm,
             renderer,
@@ -1309,19 +1506,18 @@ fn attach_output(
     // screen's, so any transform here would visibly flip the desktop.
     let wl_mode = OutputMode::from(*mode);
     let (physical_w, physical_h) = info.size().unwrap_or((0, 0));
+    let identity = connector_identity(drm.device_fd(), info.handle());
+    let make = identity.as_ref().map(|identity| identity.make.clone()).unwrap_or_else(|| "Unknown".into());
+    let model = identity.as_ref().map(|identity| identity.model.clone()).unwrap_or_else(|| name.clone());
+    let serial = identity.as_ref().map(|identity| identity.serial.clone()).unwrap_or_default();
+    let description = identity.as_ref().map(DisplayIdentity::description);
     let output = Output::new(
         name.clone(),
         PhysicalProperties {
             size: (physical_w as i32, physical_h as i32).into(),
             subpixel: info.subpixel().into(),
-            // The manufacturer and model live in the connector's EDID
-            // blob, and parsing EDID means either a parser in this
-            // crate or the `smithay-drm-extras` dependency — neither
-            // worth it for two strings clients only ever show in an
-            // about box. The connector name is at least true and
-            // stable.
-            make: "Unknown".into(),
-            model: name.clone(),
+            make,
+            model,
         },
     );
     output.set_preferred(wl_mode);
@@ -1450,8 +1646,10 @@ fn attach_output(
             connector: info.handle(),
             crtc: *crtc,
             position,
+            transform: Transform::Normal,
             drm_compositor,
             drm_modes,
+            mode_index: 0,
             frame_pending: None,
             // Nothing has ever been drawn on it.
             dirty: true,
@@ -1460,6 +1658,7 @@ fn attach_output(
             scanout_scene: Vec::new(),
             direct_scanout_active: false,
             presentation: None,
+            last_vblank: None,
             refresh: if wl_mode.refresh > 0 {
                 Refresh::fixed(Duration::from_nanos(1_000_000_000_000 / wl_mode.refresh as u64))
             } else {
@@ -1467,7 +1666,16 @@ fn attach_output(
             },
             frame_clock: FrameClock::new(*mode),
         },
-        OutputSetup { output, position, size, modes },
+        OutputSetup {
+            output,
+            identity: description,
+            serial,
+            position,
+            size,
+            transform: Transform::Normal,
+            requested_mode: None,
+            modes,
+        },
     ))
 }
 
@@ -1745,6 +1953,7 @@ fn service_pending_flips(session: &mut SessionGraphics) -> bool {
         // pending, which smithay answers `Ok(None)`. Harmless, and the
         // same shape the pause/resume path has always had.
         output.frame_pending = None;
+        output.last_vblank = None;
         // The abandoned pending scene and the buffer that was current
         // before the reset both go: reset_state disabled the planes,
         // so the display engine can no longer read either.
@@ -1798,8 +2007,9 @@ pub(crate) fn apply_mode(graphics: &mut Graphics, index: usize, mode_index: usiz
             output.drm_compositor.set_output_mode_source(OutputModeSource::Static {
                 size,
                 scale: smithay::utils::Scale::from(1.0),
-                transform: Transform::Normal,
+                transform: output.transform,
             });
+            output.mode_index = mode_index;
             let millihertz = OutputMode::from(mode).refresh;
             output.refresh = if millihertz > 0 {
                 Refresh::fixed(Duration::from_nanos(1_000_000_000_000 / millihertz as u64))
@@ -1809,6 +2019,73 @@ pub(crate) fn apply_mode(graphics: &mut Graphics, index: usize, mode_index: usiz
             output.frame_clock.update_mode(mode);
             output.dirty = true;
             Ok(())
+        }
+    }
+}
+
+/// Changes one hardware output's user-visible rotation while keeping
+/// the KMS framebuffer at the connector mode's physical size. The
+/// renderer maps the transformed logical viewport into that buffer.
+pub(crate) fn apply_transform(graphics: &mut Graphics, index: usize, transform: Transform) -> Result<(), String> {
+    match graphics {
+        Graphics::Winit(_) => {
+            if transform == Transform::Normal {
+                Ok(())
+            } else {
+                Err("the nested output reserves its transform for the host EGL surface".into())
+            }
+        }
+        Graphics::Session(session) => {
+            let output = session.outputs.get_mut(index).ok_or_else(|| format!("no session output at index {index}"))?;
+            let mode = *output
+                .drm_modes
+                .get(output.mode_index)
+                .ok_or_else(|| format!("current mode is missing on {}", output.name))?;
+            let size = smithay::utils::Size::from((mode.size().0 as i32, mode.size().1 as i32));
+            output.drm_compositor.set_output_mode_source(OutputModeSource::Static {
+                size,
+                scale: smithay::utils::Scale::from(1.0),
+                transform,
+            });
+            output.transform = transform;
+            output.dirty = true;
+            Ok(())
+        }
+    }
+}
+
+/// Applies mode/rotation decisions made from startup monitor rules
+/// before the corresponding globals become visible to clients.
+pub(crate) fn apply_output_setups(graphics: &mut Graphics, setups: &mut [OutputSetup]) {
+    for (index, setup) in setups.iter_mut().enumerate() {
+        let requested_transform = setup.transform;
+        let result = setup
+            .requested_mode
+            .map_or(Ok(()), |mode_index| apply_mode(graphics, index, mode_index))
+            .and_then(|()| apply_transform(graphics, index, requested_transform));
+        if let Err(error) = result {
+            tracing::warn!(
+                %error,
+                output = %setup.output.name(),
+                "startup output configuration was refused; keeping the active mode and orientation"
+            );
+            setup.requested_mode = None;
+            setup.transform = Transform::Normal;
+            if let Some(mode) = setup.output.current_mode() {
+                setup.size = Size::new(mode.size.w.max(0) as u32, mode.size.h.max(0) as u32);
+            }
+            continue;
+        }
+        if matches!(graphics, Graphics::Session(_)) {
+            let mode = setup
+                .requested_mode
+                .and_then(|mode_index| setup.modes.get(mode_index).copied());
+            setup.output.change_current_state(
+                mode,
+                Some(requested_transform),
+                None,
+                Some((setup.position.x, setup.position.y).into()),
+            );
         }
     }
 }
@@ -1984,7 +2261,6 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
         pointer_location,
         cursor_status,
         cursors,
-        start_time,
         ..
     } = comp;
     let Graphics::Session(session) = graphics else {
@@ -2093,7 +2369,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
             viewport,
         );
 
-        let (rendered, direct_scanout) =
+        let (rendered, direct_scanout, render_states) =
             match output.drm_compositor.render_frame(renderer, &output.scene_scratch, clear_color, frame_flags()) {
             Ok(result) => {
                 let direct_scanout = matches!(&result.primary_element, PrimaryPlaneElement::Element(_));
@@ -2110,7 +2386,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
                         }
                     }
                 }
-                (!result.is_empty, direct_scanout)
+                (!result.is_empty, direct_scanout, result.states)
             }
             Err(error) => {
                 // Includes the atomic test failures a returning VT
@@ -2143,6 +2419,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
                             wm.backend(),
                             &entry.output,
                             monitor.geometry,
+                            Some(&render_states),
                         ));
                     }
                 }
@@ -2157,12 +2434,20 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
                             wm.backend(),
                             &entry.output,
                             monitor.geometry,
+                            Some(&render_states),
                         );
-                        crate::renderer::present_now(
-                            &mut feedback,
-                            output.refresh,
-                            smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync,
-                        );
+                        let flags = smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync;
+                        if let Some((at, sequence)) = output.last_vblank {
+                            crate::renderer::present_at(
+                                &mut feedback,
+                                at,
+                                output.refresh,
+                                sequence,
+                                flags | smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::HwClock,
+                            );
+                        } else {
+                            crate::renderer::present_now(&mut feedback, output.refresh, flags);
+                        }
                     }
                 }
                 Err(error) => {
@@ -2211,21 +2496,11 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
         drew_any = true;
     }
 
+    // Empty and successfully prepared frames both prove the rendering
+    // path is healthy. Client callbacks wait for the vblank handler,
+    // which is the only place that knows a queued frame really landed.
     if drew_any {
-        // Frame callbacks are attributed to the primary output. They
-        // pace clients, and a client that hears from one output per
-        // frame draws at that output's rate — so on a mixed-refresh
-        // desktop everything is paced by the primary. Doing better means
-        // tracking which output each surface is actually on
-        // (`Output::enter`/`leave` and a per-surface primary scan-out
-        // choice), which is the same bookkeeping presentation feedback
-        // would need and neither exists yet.
-        // A frame reached the hardware, so the failure streak that
-        // throttles the warnings above is over.
         crate::renderer::note_frame_success();
-        if let Some(primary) = output_entries.first() {
-            crate::renderer::send_frame_callbacks(wm.backend(), &primary.output, cursor_status, start_time.elapsed());
-        }
     }
     drew_any
 }
@@ -2272,16 +2547,64 @@ fn open_first_usable_device(
     }
 
     let mut failures = Vec::new();
+    let mut selected: Option<(PathBuf, Device)> = None;
     for path in candidates {
-        match probe_device(seat_session, &path) {
-            Ok(device) => return Ok((path, device)),
-            Err(reason) => {
-                tracing::info!(device = %path.display(), %reason, "skipping DRM device");
-                failures.push(format!("{}: {reason}", path.display()));
+        if selected.is_none() {
+            match probe_device(seat_session, &path) {
+                Ok(device) => {
+                    selected = Some((path, device));
+                }
+                Err(reason) => {
+                    tracing::info!(device = %path.display(), %reason, "skipping DRM device");
+                    failures.push(format!("{}: {reason}", path.display()));
+                }
             }
+            continue;
+        }
+
+        match connected_desktop_connectors(seat_session, &path) {
+            Ok(connectors) if !connectors.is_empty() => {
+                let selected_path = selected.as_ref().map(|(path, _)| path.as_path()).unwrap();
+                tracing::warn!(
+                    device = %path.display(),
+                    connectors = %connectors.join(", "),
+                    selected = %selected_path.display(),
+                    override_variable = "CHONKSTEP_DRM_DEVICE",
+                    "connected outputs are omitted because this session drives one DRM device"
+                );
+            }
+            Ok(_) => {}
+            Err(reason) => tracing::debug!(device = %path.display(), %reason, "could not inspect unselected DRM device"),
         }
     }
-    Err(format!("no usable DRM device on seat {seat_name} ({})", failures.join("; ")).into())
+    if let Some(selected) = selected {
+        Ok(selected)
+    } else {
+        Err(format!("no usable DRM device on seat {seat_name} ({})", failures.join("; ")).into())
+    }
+}
+
+/// Connector-only probe for devices after the selected GPU. It avoids
+/// GBM/EGL creation and, crucially, does not construct a `DrmDevice`
+/// with connector-reset enabled; it observes other GPUs without
+/// disturbing whichever compositor currently owns their display state.
+fn connected_desktop_connectors(
+    seat_session: &mut LibSeatSession,
+    path: &Path,
+) -> Result<Vec<String>, String> {
+    let fd = seat_session.open(path, DEVICE_FLAGS).map_err(|error| format!("the seat would not open it: {error:?}"))?;
+    let fd = DrmDeviceFd::new(DeviceFd::from(fd));
+    let resources = fd.resource_handles().map_err(|error| format!("could not enumerate KMS resources: {error}"))?;
+    let mut names = Vec::new();
+    for handle in resources.connectors() {
+        let Ok(info) = fd.get_connector(*handle, true) else {
+            continue;
+        };
+        if info.state() == connector::State::Connected && !connector_is_non_desktop(&fd, *handle) {
+            names.push(connector_name(&info));
+        }
+    }
+    Ok(names)
 }
 
 /// Candidate DRM nodes, best first and deduplicated: an explicit
@@ -2424,6 +2747,10 @@ fn pick_outputs(drm: &DrmDevice) -> Result<Vec<ConnectorTarget>, String> {
             skipped.push(format!("{name} is {:?}", info.state()));
             continue;
         }
+        if connector_is_non_desktop(drm.device_fd(), *handle) {
+            skipped.push(format!("{name} is marked non-desktop (reserved for a lease/VR runtime)"));
+            continue;
+        }
         let Some(mode) = preferred_mode(&info) else {
             skipped.push(format!("{name} is connected but reports no modes"));
             continue;
@@ -2509,6 +2836,39 @@ fn connector_name(connector: &connector::Info) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_edid() -> [u8; 128] {
+        let mut edid = [0u8; 128];
+        edid[..8].copy_from_slice(&[0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00]);
+        // DEL: D=4, E=5, L=12 in EDID's packed five-bit alphabet.
+        edid[8..10].copy_from_slice(&((4u16 << 10) | (5u16 << 5) | 12).to_be_bytes());
+        edid[10..12].copy_from_slice(&0x1234u16.to_le_bytes());
+        edid[12..16].copy_from_slice(&0x01020304u32.to_le_bytes());
+        edid[54..59].copy_from_slice(&[0, 0, 0, 0xfc, 0]);
+        edid[59..72].copy_from_slice(b"DELL U2720Q\n ");
+        edid[72..77].copy_from_slice(&[0, 0, 0, 0xff, 0]);
+        edid[77..90].copy_from_slice(b"ABC123\n      ");
+        edid
+    }
+
+    #[test]
+    fn minimal_edid_reader_builds_hyprland_style_identity() {
+        let identity = parse_edid_identity(&test_edid()).unwrap();
+        assert!(identity.make == "Dell Inc." || identity.make == "DEL");
+        assert_eq!(identity.model, "DELL U2720Q");
+        assert_eq!(identity.serial, "ABC123");
+        assert_eq!(identity.description(), format!("{} DELL U2720Q ABC123", identity.make));
+    }
+
+    #[test]
+    fn edid_reader_uses_numeric_fallbacks_without_text_descriptors() {
+        let mut edid = test_edid();
+        edid[54..90].fill(0);
+        let identity = parse_edid_identity(&edid).unwrap();
+        assert_eq!(identity.model, "0x1234");
+        assert_eq!(identity.serial, "0x01020304");
+        assert!(parse_edid_identity(&edid[1..]).is_none());
+    }
 
     /// The strict-release default follows the driver: on for NVIDIA
     /// (no implicit dmabuf fencing to mask an early release), off

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -774,6 +774,19 @@ pub struct WaylandBackend {
     /// the renderer clears it after drawing. This is the whole
     /// redraw-scheduling protocol: no damage, no render.
     pub(crate) damage: bool,
+    /// Call site that most recently invalidated the scene. A static
+    /// `Location` costs no allocation on the hot path and makes a live
+    /// diagnostic dump answer why the compositor last chose to draw.
+    pub(crate) last_damage_source: Option<&'static std::panic::Location<'static>>,
+    /// Compositor-wide cursor suppression requested through the
+    /// Hyprland compatibility socket. The owner is the focused client
+    /// at the moment it hides the cursor, so killing a screensaver
+    /// cannot strand the rest of the session without a pointer.
+    pub(crate) cursor_hidden: bool,
+    pub(crate) cursor_hidden_owner: Option<WlSurface>,
+    /// Selected graphics stack and hardware identity for live system
+    /// information (`nested-winit` or the KMS/driver/render-node set).
+    pub(crate) graphics_diagnostics: String,
     /// Handle to the wayland display, for verbs that must touch
     /// protocol state directly (client credentials for `window_pid`,
     /// disconnecting a client for `kill_client`).
@@ -999,6 +1012,10 @@ impl WaylandBackend {
             ime_popups: Vec::new(),
             output_size,
             damage: true,
+            last_damage_source: None,
+            cursor_hidden: false,
+            cursor_hidden_owner: None,
+            graphics_diagnostics: "backend=uninitialized".to_string(),
             display_handle,
             pending_focus: None,
             preview_edge: None,
@@ -1082,8 +1099,10 @@ impl WaylandBackend {
     /// Marks the scene dirty. Every mutating verb and every handler
     /// that changes anything visible must call this (or set the field)
     /// or its change waits for the next unrelated damage to appear.
+    #[track_caller]
     pub(crate) fn mark_damaged(&mut self) {
         self.damage = true;
+        self.last_damage_source = Some(std::panic::Location::caller());
     }
 
     /// Records that the answer to "may the session idle?" can have
@@ -1397,8 +1416,22 @@ pub(crate) enum Graphics {
 /// produces exactly one, at the origin.
 pub(crate) struct OutputSetup {
     pub output: Output,
+    /// Stable EDID description (`make model serial`) for matching
+    /// `monitor = desc:...` and persisting placement independently of
+    /// the connector port. `None` for nested/virtual outputs and
+    /// hardware whose EDID could not be read.
+    pub identity: Option<String>,
+    /// EDID serial kept separately because Smithay's
+    /// `PhysicalProperties` carries only make and model.
+    pub serial: String,
     pub position: Point,
     pub size: Size,
+    /// User-visible orientation. Kept separate from the nested
+    /// backend's `Flipped180` EGL correction.
+    pub transform: Transform,
+    /// Mode selected by a startup monitor rule, to be applied to KMS
+    /// before the `wl_output` global is published.
+    pub requested_mode: Option<usize>,
     /// Every mode this output can drive, current/preferred first. One
     /// entry on the nested backend (the host window has no modes to
     /// offer); the connector's full EDID mode list on the session
@@ -1457,6 +1490,9 @@ pub(crate) struct MonitorOutput {
     /// Current mode's refresh in millihertz; 0 when no real mode is
     /// driven, which is what the wire layer turns into its fallback.
     pub refresh_millihertz: u32,
+    /// wl_output transform number (0/1/2/3 for the rotations we
+    /// support), mirrored into the Hyprland compatibility snapshot.
+    pub transform: i32,
     pub modes: Vec<MonitorMode>,
 }
 
@@ -1470,11 +1506,14 @@ pub(crate) struct MonitorOutput {
 /// has to agree on one.
 pub(crate) struct OutputEntry {
     pub output: Output,
+    pub identity: Option<String>,
+    pub serial: String,
     /// Top-left corner in global compositor space. Every rect in the
     /// ledger is global, so this is what the renderer subtracts to put
     /// the one shared scene into this output's framebuffer.
     pub position: Point,
     pub size: Size,
+    pub transform: Transform,
     /// This output's fractional UI scale — what fractional-scale-v1
     /// tells clients on it, what `wl_output.scale` advertises the
     /// ceiling of, and what `WaylandBackend::monitor_scales` mirrors
@@ -1509,8 +1548,11 @@ impl OutputEntry {
         let damage_tracker = physical_damage_tracker(&setup.output, setup.size);
         Self {
             output: setup.output,
+            identity: setup.identity,
+            serial: setup.serial,
             position: setup.position,
             size: setup.size,
+            transform: setup.transform,
             scale: 1.0,
             modes: setup.modes,
             damage_tracker,
@@ -1557,9 +1599,18 @@ impl OutputEntry {
 /// putting their scaled buffers back at 1 buffer pixel : 1 screen
 /// pixel. The session backend pins its `DrmCompositor`s the same way
 /// (`session::attach_output`); the two must never disagree.
-pub(crate) fn physical_damage_tracker(output: &Output, size: Size) -> OutputDamageTracker {
+pub(crate) fn physical_damage_tracker(output: &Output, fallback_size: Size) -> OutputDamageTracker {
+    // `OutputDamageTracker` wants the untransformed framebuffer size;
+    // its transform turns that into the logical output rectangle for
+    // intersection. `OutputEntry::size` is already transformed for
+    // desktop layout, so feeding it here would swap portrait outputs a
+    // second time and render against the wrong framebuffer dimensions.
+    let size = output.current_mode().map_or_else(
+        || SSize::<i32, Physical>::from((fallback_size.w as i32, fallback_size.h as i32)),
+        |mode| mode.size,
+    );
     OutputDamageTracker::new(
-        SSize::<i32, Physical>::from((size.w as i32, size.h as i32)),
+        size,
         1.0,
         output.current_transform(),
     )
@@ -1621,8 +1672,8 @@ fn advertise_scales(outputs: &mut [OutputEntry], scales: &[f64]) {
 
 /// Applies the supported, whole `monitor =` lines while real outputs
 /// and their EDID facts are available. Unsupported fields refuse their
-/// entire line so a rotated/disabled/mirrored request is never partly
-/// honored as only a scale or position change.
+/// entire line so a disabled/mirrored request is never partly honored
+/// as only a scale, orientation, mode, or position change.
 pub(crate) fn apply_monitor_rules(
     setups: &mut [OutputSetup],
     rules: &[wm_config::hyprland::directive::Monitor],
@@ -1632,16 +1683,28 @@ pub(crate) fn apply_monitor_rules(
     let mut auto_x = 0i32;
     let mut changed_position = false;
     for (index, setup) in setups.iter_mut().enumerate() {
-        let exact = rules.iter().rev().find(|rule| rule.output == setup.output.name());
+        let exact = rules.iter().rev().find(|rule| monitor_rule_matches(setup, &rule.output));
         let catch_all = rules.iter().rev().find(|rule| rule.output.trim().is_empty());
         let Some(rule) = exact.or(catch_all) else {
             auto_x = auto_x.max(setup.position.x.saturating_add(setup.size.w as i32));
             continue;
         };
-        let unsupported = rule.extra.first().map(String::as_str).or_else(|| {
+        let transform = match monitor_transform(&rule.extra) {
+            Ok(transform) => transform,
+            Err(field) => {
+                tracing::warn!(
+                    output = %setup.output.name(),
+                    field,
+                    "hyprland-config: monitor line refused whole because this field is unsupported"
+                );
+                auto_x = auto_x.max(setup.position.x.saturating_add(setup.size.w as i32));
+                continue;
+            }
+        };
+        let unsupported = {
             let mode = rule.mode.trim().to_ascii_lowercase();
             (mode == "disable" || mode.starts_with("mirror")).then_some(rule.mode.as_str())
-        });
+        };
         if let Some(field) = unsupported {
             tracing::warn!(
                 output = %setup.output.name(),
@@ -1653,19 +1716,25 @@ pub(crate) fn apply_monitor_rules(
         }
 
         let mode = rule.mode.trim();
-        let new_size = if mode.is_empty() || mode.eq_ignore_ascii_case("preferred") {
-            setup.output.preferred_mode().map_or(setup.size, |preferred| {
-                Size::new(preferred.size.w.max(0) as u32, preferred.size.h.max(0) as u32)
-            })
-        } else {
+        let Some(mode_index) = resolve_monitor_mode(&setup.output, &setup.modes, mode) else {
+            let advertised = setup
+                .modes
+                .iter()
+                .map(|mode| format!("{}x{}@{:.3}", mode.size.w, mode.size.h, f64::from(mode.refresh) / 1000.0))
+                .collect::<Vec<_>>()
+                .join(", ");
             tracing::warn!(
                 output = %setup.output.name(),
                 mode,
-                "hyprland-config: monitor line refused whole; explicit modes are not applied during output bootstrap"
+                advertised,
+                "hyprland-config: monitor line refused whole; requested mode is not advertised"
             );
             auto_x = auto_x.max(setup.position.x.saturating_add(setup.size.w as i32));
             continue;
         };
+        let selected_mode = setup.modes[mode_index];
+        let transformed = transform.transform_size(selected_mode.size);
+        let new_size = Size::new(transformed.w.max(0) as u32, transformed.h.max(0) as u32);
 
         let position = rule.position.trim();
         let new_position = if position.is_empty() || position.eq_ignore_ascii_case("auto") {
@@ -1702,6 +1771,8 @@ pub(crate) fn apply_monitor_rules(
         };
         setup.size = new_size;
         setup.position = new_position;
+        setup.transform = transform;
+        setup.requested_mode = Some(mode_index);
         changed_position = true;
         auto_x = auto_x.max(setup.position.x.saturating_add(setup.size.w as i32));
         scales[index] = scale;
@@ -1710,8 +1781,36 @@ pub(crate) fn apply_monitor_rules(
             x = setup.position.x,
             y = setup.position.y,
             scale,
+            transform = transform_number(transform),
+            mode = %format!("{}x{}@{:.3}", selected_mode.size.w, selected_mode.size.h, f64::from(selected_mode.refresh) / 1000.0),
             "hyprland-config: monitor line applied"
         );
+    }
+    let connectors = setups.iter().map(|setup| setup.output.name()).collect::<Vec<_>>().join(", ");
+    let descriptions = setups
+        .iter()
+        .filter_map(|setup| setup.identity.as_deref())
+        .collect::<Vec<_>>()
+        .join(", ");
+    for rule in rules {
+        let selector = rule.output.trim();
+        if selector.is_empty() || setups.iter().any(|setup| monitor_rule_matches(setup, selector)) {
+            continue;
+        }
+        if selector.starts_with("desc:") {
+            tracing::warn!(
+                monitor = selector,
+                connected = %connectors,
+                descriptions = %if descriptions.is_empty() { "none (EDID unavailable)" } else { &descriptions },
+                "hyprland-config: monitor description matched no connected output"
+            );
+        } else {
+            tracing::warn!(
+                monitor = selector,
+                connected = %connectors,
+                "hyprland-config: monitor name matched no connected output"
+            );
+        }
     }
     if changed_position {
         let min_x = setups.iter().map(|setup| setup.position.x).min().unwrap_or(0);
@@ -1722,6 +1821,117 @@ pub(crate) fn apply_monitor_rules(
         }
     }
     scales
+}
+
+/// Hyprland's stable selector is the exact human-readable EDID
+/// description printed by `hyprctl monitors`: `make model serial`.
+/// Connector matching remains available for configs that intentionally
+/// target a particular port.
+fn monitor_rule_matches(setup: &OutputSetup, selector: &str) -> bool {
+    let selector = selector.trim();
+    if let Some(description) = selector.strip_prefix("desc:") {
+        let description = description.trim();
+        return !description.is_empty() && setup.identity.as_deref() == Some(description);
+    }
+    selector == setup.output.name()
+}
+
+const MODE_REFRESH_TOLERANCE_MHZ: i32 = 1_000;
+
+/// EDID refresh values are measured millihertz and routinely differ
+/// from their marketing integer by one or two millihertz. Match the
+/// nearest advertised timing, but never round a request to a visibly
+/// different refresh rate.
+pub(crate) fn refresh_matches(advertised: i32, requested: i32) -> bool {
+    requested == 0 || advertised.abs_diff(requested) <= MODE_REFRESH_TOLERANCE_MHZ as u32
+}
+
+fn resolve_monitor_mode(output: &Output, modes: &[Mode], request: &str) -> Option<usize> {
+    if modes.is_empty() {
+        return None;
+    }
+    let request = request.trim().to_ascii_lowercase();
+    let preferred = output.preferred_mode().unwrap_or(modes[0]);
+    let preferred_index = || {
+        modes
+            .iter()
+            .position(|mode| mode.size == preferred.size && mode.refresh == preferred.refresh)
+            .unwrap_or(0)
+    };
+    if request.is_empty() || request == "preferred" {
+        return Some(preferred_index());
+    }
+    if request == "highrr" {
+        return modes
+            .iter()
+            .enumerate()
+            .filter(|(_, mode)| mode.size == preferred.size)
+            .max_by_key(|(_, mode)| mode.refresh)
+            .map(|(index, _)| index);
+    }
+    if request == "highres" {
+        return modes
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, mode)| (i64::from(mode.size.w) * i64::from(mode.size.h), mode.refresh))
+            .map(|(index, _)| index);
+    }
+
+    let (size_part, refresh_part) = request.split_once('@').map_or((request.as_str(), None), |(size, rate)| {
+        (size, Some(rate))
+    });
+    let (width, height) = if size_part == "preferred" {
+        (preferred.size.w, preferred.size.h)
+    } else {
+        let (width, height) = size_part.split_once('x')?;
+        (width.parse::<i32>().ok()?, height.parse::<i32>().ok()?)
+    };
+    let requested_refresh = refresh_part.and_then(|rate| rate.parse::<f64>().ok()).and_then(|rate| {
+        (rate.is_finite() && rate > 0.0 && rate <= f64::from(i32::MAX) / 1000.0)
+            .then_some((rate * 1000.0).round() as i32)
+    });
+    if refresh_part.is_some() && requested_refresh.is_none() {
+        return None;
+    }
+    let candidate = modes
+        .iter()
+        .enumerate()
+        .filter(|(_, mode)| mode.size.w == width && mode.size.h == height)
+        .min_by_key(|(_, mode)| requested_refresh.map_or(i32::MAX - mode.refresh, |rate| mode.refresh.abs_diff(rate) as i32));
+    match (candidate, requested_refresh) {
+        (Some((index, mode)), Some(rate)) if refresh_matches(mode.refresh, rate) => Some(index),
+        (Some((index, _)), None) => Some(index),
+        _ => None,
+    }
+}
+
+fn monitor_transform(extra: &[String]) -> Result<Transform, &str> {
+    if extra.is_empty() {
+        return Ok(Transform::Normal);
+    }
+    if extra.len() != 2 || !extra[0].eq_ignore_ascii_case("transform") {
+        return Err(extra.first().map(String::as_str).unwrap_or("extra field"));
+    }
+    match extra[1].trim() {
+        "0" => Ok(Transform::Normal),
+        "1" => Ok(Transform::_90),
+        "2" => Ok(Transform::_180),
+        "3" => Ok(Transform::_270),
+        _ => Err(extra[1].as_str()),
+    }
+}
+
+pub(crate) fn transform_number(transform: Transform) -> i32 {
+    match transform {
+        Transform::Normal => 0,
+        Transform::_90 => 1,
+        Transform::_180 => 2,
+        Transform::_270 => 3,
+        Transform::Flipped => 4,
+        Transform::Flipped90 => 5,
+        Transform::Flipped180 => 6,
+        Transform::Flipped270 => 7,
+    }
 }
 
 /// Mirrors a DRM connector delta into every positional output ledger.
@@ -1773,18 +1983,25 @@ pub(crate) fn apply_connector_hotplug(
         .iter()
         .map(|entry| OutputSetup {
             output: entry.output.clone(),
+            identity: entry.identity.clone(),
+            serial: entry.serial.clone(),
             position: entry.position,
             size: entry.size,
+            transform: entry.transform,
+            requested_mode: None,
             modes: entry.modes.clone(),
         })
         .collect();
     let scales = apply_monitor_rules(&mut setups, &session.monitor_rules, comp.ui_scale as f64);
+    crate::session::apply_output_setups(&mut comp.graphics, &mut setups);
     for ((entry, setup), scale) in comp.outputs.iter_mut().zip(setups).zip(scales) {
         entry.position = setup.position;
+        entry.size = setup.size;
+        entry.transform = setup.transform;
         entry.scale = scale;
         entry.output.change_current_state(
             None,
-            None,
+            matches!(comp.graphics, Graphics::Session(_)).then_some(entry.transform),
             Some(advertised_output_scale(scale as f32)),
             Some((entry.position.x, entry.position.y).into()),
         );
@@ -1799,6 +2016,7 @@ pub(crate) fn apply_connector_hotplug(
         .map(|(index, entry)| MonitorInfo {
             geometry: Rect::new(entry.position, entry.size),
             name: entry.output.name(),
+            identity: entry.identity.clone(),
             primary: index == 0,
         })
         .collect();
@@ -1809,7 +2027,7 @@ pub(crate) fn apply_connector_hotplug(
         backend.monitor_scales = monitor_scales;
         backend.output_size = union_size(&backend.monitors);
         backend.pending_resize = Some(backend.output_size);
-        backend.damage = true;
+        backend.mark_damaged();
         backend.layer_layout_dirty = true;
         backend.idle_policy_dirty = true;
     }
@@ -2238,11 +2456,15 @@ impl Compositor {
     }
 
     pub(crate) fn dispatch_pending(&mut self) {
+        let dispatch_span = tracing::info_span!("dispatch_pass");
+        let _dispatch_guard = dispatch_span.enter();
         let dispatch_started = Instant::now();
         self.apply_pending_keyboard();
-        crate::session::service_connector_hotplug(self);
+        tracing::debug_span!("dispatch_phase", phase = "connector_hotplug")
+            .in_scope(|| crate::session::service_connector_hotplug(self));
         let phase_started = Instant::now();
-        crate::input::tick_repeating_binding(self);
+        tracing::debug_span!("dispatch_phase", phase = "input")
+            .in_scope(|| crate::input::tick_repeating_binding(self));
         // Consecutive `PointerMotion` events coalesce to the most
         // recent one — same rationale as the X11 loop: during a fast
         // drag every intermediate position is stale by the time it
@@ -2397,6 +2619,7 @@ impl Compositor {
         self.dismiss_popups_after_parent_resize();
         self.popups.cleanup();
         self.wm.backend_mut().reconcile_popup_roots();
+        self.reconcile_cursor_visibility();
         self.core_protocols.sweep_activation_tokens(Instant::now());
         self.apply_pending_focus();
         // Beside the focus intent and for the same reason: a drag that
@@ -2604,6 +2827,26 @@ impl Compositor {
         // door never opens without CHONKSTEP_TEST_SOCKET).
         crate::test_door::after_frame(self);
         self.frame_stats.record_dispatch(dispatch_started.elapsed());
+    }
+
+    /// Restores a cursor hidden on behalf of a client that has gone
+    /// away without running its cleanup command. The compatibility
+    /// socket is one-shot, so ownership follows the focused Wayland
+    /// surface rather than the short-lived `hyprctl` process.
+    fn reconcile_cursor_visibility(&mut self) {
+        let owner_died = self
+            .wm
+            .backend()
+            .cursor_hidden_owner
+            .as_ref()
+            .is_some_and(|owner| !owner.is_alive());
+        if owner_died {
+            let backend = self.wm.backend_mut();
+            backend.cursor_hidden = false;
+            backend.cursor_hidden_owner = None;
+            backend.mark_damaged();
+            tracing::info!("restored cursor after the client that hid it disconnected");
+        }
     }
 
     /// Dismiss popup trees whose native parent changed size.
@@ -3167,7 +3410,7 @@ impl Compositor {
         // even while only a single output can resize.
         backend.output_size = union_size(&backend.monitors);
         backend.pending_resize = Some(backend.output_size);
-        backend.damage = true;
+        backend.mark_damaged();
         self.layer_shell.needs_arrange = true;
     }
 
@@ -3199,16 +3442,13 @@ impl Compositor {
                 MonitorOutput {
                     make: properties.make,
                     model: properties.model,
-                    // No connector serial reaches this compositor. Left
-                    // empty rather than filled with the model again:
-                    // an empty string is a readable "not known", a
-                    // duplicated model is a wrong answer.
-                    serial: String::new(),
+                    serial: entry.serial.clone(),
                     refresh_millihertz: entry
                         .output
                         .current_mode()
                         .and_then(|mode| u32::try_from(mode.refresh).ok())
                         .unwrap_or(0),
+                    transform: transform_number(entry.transform),
                     modes: entry
                         .modes
                         .iter()
@@ -3720,7 +3960,16 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         // multi-monitor path rather than a path of its own.
         (
             Graphics::Winit(Box::new(winit_backend)),
-            vec![OutputSetup { output, position: Point::new(0, 0), size, modes: vec![mode] }],
+            vec![OutputSetup {
+                output,
+                identity: None,
+                serial: String::new(),
+                position: Point::new(0, 0),
+                size,
+                transform: Transform::Normal,
+                requested_mode: None,
+                modes: vec![mode],
+            }],
         )
     } else {
         tracing::info!("session backend: taking over the DRM device and input");
@@ -3729,6 +3978,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     };
     let configured_scale = chonk_shell::startup::read_scale_factor(config.scale) as f64;
     let monitor_scales = apply_monitor_rules(&mut output_setups, &config.monitor_rules, configured_scale);
+    crate::session::apply_output_setups(&mut graphics, &mut output_setups);
     let initial_layout: Vec<(Point, Size)> = output_setups.iter().map(|setup| (setup.position, setup.size)).collect();
     crate::session::sync_positions(&mut graphics, &initial_layout);
     let mut outputs: Vec<OutputEntry> =
@@ -3746,6 +3996,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         .map(|(index, entry)| MonitorInfo {
             geometry: Rect { pos: entry.position, size: entry.size },
             name: entry.output.name(),
+            identity: entry.identity.clone(),
             primary: index == 0,
         })
         .collect();
@@ -3950,6 +4201,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // `WindowManager::new` takes ownership — the exact construction
     // order the X11 binary uses, for the exact same borrow reason.
     let mut backend = WaylandBackend::new(display_handle.clone(), monitors, scale);
+    backend.graphics_diagnostics = crate::session::graphics_diagnostics(&graphics);
     backend.monitor_scales = effective_monitor_scales;
     backend.repeat_delay = std::time::Duration::from_millis(repeat_delay as u64);
     backend.repeat_rate = repeat_rate as u32;
@@ -4629,6 +4881,7 @@ mod tests {
         MonitorInfo {
             geometry: Rect { pos: Point::new(x, y), size: Size::new(w, h) },
             name: format!("test-{x}x{y}"),
+            identity: None,
             primary: x == 0 && y == 0,
         }
     }
@@ -4739,7 +4992,16 @@ mod tests {
         let mode = Mode { size: smithay::utils::Size::from((size.w as i32, size.h as i32)), refresh: 60_000 };
         output.change_current_state(Some(mode), None, None, Some((0, 0).into()));
         output.set_preferred(mode);
-        OutputSetup { output, position, size, modes: vec![mode] }
+        OutputSetup {
+            output,
+            identity: None,
+            serial: String::new(),
+            position,
+            size,
+            transform: Transform::Normal,
+            requested_mode: None,
+            modes: vec![mode],
+        }
     }
 
     fn monitor_rule(
@@ -4775,14 +5037,70 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_monitor_fields_refuse_the_whole_line() {
+    fn monitor_description_rule_follows_the_panel_instead_of_the_port() {
+        let description = "Dell Inc. DELL U2720Q ABC123";
+        let mut panel = output_setup("DP-7", (600, 340), Size::new(3840, 2160), Point::new(1920, 0));
+        panel.identity = Some(description.to_string());
+        panel.serial = "ABC123".to_string();
+        let mut setups = vec![
+            output_setup("eDP-1", (280, 160), Size::new(1920, 1080), Point::new(0, 0)),
+            panel,
+        ];
+        let rules = vec![
+            monitor_rule("", "preferred", "auto", "1", &[]),
+            monitor_rule(&format!("desc:{description}"), "preferred", "0x0", "2", &[]),
+        ];
+
+        let scales = apply_monitor_rules(&mut setups, &rules, 1.0);
+        assert_eq!(scales, vec![1.0, 2.0]);
+        assert_eq!(setups[1].position, Point::new(0, 0));
+    }
+
+    #[test]
+    fn monitor_rotation_is_applied_as_part_of_the_whole_line() {
+        let mut setups = vec![output_setup("DP-1", (600, 340), Size::new(1920, 1080), Point::new(77, 88))];
+        let rules = vec![monitor_rule("DP-1", "preferred", "0x0", "2", &["transform", "1"])];
+        let scales = apply_monitor_rules(&mut setups, &rules, 1.25);
+        assert_eq!(scales, vec![2.0]);
+        assert_eq!(setups[0].position, Point::new(0, 0));
+        assert_eq!(setups[0].size, Size::new(1080, 1920));
+        assert_eq!(setups[0].transform, Transform::_90);
+        assert_eq!(setups[0].requested_mode, Some(0));
+    }
+
+    #[test]
+    fn unsupported_monitor_fields_still_refuse_the_whole_line() {
         let original = Point::new(77, 88);
         let mut setups = vec![output_setup("DP-1", (600, 340), Size::new(1920, 1080), original)];
-        let rules = vec![monitor_rule("DP-1", "preferred", "0x0", "2", &["transform", "1"])];
+        let rules = vec![monitor_rule("DP-1", "preferred", "0x0", "2", &["cm", "srgb"])];
         let scales = apply_monitor_rules(&mut setups, &rules, 1.25);
         assert_eq!(scales, vec![1.25]);
         assert_eq!(setups[0].position, original, "position was not partially applied");
         assert_eq!(setups[0].size, Size::new(1920, 1080));
+        assert_eq!(setups[0].transform, Transform::Normal);
+        assert_eq!(setups[0].requested_mode, None);
+    }
+
+    #[test]
+    fn explicit_monitor_modes_select_the_nearest_advertised_timing() {
+        use smithay::output::Mode;
+
+        let mut setup = output_setup("DP-1", (600, 340), Size::new(1920, 1080), Point::new(0, 0));
+        setup.modes.extend([
+            Mode { size: (2560, 1440).into(), refresh: 60_000 },
+            Mode { size: (2560, 1440).into(), refresh: 143_999 },
+            Mode { size: (3840, 2160).into(), refresh: 59_940 },
+        ]);
+        let mut setups = vec![setup];
+        let rules = vec![monitor_rule("DP-1", "2560x1440@144", "auto", "1", &[])];
+        assert_eq!(apply_monitor_rules(&mut setups, &rules, 1.0), vec![1.0]);
+        assert_eq!(setups[0].size, Size::new(2560, 1440));
+        assert_eq!(setups[0].requested_mode, Some(2));
+
+        let rules = vec![monitor_rule("DP-1", "highres", "auto", "1", &[])];
+        apply_monitor_rules(&mut setups, &rules, 1.0);
+        assert_eq!(setups[0].size, Size::new(3840, 2160));
+        assert_eq!(setups[0].requested_mode, Some(3));
     }
 
     #[test]

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -739,6 +739,7 @@ impl CompositorHandler for Compositor {
         backend.mark_idle_policy_dirty();
     }
 
+    #[tracing::instrument(name = "surface_commit", skip_all)]
     fn commit(&mut self, surface: &WlSurface) {
         // Buffer bookkeeping first — everything below (and the
         // renderer, and the hit-test's subsurface walk) reads the

--- a/crates/wm-x11/src/backend.rs
+++ b/crates/wm-x11/src/backend.rs
@@ -1662,7 +1662,12 @@ fn query_monitors(conn: &RustConnection, root: Window, randr: Option<(u32, u32)>
             _ => tracing::debug!("RandR reported no active CRTCs; falling back to one screen-sized monitor"),
         }
     }
-    vec![MonitorInfo { geometry: Rect { pos: Point::new(0, 0), size: screen }, name: "screen-0".to_string(), primary: true }]
+    vec![MonitorInfo {
+        geometry: Rect { pos: Point::new(0, 0), size: screen },
+        name: "screen-0".to_string(),
+        identity: None,
+        primary: true,
+    }]
 }
 
 /// RandR 1.5 `GetMonitors`. `get_active = true` on purpose: a monitor
@@ -1689,6 +1694,7 @@ fn monitors_via_get_monitors(conn: &RustConnection, root: Window) -> Option<Vec<
         monitors.push(MonitorInfo {
             geometry: monitor_rect(monitor.x, monitor.y, monitor.width, monitor.height),
             name,
+            identity: None,
             primary: monitor.primary,
         });
     }
@@ -1753,7 +1759,7 @@ fn monitors_via_crtcs(conn: &RustConnection, root: Window) -> Option<Vec<Monitor
                 .map(|reply| String::from_utf8_lossy(&reply.name).into_owned())
                 .filter(|name| !name.is_empty())
                 .unwrap_or_else(|| format!("output-{output}"));
-            MonitorInfo { geometry, name, primary }
+            MonitorInfo { geometry, name, identity: None, primary }
         })
         .collect();
     Some(monitors)
@@ -3317,7 +3323,12 @@ mod tests {
     use super::*;
 
     fn monitor(name: &str, x: i32, y: i32, w: u32, h: u32, primary: bool) -> MonitorInfo {
-        MonitorInfo { geometry: Rect { pos: Point::new(x, y), size: Size::new(w, h) }, name: name.to_string(), primary }
+        MonitorInfo {
+            geometry: Rect { pos: Point::new(x, y), size: Size::new(w, h) },
+            name: name.to_string(),
+            identity: None,
+            primary,
+        }
     }
 
     #[test]

--- a/docs/control-socket.md
+++ b/docs/control-socket.md
@@ -1,4 +1,4 @@
-# The chonkstep control socket, version 1
+# The chonkstep control socket, version 2
 
 This is the wire contract between the chonkstep shell and anything that
 wants to *show* the desktop's state or *steer* it from outside — a bar
@@ -127,7 +127,7 @@ Move To submenu.
 Always first. Identifies the protocol and the session.
 
 ```json
-{"event":"hello","protocol":1,"session":"wayland","pid":1441097}
+{"event":"hello","protocol":2,"session":"wayland","pid":1441097}
 ```
 
 - `protocol` — the integer version of this document. Breaking changes
@@ -216,6 +216,17 @@ socket is not blind, and so it can correlate focus with a workspace.
   `null` if it could not be parsed at all.
 - `message` — for a human. Not stable; do not match on it.
 
+### 3.7 `debug`
+
+An explicit `debug` request receives one read-only live dump:
+
+```json
+{"event":"debug","topic":"scene","data":"locked=false damage=false ..."}
+```
+
+It is never broadcast as a changing facet. `data` is diagnostic text
+for people and bug reports, not a stable machine protocol.
+
 ## 4. Requests (client → shell)
 
 The verb set is deliberately closed and tiny: it covers what a bar
@@ -248,6 +259,17 @@ Naming the workspace that is already active changes nothing, so the
 shell has nothing to broadcast; the asking client — and only that
 client — is sent the current `workspaces` event again as its
 acknowledgement. Every request gets an answer, even a redundant one.
+
+### 4.3 `debug`
+
+```json
+{"request":"debug","topic":"scene"}
+```
+
+Returns one `debug` event. The valid topics are `scene`, `focus`, and
+`clients`; they currently share one correlated dump so counts,
+stacking, focus intent, damage state, and live diagnostic switches are
+captured from the same instant. An unknown topic receives `error`.
 
 ## 5. What is deliberately absent
 

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -209,7 +209,7 @@ specific directive, not a count. Turn on `RUST_LOG=debug` to see them.
 | `exec` (as opposed to `exec-once`) | It re-runs on every config reload, which here would mean on every poll. Taking it as autostart would start a fresh copy each time you edited anything. |
 | `submap`, workspace rules, `plugin`, `bezier`, `animation` | Hyprland's own machinery. Every binding inside conf `submap = name … reset` or Lua `hl.define_submap` is skipped with its chord and submap; it is never promoted to a global grab. |
 | `hl.on("layer.opened")` selection bindings | Read as a namespace-scoped keymap. It is installed only while a matching layer-shell surface is mapped and removed after the last such surface closes. A handler with unknown side effects is refused whole. |
-| Unsupported `monitor =` lines | A line containing disable, mirror, transform/extra fields, or an explicit mode is refused whole. The supported subset is applied as described below. |
+| Unsupported `monitor =` lines | A line containing disable, mirror, or an extra field other than a 0/90/180/270-degree transform is refused whole. Explicit modes and those transforms are supported as described below. |
 
 ### Bindings this desktop has no verb for
 
@@ -278,17 +278,26 @@ Any additional side effect refuses the entire handler.
 
 Monitor rules are resolved only after the compositor has the connected
 outputs and their EDID facts. An exact output rule beats the last
-catch-all rule. The supported transaction is:
+catch-all rule. The selector may be a connector name such as `DP-2` or
+Hyprland's stable `desc:make model serial` form (copy the `description`
+from `hyprctl monitors`); the latter follows a physical display when it
+moves to another dock port. A selector that matches nothing is named in
+the log together with the connected connectors and EDID descriptions.
+The supported transaction is:
 
-- `preferred` mode (or omitted), resolved from that head's mode list;
+- `preferred` (or omitted), `highrr`, `highres`, `WIDTHxHEIGHT`,
+  `WIDTHxHEIGHT@RATE`, or `preferred@RATE`, resolved from that head's
+  advertised mode list (with measured-refresh tolerance);
 - `auto` position, laid out left-to-right, or an explicit `XxY`;
 - numeric scale from 0.5 through 4, or `auto` from physical DPI
-  (1.0/1.5/2.0 thresholds).
+  (1.0/1.5/2.0 thresholds);
+- `transform, 0` through `transform, 3` for 0/90/180/270-degree
+  clockwise output rotation.
 
 Negative positions are normalized together so the logical desktop
-starts at zero without changing relative placement. Any unsupported
-field, `disable`, `mirror`, malformed position/scale, or explicit mode
-refuses the whole line with the output and field in the log. The same
+starts at zero without changing relative placement. An unadvertised
+mode, unsupported field, `disable`, `mirror`, or malformed
+position/scale refuses the whole line with the output and field in the log. The same
 output state backs IPC and `zwlr_output_management`, so advertised
 scale, renderer scale, shell geometry, and application fractional scale
 cannot diverge.

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -121,6 +121,8 @@ actions. Supported families include:
   source, including `[[...]]` and `[=[...]=]` strings;
 - `eval hl.dispatch(hl.dsp....)`;
 - `eval hl.monitor({ output=..., scale=... })` for a live output;
+- `eval hl.config({ cursor = { invisible = BOOL } })`, the live
+  cursor-visibility property used by Omarchy's screensaver;
 - `reload`, which re-reads chonkstep/Hyprland configuration and emits
   `configreloaded` only after it has applied.
 
@@ -130,7 +132,11 @@ not reported as unknown syntax. Monitor scaling validates the output
 and range before changing anything, so an Omarchy script cannot record
 a scale that the compositor said it applied but did not.
 
-`keyword` is refused, and the refusal names what does work instead:
+`keyword` is refused except for the named
+`keyword cursor:invisible BOOL` screensaver fallback, which reaches the
+same live cursor flag as `hl.config`. If the focused client that hid
+the cursor disconnects without restoring it, chonkstep restores the
+cursor automatically. Every other refusal names what does work instead:
 chonkstep re-reads `~/.config/hypr` within a second of an edit, and
 `hyprctl eval hl.monitor({ output=..., scale=... })` changes a live
 scale. The one shipped Omarchy caller is the monitor panel's row toggle
@@ -147,14 +153,13 @@ refusal and the string is the only diagnostic a user gets.
 The monitor object reports measured values, not conventional ones.
 `refreshRate` is the driven mode's rate, `availableModes` is the
 connector's mode list in `WIDTHxHEIGHT@RATEHz` with the current mode
-first, and `make`/`model` come from the same properties the matching
-`wl_output` advertises—so IPC and `zwlr_output_management` cannot
-describe one panel two ways. Two fields stay empty on purpose: `serial`,
-because no connector serial reaches this compositor, and a duplicated
-model would be a wrong answer where an empty string is a readable "not
-known"; and `vrr`, which is covered by the adaptive-sync work. A backend
-driving no real mode reports 60 Hz rather than 0, because a bar divides
-this into a frame budget.
+first, and `make`/`model`/`serial` are read from the connector EDID. The
+same `make model serial` description backs `monitor = desc:…`,
+`wl_output`, IPC, and `zwlr_output_management`, so those interfaces
+cannot describe one panel two ways. `serial` stays empty only when the
+EDID itself supplies none; `vrr` remains covered by the adaptive-sync
+work. A backend driving no real mode reports 60 Hz rather than 0,
+because a bar divides this into a frame budget.
 
 Tiling vocabulary—`layoutmsg`, `togglesplit`, `swapwindow`, `pseudo`,
 groups, special workspaces, tiled workspace options—has no faithful

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,58 @@
+# Logging and live diagnostics
+
+The Wayland session writes its current log to
+`${XDG_STATE_HOME:-$HOME/.local/state}/chonkstep/wayland-session.log`.
+The previous login is retained as `wayland-session.log.old`. The X11
+session writes to the same state directory through its session script.
+
+`RUST_LOG` selects tracing targets at startup. Useful examples:
+
+```sh
+RUST_LOG=info,wm_wayland::session=debug
+RUST_LOG=info,wm_wayland::layers=trace
+RUST_LOG=info,wm_wayland::input=debug
+RUST_LOG=info,wm_wayland::renderer=debug
+```
+
+The Wayland compositor's filter is reloadable. These commands change it
+without closing clients or restarting the desktop:
+
+```sh
+hyprctl log-filter 'info,wm_wayland::session=debug'
+hyprctl log-filter 'info,wm_wayland::layers=trace'
+```
+
+| Symptom | Suggested target |
+|---|---|
+| Frozen or dark output | `wm_wayland::session=debug` |
+| Popup/layer misplaced | `wm_wayland::layers=trace,wm_wayland::xdg=debug` |
+| Window size or scale wrong | `wm_wayland::xdg=debug,wm_wayland::output_mgmt=debug` |
+| Screen sharing is black | `wm_wayland::capture=debug,wm_wayland::image_capture=debug` |
+| Key or pointer binding fails | `wm_wayland::input=debug` |
+
+`hyprctl systeminfo` returns a live build/output/scene summary. The
+control socket also accepts `{"request":"debug","topic":"scene"}`;
+`focus` and `clients` are valid topics as well. Run
+`chonkstep-bugreport` to collect those answers, both log generations,
+the package/build identity, recovery marker, and user configuration into
+one mode-0600 file. The report is not redacted; review it before sharing.
+
+## Diagnostic switches
+
+The environment variables below establish startup defaults. On Wayland,
+the corresponding live knob can be changed with
+`hyprctl debug-set KNOB BOOL`.
+
+| Environment variable | Live knob | Effect |
+|---|---|---|
+| `CHONKSTEP_DAMAGE_LOG` | `damage-log` | Log renderer damage rectangles per submitted frame. |
+| `CHONKSTEP_IDLE_LOG` | `idle-log` | Log actual idle-inhibition policy transitions. |
+| `CHONKSTEP_FULL_DAMAGE` | `full-damage` | Force whole-output repainting for artifact diagnosis. |
+| `CHONKSTEP_NO_DIRECT_SCANOUT` | `no-direct-scanout` | Keep fullscreen clients on the GLES composition path. |
+| `CHONKSTEP_NO_CURSOR_PLANE` | `no-cursor-plane` | Composite the cursor rather than using a KMS cursor plane. |
+| `CHONKSTEP_STRICT_BUFFER_RELEASE` | — | Hold composited client buffers through vblank; startup-only because it changes buffer ownership. |
+| `CHONKSTEP_DRM_DEVICE` | — | Select the single DRM card the session drives; startup-only. |
+
+The dispatch loop emits a `dispatch_pass` span, phase spans around input
+and connector work, and surface/layer handler spans. Enabling their
+targets adds that context to nested warnings and Smithay events.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -223,6 +223,8 @@ Then turn on the two settings that make sessions durable:
 # crash the watchdog recovered from. Never resurrects a window you
 # deliberately closed. Off by default because a session that spawns
 # apps you did not just ask for is something to opt into.
+# On Wayland, windows are stored relative to the monitor's EDID identity,
+# so changing dock ports does not move them to a different display.
 restore_session = true
 
 # Wayland session only: when the compositor crashes, the session

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -52,6 +52,7 @@ depends=(
   'libinput'
   'seatd'
   'systemd-libs'
+  'hwdata'           # PNP manufacturer names for stable EDID descriptions
   'wayland'
   'xorg-xwayland'
   'foot'
@@ -141,6 +142,7 @@ package() {
   install -Dm755 scripts/reload.sh "$pkgdir/usr/lib/chonkstep/reload.sh"
   install -Dm755 scripts/restart.sh "$pkgdir/usr/lib/chonkstep/restart.sh"
   install -Dm755 scripts/verify-install.sh "$pkgdir/usr/lib/chonkstep/verify-install.sh"
+  install -Dm755 scripts/chonkstep-bugreport "$pkgdir/usr/bin/chonkstep-bugreport"
 
   # Session entries, one per stack, so a login manager offers both.
   # TryExec is deliberate and package-only: greeters that verify it
@@ -222,6 +224,7 @@ DESKTOP
   install -Dm644 docs/appearance.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/control-socket.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/memory.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/logging.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 README.md CHANGELOG.md -t "$pkgdir/usr/share/doc/$pkgname"
 
   for plugin in omarchy/plugins/*/; do

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -56,6 +56,7 @@ depends=(
   'libinput'         # real keyboards, mice, touchpads
   'seatd'            # libseat; the daemon itself is only needed without logind
   'systemd-libs'     # libudev: device discovery and hot-plug
+  'hwdata'           # PNP manufacturer names for Hyprland-compatible EDID descriptions
   'wayland'          # client libraries, loaded at runtime for nested mode
   'xorg-xwayland'    # spawned at boot so X11 apps run in the Wayland session
   'foot'             # the terminal the desktop spawns
@@ -145,6 +146,7 @@ package() {
   install -Dm755 scripts/reload.sh "$pkgdir/usr/lib/chonkstep/reload.sh"
   install -Dm755 scripts/restart.sh "$pkgdir/usr/lib/chonkstep/restart.sh"
   install -Dm755 scripts/verify-install.sh "$pkgdir/usr/lib/chonkstep/verify-install.sh"
+  install -Dm755 scripts/chonkstep-bugreport "$pkgdir/usr/bin/chonkstep-bugreport"
 
   # Session entries, one per stack, so a login manager offers both.
   # TryExec is deliberate and package-only: greeters that verify it
@@ -229,6 +231,7 @@ DESKTOP
   install -Dm644 docs/appearance.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/control-socket.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/memory.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/logging.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 README.md CHANGELOG.md -t "$pkgdir/usr/share/doc/$pkgname"
 
   # The Omarchy bar widgets that read the control socket, and the guide

--- a/scripts/chonkstep-bugreport
+++ b/scripts/chonkstep-bugreport
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Collect a live ChonkStep report without restarting the compositor.
+set -u
+
+stamp="$(date +%Y%m%d-%H%M%S)"
+report="${1:-chonkstep-bugreport-$stamp.txt}"
+state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/chonkstep"
+umask 077
+: > "$report" || exit 1
+
+section() {
+    printf '\n===== %s =====\n' "$1" >> "$report"
+}
+
+section "PRIVACY NOTICE"
+printf '%s\n' \
+    "This file contains process, display, window-title, log and configuration data." \
+    "Nothing is redacted automatically. Review it before sharing." >> "$report"
+
+section "SYSTEM INFO"
+if command -v hyprctl >/dev/null 2>&1; then
+    hyprctl systeminfo >> "$report" 2>&1 || true
+else
+    printf 'hyprctl is not installed\n' >> "$report"
+fi
+
+section "LIVE SCENE"
+if [ -n "${CHONKSTEP_CONTROL_SOCKET:-}" ] && [ -S "$CHONKSTEP_CONTROL_SOCKET" ] && command -v socat >/dev/null 2>&1; then
+    printf '{"request":"debug","topic":"scene"}\n' |
+        timeout 2 socat - "UNIX-CONNECT:$CHONKSTEP_CONTROL_SOCKET" >> "$report" 2>&1 || true
+else
+    printf 'control socket or socat unavailable\n' >> "$report"
+fi
+
+section "PACKAGE OR BUILD"
+if command -v pacman >/dev/null 2>&1; then
+    pacman -Qi chonkstep >> "$report" 2>&1 || true
+fi
+chonkstep-wayland --version >> "$report" 2>&1 || true
+
+section "RECOVERY"
+if [ -e "$state_dir/recovery" ]; then
+    printf 'recovery marker is present\n' >> "$report"
+else
+    printf 'recovery marker is absent\n' >> "$report"
+fi
+
+for log in "$state_dir/wayland-session.log.old" "$state_dir/wayland-session.log"; do
+    section "$log (last 400 lines)"
+    if [ -r "$log" ]; then
+        tail -n 400 "$log" >> "$report" 2>&1
+    else
+        printf 'not readable\n' >> "$report"
+    fi
+done
+
+for config in "$HOME/.config/chonkstep/config.toml" "$HOME/.config/hypr/hyprland.conf"; do
+    section "$config"
+    if [ -r "$config" ]; then
+        sed -n '1,2000p' "$config" >> "$report" 2>&1
+    else
+        printf 'not readable\n' >> "$report"
+    fi
+done
+
+printf 'Wrote %s; review it before sharing.\n' "$report"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -90,7 +90,8 @@ echo "Installing dependencies (sudo)..."
 # The last two lines are the Wayland half's build and runtime needs,
 # and they are not optional even for an X11-only user: the workspace
 # build below compiles wm-wayland on any Linux host, and that links
-# against every one of them.
+# against every one of them. hwdata supplies the PNP manufacturer names
+# used to make EDID descriptions match Hyprland's `desc:` selectors.
 #
 # Nested and session backends alike: libxkbcommon (keyboard layouts),
 # libglvnd/mesa (EGL/GLES for the compositor's renderer, and libgbm for
@@ -133,7 +134,7 @@ sudo pacman -S --needed --noconfirm \
     foot picom wireplumber \
     ttf-dejavu gsfonts $jb_font noto-fonts \
     libxkbcommon libglvnd mesa xorg-xwayland \
-    libdrm libinput systemd-libs seatd \
+    libdrm libinput systemd-libs seatd hwdata \
     pipewire xdg-desktop-portal xdg-desktop-portal-wlr xdg-desktop-portal-gtk \
     uwsm
 
@@ -278,7 +279,7 @@ if [ ! -e "$config" ]; then
     echo "Seeded ${config} (all defaults, fully commented)."
 fi
 
-# The two tools a user reaches for by name, put on PATH the same way
+# The tools a user reaches for by name, put on PATH the same way
 # the session entries were: as links back into this checkout, so
 # scripts/update.sh keeps them current with nothing else to do.
 # chonk-get is a script and lives in scripts/; omarchy-export-themes is
@@ -290,6 +291,7 @@ fi
 bin="$HOME/.local/bin"
 install -d "$bin"
 ln -sfn "${repo}/scripts/chonk-get" "$bin/chonk-get"
+ln -sfn "${repo}/scripts/chonkstep-bugreport" "$bin/chonkstep-bugreport"
 ln -sfn "${repo}/target/release/omarchy-export-themes" "$bin/omarchy-export-themes"
 # chonk-netjoin is the odd one out here: nobody types it. It is the
 # wifi passphrase dialog the LNK panel spawns when someone clicks a


### PR DESCRIPTION
## Summary

- Tie frame callbacks and presentation feedback to real output submissions and DRM page flips, including truthful sequence, render-state, and zero-copy metadata.
- Filter non-desktop connectors, make explicit mode and rotation changes transactional, and diagnose displays omitted by the single-GPU session policy.
- Add request-driven compositor diagnostics, runtime log filters and debug knobs, tracing spans, and the chonkstep-bugreport collector.
- Read connector EDID identity, support Hyprland monitor desc selectors with loud unmatched-rule diagnostics, publish make/model/serial consistently, and persist window geometry relative to the stable physical monitor.
- Support the two screensaver cursor-visibility commands with live ownership and automatic restoration when the requesting surface exits.
- Harden layer-shell size handling and extend the hostile-client sweep with the unsigned-overflow case.

## Issues

Closes #65
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #73
Closes #74
Closes #85
Closes #124

## Validation

- cargo test --workspace --all-targets
- cargo clippy --workspace --all-targets --no-deps with warnings, disallowed methods/types, and undocumented unsafe blocks denied
- rustdoc for the complete workspace with warnings denied
- shellcheck and bash syntax checks for touched scripts and package recipes
- live headless E2E: screensaver_cursor_visibility_is_live_and_owned
- live headless E2E: no_hostile_client_can_take_the_desktop_with_it