### PR TITLE
Present as Omarchy: its menu at the root, one theme list, previews in the export (#133)

### DIFF
--- a/crates/chonk-shell/src/desktop.rs
+++ b/crates/chonk-shell/src/desktop.rs
@@ -416,7 +416,15 @@ const ACTION_OMARCHY_BASE: u32 = 1_000_000;
 
 /// The root menu's fixed title — also what a fresh `ShellMenu` is
 /// titled before any session opens.
-const ROOT_MENU_TITLE: &str = "chonkstep";
+///
+/// "Omarchy", not "chonkstep", because that is what this desktop *is*
+/// to the person using it: a replacement desktop environment for
+/// Omarchy, wearing different chrome. The name a user reads on screen
+/// is the desktop they installed. Nothing below the surface is
+/// renamed — crates, log lines, config paths and the session
+/// signature all stay `chonkstep`, because renaming those breaks
+/// existing installs and buys nothing anybody sees.
+const ROOT_MENU_TITLE: &str = "Omarchy";
 
 /// The shared current-choice marker: a leading bullet on the selected
 /// row, matching spaces on every other row so all labels in the column
@@ -438,7 +446,7 @@ pub(crate) fn bullet_label(selected: bool, label: &str) -> String {
 /// category list to drift out of sync with the enum). Within a
 /// cascade, apps keep their index order: `scan_applications` delivers
 /// the flat vec sorted by name, and filtering by category preserves
-/// that, so each cascade is alphabetical for free. "About chonkstep"
+/// that, so each cascade is alphabetical for free. "About"
 /// closes the submenu after every cascade — with an empty index it is
 /// the whole submenu, so Applications never opens onto nothing.
 fn applications_items(apps: &[crate::apps::AppEntry]) -> Vec<MenuItem> {
@@ -455,7 +463,7 @@ fn applications_items(apps: &[crate::apps::AppEntry]) -> Vec<MenuItem> {
     by_category
         .into_iter()
         .map(|(category, entries)| MenuItem::Submenu { label: category.label().to_string(), items: entries })
-        .chain(std::iter::once(MenuItem::Action { label: "About chonkstep".to_string(), action: ACTION_LAUNCH_ABOUT }))
+        .chain(std::iter::once(MenuItem::Action { label: "About".to_string(), action: ACTION_LAUNCH_ABOUT }))
         .collect()
 }
 
@@ -521,35 +529,64 @@ fn root_menu_items(
         }))
         .collect();
 
+    // Two shapes, chosen by whether Omarchy's menu is readable.
+    //
+    // With Omarchy present the root menu *is* Omarchy's menu: its rows
+    // sit at the top level rather than inside a submenu, because this
+    // desktop is a replacement for Omarchy and not a different desktop
+    // hosting it. A user right-clicking the desk should find the menu
+    // they already know.
+    //
+    // Two of this desk's own rows are folded in rather than wrapped.
+    // `Applications` goes first, in the position Omarchy's own `Apps`
+    // row occupies — and it has to, because that row is provider-backed
+    // and `MenuModel::build` skips it (`Skip::Provider`), so promoting
+    // Omarchy's tree alone would leave the desktop with no application
+    // launcher in its menu at all. `Dock` and `Omarchy Bar` go last,
+    // before `Exit`: they are choices about this desk's furniture, and
+    // they have no counterpart in Omarchy's tree.
+    //
+    // What is deliberately *not* carried over is `Theme` and
+    // `Wallpaper`. Omarchy's `style.theme` and `style.background` rows
+    // do survive the filter, they drive `omarchy-theme-set`, and this
+    // compositor already follows the symlink that writes — so offering
+    // a second list beside them is the split theme system this desktop
+    // is trying not to have. chonkstep's own themes reach that one list
+    // by being exported into `~/.config/omarchy/themes` (see
+    // `crate::omarchy_export`), not by getting a menu of their own.
+    if !omarchy.is_empty() {
+        let mut items = vec![
+            MenuItem::Submenu { label: "Applications".to_string(), items: applications_items(apps) },
+            MenuItem::Action { label: "Terminal".to_string(), action: ACTION_LAUNCH_TERMINAL },
+        ];
+        items.extend(omarchy);
+        items.push(MenuItem::Action { label: bullet_label(!dock.is_hidden(), "Dock"), action: ACTION_DOCK });
+        if let Some(bar) = omarchy_bar {
+            items.push(MenuItem::Action {
+                label: bullet_label(!bar.is_hidden(), "Omarchy Bar"),
+                action: ACTION_OMARCHY_BAR,
+            });
+        }
+        items.push(MenuItem::Action { label: "Exit".to_string(), action: ACTION_EXIT });
+        return items;
+    }
+
+    // No Omarchy to read: this desk's own tree, unchanged. A session on
+    // a machine without Omarchy installed still needs a way to pick a
+    // theme, a wallpaper and an application, so the rows the branch
+    // above drops are exactly the rows that must survive here.
     let mut items = vec![
         MenuItem::Action { label: "Terminal".to_string(), action: ACTION_LAUNCH_TERMINAL },
         MenuItem::Submenu { label: "Applications".to_string(), items: applications_items(apps) },
         MenuItem::Submenu { label: "Theme".to_string(), items: theme_items },
         MenuItem::Submenu { label: "Wallpaper".to_string(), items: wallpaper_items },
     ];
-    // The Dock's own row, immediately above the bar's: two rows about
-    // which chrome this desk wears, in the section that already holds
-    // the wallpaper and the theme, bulleted the same way so a glance
-    // at the menu says which of the two columns are on. This desk's
-    // own furniture is listed first and the guest's second, the same
-    // order the Omarchy submenu takes below.
     items.push(MenuItem::Action { label: bullet_label(!dock.is_hidden(), "Dock"), action: ACTION_DOCK });
-    // The bar toggle sits with chonkstep's own look-and-feel rows —
-    // it is a choice about *this* desk's furniture, like the wallpaper
-    // — and is marked the way the Theme and Wallpaper rows mark the
-    // current choice, so a glance at the menu says whether the bar is
-    // on.
     if let Some(bar) = omarchy_bar {
         items.push(MenuItem::Action {
             label: bullet_label(!bar.is_hidden(), "Omarchy Bar"),
             action: ACTION_OMARCHY_BAR,
         });
-    }
-    // After chonkstep's own choices and before Exit: it is a guest's
-    // menu inside the host's, so it sits below the host's rows and
-    // above the one row that ends the session.
-    if !omarchy.is_empty() {
-        items.push(MenuItem::Submenu { label: "Omarchy".to_string(), items: omarchy });
     }
     items.push(MenuItem::Action { label: "Exit".to_string(), action: ACTION_EXIT });
     items
@@ -4430,7 +4467,10 @@ mod tests {
         assert!(labels(None).iter().all(|label| !label.contains("Omarchy Bar")), "no shell, no row");
         let hidden = labels(Some(BarVisibility::Hidden));
         let row = hidden.iter().position(|label| label == "  Omarchy Bar").expect("an unmarked row for a hidden bar");
-        assert_eq!(hidden[row + 1], "Omarchy", "chonkstep's row, then the guest's submenu");
+        // This desk's own furniture sits after Omarchy's rows and
+        // before the one row that ends the session.
+        assert_eq!(hidden[row - 1], "\u{2022} Dock", "the two furniture toggles are adjacent");
+        assert_eq!(hidden[row + 1], "Exit", "and Exit closes the menu");
         assert_eq!(hidden.last().unwrap(), "Exit");
         assert!(labels(Some(BarVisibility::Shown)).contains(&"\u{2022} Omarchy Bar".to_string()), "marked when shown");
         assert!(matches!(
@@ -4875,7 +4915,7 @@ mod tests {
         // first category encountered in the index, with About closing
         // the submenu after every cascade.
         let labels: Vec<&str> = applications.iter().map(|item| item.label()).collect();
-        assert_eq!(labels, ["Development", "Graphics", "Internet", "About chonkstep"]);
+        assert_eq!(labels, ["Development", "Graphics", "Internet", "About"]);
 
         // A multi-app category lists its apps in index order — which
         // is alphabetical, since the index arrives name-sorted — and
@@ -4964,7 +5004,10 @@ mod tests {
     }
 
     #[test]
-    fn the_omarchy_submenu_sits_between_wallpaper_and_exit_only_when_it_has_rows() {
+    fn the_root_menu_is_omarchys_tree_when_there_is_one_and_this_desks_own_when_there_is_not() {
+        // No Omarchy to read: this desk's own tree, and it must still
+        // carry the rows a user needs to dress the desktop, because
+        // nothing else on the machine offers them.
         let without = root_menu_items(
             Wallpaper::TealBlueprint,
             "nextstep-classic",
@@ -4977,18 +5020,38 @@ mod tests {
         let labels: Vec<&str> = without.iter().map(MenuItem::label).collect();
         assert_eq!(labels, ["Terminal", "Applications", "Theme", "Wallpaper", "\u{2022} Dock", "Exit"]);
 
-        let rows = vec![MenuItem::Action { label: "About".to_string(), action: ACTION_OMARCHY_BASE }];
+        // With Omarchy present its rows are the menu, at the top level
+        // rather than behind an `Omarchy` cascade.
+        let rows = vec![
+            MenuItem::Submenu { label: "Style".to_string(), items: Vec::new() },
+            MenuItem::Submenu { label: "System".to_string(), items: Vec::new() },
+        ];
         let with =
             root_menu_items(Wallpaper::TealBlueprint, "nextstep-classic", &[], None, rows, None, DockVisibility::Shown);
         let labels: Vec<&str> = with.iter().map(MenuItem::label).collect();
-        assert_eq!(labels, ["Terminal", "Applications", "Theme", "Wallpaper", "\u{2022} Dock", "Omarchy", "Exit"]);
+        assert_eq!(
+            labels,
+            ["Applications", "Terminal", "Style", "System", "\u{2022} Dock", "Exit"],
+            "Omarchy's rows are the menu; this desk folds Applications in ahead of them and its own toggles after"
+        );
+        assert!(
+            !labels.contains(&"Omarchy"),
+            "no `Omarchy` wrapper: the menu is Omarchy's, it does not contain one"
+        );
+        // The second theme list is gone. `style.theme` survives the
+        // model's filter and drives `omarchy-theme-set`, which this
+        // compositor already follows.
+        assert!(
+            !labels.contains(&"Theme") && !labels.contains(&"Wallpaper"),
+            "one theme system: chonkstep's built-ins reach Omarchy's picker by export, not by a menu of their own"
+        );
     }
 
     #[test]
     fn an_empty_app_index_leaves_applications_as_just_about() {
         let applications = applications_submenu(&[]);
         let labels: Vec<&str> = applications.iter().map(|item| item.label()).collect();
-        assert_eq!(labels, ["About chonkstep"], "no empty category cascades, About still reachable");
+        assert_eq!(labels, ["About"], "no empty category cascades, About still reachable");
         assert!(
             applications.iter().all(|item| matches!(item, MenuItem::Action { .. })),
             "an empty index must produce no cascade at all, not empty ones"

--- a/crates/chonk-shell/src/omarchy_export.rs
+++ b/crates/chonk-shell/src/omarchy_export.rs
@@ -18,7 +18,8 @@
 //! uses, with the terminal palette intact.
 //!
 //! A directory holds exactly what Omarchy reads from a colours-only
-//! theme: `colors.toml` and `backgrounds/<wallpaper>.png`. No
+//! theme: `colors.toml`, `backgrounds/<wallpaper>.png` and a rendered
+//! `preview.png` for the picker. No
 //! `hyprland.lua`, `neovim.lua` or terminal configs — those Omarchy
 //! templates itself from the palette, and a theme that ships them is
 //! treated as shipping code (see `omarchy-theme-set`'s deny list).
@@ -48,10 +49,114 @@ pub fn export(target: &Path) -> std::io::Result<Vec<PathBuf>> {
         let palette = wm_theme::omarchy::palette_from_theme(&theme);
         std::fs::write(dir.join("colors.toml"), colors_toml(&theme.name, &palette))?;
         let (file, png) = background(&theme.wallpaper, theme.appearance)?;
-        std::fs::write(dir.join("backgrounds").join(file), png)?;
+        std::fs::write(dir.join("backgrounds").join(&file), png.clone())?;
+        // The picker's tile. A theme without one is a blank rectangle
+        // in Omarchy's theme list, which is the whole reason a user
+        // scrolls that list — see `preview`.
+        std::fs::write(dir.join("preview.png"), preview(&theme, &png)?)?;
         written.push(dir);
     }
     Ok(written)
+}
+
+/// The width and height of a rendered preview. Omarchy's own previews
+/// are full-resolution screenshots; a picker scales whatever it is
+/// given, so this is sized to read clearly as a thumbnail without
+/// carrying a megabyte per theme.
+const PREVIEW: (u32, u32) = (1280, 800);
+
+/// Draws a theme's `preview.png`: its background with two of its own
+/// window frames on it.
+///
+/// Rendered rather than photographed, deliberately. Omarchy's previews
+/// are screenshots, and a screenshot is truer — but producing one needs
+/// a running compositor on a real display, which puts it out of reach
+/// of an exporter that has to work over ssh, in a package build and in
+/// CI. What is drawn here comes from the same `ThemeEngine` the
+/// compositor decorates live windows with, so the chrome in the tile is
+/// the chrome the user will get; only the arrangement is invented.
+///
+/// The two frames are the smallest arrangement that says something: one
+/// focused and one not, because a theme's focused/unfocused distinction
+/// is the thing a picker most needs to show and the thing a flat colour
+/// swatch cannot.
+fn preview(theme: &wm_theme::Theme, background_png: &[u8]) -> std::io::Result<Vec<u8>> {
+    use tiny_skia::{Pixmap, PixmapPaint, Transform};
+    use wm_theme_api::{DecorationRequest, Size, ThemeEngine};
+
+    let (width, height) = PREVIEW;
+    let mut canvas = Pixmap::new(width, height).ok_or_else(|| {
+        std::io::Error::other("preview canvas could not be allocated")
+    })?;
+
+    // The background, scaled to cover. `background` already handed us
+    // PNG bytes for every theme — the procedural grounds included,
+    // which it renders flat — so there is always something to draw.
+    if let Ok(art) = Pixmap::decode_png(background_png) {
+        let scale = (width as f32 / art.width() as f32).max(height as f32 / art.height() as f32);
+        canvas.draw_pixmap(
+            ((width as f32 - art.width() as f32 * scale) / 2.0) as i32,
+            ((height as f32 - art.height() as f32 * scale) / 2.0) as i32,
+            art.as_ref(),
+            &PixmapPaint::default(),
+            Transform::from_scale(scale, scale),
+            None,
+        );
+    }
+
+    let engine = wm_theme::RasterThemeEngine::new(theme.clone());
+    // Back window first, then the focused one over it, so the overlap
+    // reads the way a stack of windows does.
+    for (content, origin, title, focused) in [
+        (Size::new(520, 320), (150_i32, 150_i32), "Documents".to_string(), false),
+        (Size::new(560, 340), (330_i32, 300_i32), theme.name.clone(), true),
+    ] {
+        let request = DecorationRequest {
+            content_size: content,
+            title,
+            focused,
+            resizable: true,
+            buttons: Vec::new(),
+        };
+        let layout = engine.layout(&request);
+        let buffer = engine.render(&request, &layout);
+        let Some(frame) = Pixmap::from_vec(
+            buffer.pixels.clone(),
+            tiny_skia::IntSize::from_wh(buffer.width, buffer.height)
+                .ok_or_else(|| std::io::Error::other("decoration buffer has no size"))?,
+        ) else {
+            continue;
+        };
+        canvas.draw_pixmap(origin.0, origin.1, frame.as_ref(), &PixmapPaint::default(), Transform::identity(), None);
+        // The content the frame is drawn around. `render` produces the
+        // decoration only — a live window's middle is the client's
+        // pixels — so without this the tile shows two black holes and
+        // reads as a broken screenshot rather than a desktop. The
+        // theme's own terminal background is the honest fill: it is the
+        // colour this theme actually dresses a window's contents in,
+        // and it is the one surface every one of these themes defines.
+        let bg = theme.terminal.bg;
+        canvas.fill_rect(
+            tiny_skia::Rect::from_xywh(
+                (origin.0 + layout.client_offset.x) as f32,
+                (origin.1 + layout.client_offset.y) as f32,
+                content.w as f32,
+                content.h as f32,
+            )
+            .ok_or_else(|| std::io::Error::other("content rect has no size"))?,
+            &tiny_skia::Paint {
+                shader: tiny_skia::Shader::SolidColor(
+                    tiny_skia::Color::from_rgba8(bg.r, bg.g, bg.b, 255),
+                ),
+                ..Default::default()
+            },
+            Transform::identity(),
+            None,
+        );
+
+    }
+
+    canvas.encode_png().map_err(std::io::Error::other)
 }
 
 /// The palette file, headed with where it came from so nobody edits
@@ -125,7 +230,12 @@ mod tests {
             let bytes = std::fs::read(&background).unwrap_or_else(|e| panic!("{}: {e}", background.display()));
             assert!(tiny_skia::Pixmap::decode_png(&bytes).is_ok(), "{}: a PNG Omarchy can set", theme.id);
             let entries: Vec<_> = std::fs::read_dir(&dir).unwrap().map(|e| e.unwrap().file_name().to_string_lossy().to_string()).collect();
-            assert_eq!(entries.len(), 2, "{}: colors.toml and backgrounds/, nothing that runs code: {entries:?}", theme.id);
+            assert_eq!(
+                entries.len(),
+                3,
+                "{}: colors.toml, backgrounds/ and preview.png, nothing that runs code: {entries:?}",
+                theme.id
+            );
         }
         let _ = std::fs::remove_dir_all(&target);
     }
@@ -139,6 +249,58 @@ mod tests {
         let text = std::fs::read_to_string(target.join("graphite/colors.toml")).unwrap();
         assert!(wm_theme::omarchy::OmarchyPalette::parse(&text).is_ok(), "overwritten with the real palette");
         let _ = std::fs::remove_dir_all(&target);
+    }
+
+    /// A preview is written for every theme, at the declared size, and
+    /// it is a *picture* rather than a flat rectangle.
+    ///
+    /// The uniformity check is the load-bearing half. The first version
+    /// of this renderer filled each window's content before compositing
+    /// its frame, and the decoration buffer — which covers the whole
+    /// frame, content region included, and is opaque there — painted
+    /// straight over it. Every preview still had the right dimensions
+    /// and a plausible file size; only looking at one showed two black
+    /// holes where the windows should be. A test that counted bytes
+    /// would have passed.
+    #[test]
+    fn every_theme_gets_a_preview_that_is_not_a_flat_rectangle() {
+        let target = scratch("preview");
+        export(&target).unwrap();
+        for theme in wm_theme::default_theme::all_themes() {
+            let png = target.join(&theme.id).join("preview.png");
+            let pixmap = tiny_skia::Pixmap::decode_png(&std::fs::read(&png).unwrap())
+                .unwrap_or_else(|error| panic!("{}: preview is not a PNG: {error}", theme.id));
+            assert_eq!((pixmap.width(), pixmap.height()), PREVIEW, "{}", theme.id);
+
+            let pixels = pixmap.pixels();
+            let at = |x: u32, y: u32| {
+                let p = pixels[(y * pixmap.width() + x) as usize];
+                (p.red(), p.green(), p.blue())
+            };
+            // Inside the focused window, well clear of its chrome.
+            let content = at(600, 430);
+            // Its titlebar. A frame that drew puts something else here;
+            // a frame that did not leaves the content colour.
+            let titlebar = at(600, 311);
+            assert_ne!(
+                content, titlebar,
+                "{}: the focused window's titlebar and its content are the same colour, so no frame was drawn",
+                theme.id
+            );
+            // And the content is the theme's own background rather than
+            // the opaque black the decoration buffer carries there.
+            // Deliberately not a "corner differs from centre" check: on
+            // a theme whose wallpaper and terminal share a colour —
+            // ivory-halftone does — that compares equal while
+            // everything is drawn correctly.
+            let bg = theme.terminal.bg;
+            assert_eq!(
+                content,
+                (bg.r, bg.g, bg.b),
+                "{}: the focused window's content must be the theme's own background",
+                theme.id
+            );
+        }
     }
 
     #[test]

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1068,32 +1068,50 @@ impl World {
 /// "Dock" is unconditional — the Dock is chonkstep's own furniture, so
 /// every session has one to show or hide — which is why it is not one
 /// of [`RootMenu`]'s fields.
+/// The root menu on a machine with no Omarchy menu definition to read:
+/// this desk's own tree, which is the only place its theme and
+/// wallpaper rows appear.
 pub const ROOT_MENU_ROWS: &[&str] =
-    &["Terminal", "Applications", "Theme", "Wallpaper", "Dock", "Omarchy Bar", "Omarchy", "Exit"];
+    &["Terminal", "Applications", "Theme", "Wallpaper", "Dock", "Omarchy Bar", "Exit"];
 
-/// Which of the root menu's optional rows a session carries. The
-/// default — neither — is the menu the harness's own default session
-/// shows on a machine with no Omarchy menu definition.
+/// Which rows a session's root menu carries.
+///
+/// The menu has two shapes. With an Omarchy menu definition to read,
+/// *its* rows are the menu — at the top level, not behind a cascade —
+/// with `Applications` folded in ahead of them (Omarchy's own `Apps`
+/// row is provider-backed and skipped, so nothing else offers a
+/// launcher) and this desk's furniture toggles after. Without one, the
+/// desk falls back to its own tree, [`ROOT_MENU_ROWS`].
+///
+/// The default — no Omarchy rows, no bar — is what the harness's own
+/// default session shows.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RootMenu {
     /// The session hosts Omarchy's shell, so the bar toggle is listed.
     pub omarchy_bar: bool,
-    /// An Omarchy menu definition was found, so its submenu is listed.
-    pub omarchy: bool,
+    /// The Omarchy menu's own top-level row labels, in order. Empty
+    /// when no definition was found, which selects the fallback tree.
+    pub omarchy_rows: &'static [&'static str],
 }
 
 impl RootMenu {
     /// The rows this menu shows, in order.
     pub fn rows(self) -> Vec<&'static str> {
-        ROOT_MENU_ROWS
-            .iter()
-            .copied()
-            .filter(|row| match *row {
-                "Omarchy Bar" => self.omarchy_bar,
-                "Omarchy" => self.omarchy,
-                _ => true,
-            })
-            .collect()
+        if self.omarchy_rows.is_empty() {
+            return ROOT_MENU_ROWS
+                .iter()
+                .copied()
+                .filter(|row| *row != "Omarchy Bar" || self.omarchy_bar)
+                .collect();
+        }
+        let mut rows = vec!["Applications", "Terminal"];
+        rows.extend_from_slice(self.omarchy_rows);
+        rows.push("Dock");
+        if self.omarchy_bar {
+            rows.push("Omarchy Bar");
+        }
+        rows.push("Exit");
+        rows
     }
 
     /// How many rows this menu shows — what [`Session::open_root_menu`]
@@ -1762,20 +1780,30 @@ mod tests {
     /// them: the Dock is chonkstep's own furniture, so there is no
     /// session with no Dock to offer.
     #[test]
-    fn root_menu_rows_keep_their_order_with_and_without_the_optional_ones() {
+    fn root_menu_rows_keep_their_order_in_both_shapes() {
+        // No Omarchy definition: this desk's own tree, which is the
+        // only place Theme and Wallpaper appear.
         let plain = RootMenu::default();
         assert_eq!(plain.rows(), ["Terminal", "Applications", "Theme", "Wallpaper", "Dock", "Exit"]);
         assert_eq!(plain.row_of("Dock"), Some(4));
         assert_eq!(plain.row_of("Exit"), Some(5));
         assert_eq!(plain.row_of("Omarchy Bar"), None);
-        let hosted = RootMenu { omarchy_bar: true, omarchy: false };
+        let hosted = RootMenu { omarchy_bar: true, omarchy_rows: &[] };
         assert_eq!(hosted.row_count(), 7);
         assert_eq!(hosted.row_of("Dock"), Some(4), "this desk's own column, then the guest's bar");
         assert_eq!(hosted.row_of("Omarchy Bar"), Some(5));
-        let full = RootMenu { omarchy_bar: true, omarchy: true };
-        assert_eq!(full.rows(), ROOT_MENU_ROWS);
-        assert_eq!(full.row_of("Omarchy"), Some(6));
-        assert_eq!(full.row_of("Exit"), Some(7));
+
+        // With one, Omarchy's rows *are* the menu: Applications ahead
+        // of them because Omarchy's own launcher row is skipped, this
+        // desk's toggles after, and no `Omarchy` cascade anywhere.
+        let full = RootMenu { omarchy_bar: true, omarchy_rows: &["Style", "System"] };
+        assert_eq!(
+            full.rows(),
+            ["Applications", "Terminal", "Style", "System", "Dock", "Omarchy Bar", "Exit"]
+        );
+        assert_eq!(full.row_of("Omarchy"), None, "the menu is Omarchy's; it does not contain one");
+        assert_eq!(full.row_of("Theme"), None, "one theme system: Omarchy's Style row owns it");
+        assert_eq!(full.row_of("Exit"), Some(6));
     }
 
     #[test]

--- a/crates/chonk-testkit/tests/dock_toggle.rs
+++ b/crates/chonk-testkit/tests/dock_toggle.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 /// The root menu on the harness's default session: no hosted shell, so
 /// no `Omarchy Bar` row, and an empty `OMARCHY_PATH` so no `Omarchy`
 /// submenu either. The `Dock` row is unconditional.
-const PLAIN: RootMenu = RootMenu { omarchy_bar: false, omarchy: false };
+const PLAIN: RootMenu = RootMenu { omarchy_bar: false, omarchy_rows: &[] };
 
 /// Toggles maximize on the focused window with the default binding.
 /// Two modifiers, so the door's single-modifier `chord` does not fit.

--- a/crates/chonk-testkit/tests/omarchy_bar.rs
+++ b/crates/chonk-testkit/tests/omarchy_bar.rs
@@ -34,7 +34,7 @@ const BAR: u32 = 48;
 /// The root menu on a desk with a hosted shell and no Omarchy menu
 /// definition (the scratch root below carries none): the bar toggle is
 /// listed, the Omarchy submenu is not.
-const HOSTED: RootMenu = RootMenu { omarchy_bar: true, omarchy: false };
+const HOSTED: RootMenu = RootMenu { omarchy_bar: true, omarchy_rows: &[] };
 
 /// Writes the Omarchy root the compositor will find: the QML file the
 /// launcher would hand Quickshell (never read here) and a launcher that

--- a/crates/chonk-testkit/tests/omarchy_menu.rs
+++ b/crates/chonk-testkit/tests/omarchy_menu.rs
@@ -24,7 +24,11 @@ use std::time::Duration;
 /// (the scratch tree) and the shell is not hosted (the harness
 /// default), so the Omarchy submenu is listed and the bar toggle is
 /// not.
-const WITH_OMARCHY: RootMenu = RootMenu { omarchy_bar: false, omarchy: true };
+/// With a definition present, Omarchy's own top-level rows *are* the
+/// root menu — the scratch tree's `Test` cascade and its `Marked`
+/// action — with `Applications` and `Terminal` ahead of them and this
+/// desk's `Dock` toggle and `Exit` after.
+const WITH_OMARCHY: RootMenu = RootMenu { omarchy_bar: false, omarchy_rows: &["Test", "Marked"] };
 
 /// Writes a scratch `OMARCHY_PATH` tree whose menu has three rows under
 /// one `Omarchy` submenu — `Plain`, `Guarded` (shown, because the flag
@@ -97,12 +101,15 @@ fn wait_for_conditions(session: &mut Session) {
     .expect("the shell should evaluate the scratch menu's conditions");
 }
 
-/// The whole path a user takes: right-click, Omarchy, a row, and the
-/// row's command running — with the condition model visible in the
-/// row count along the way.
+/// The whole path a user takes: right-click, a row of Omarchy's own
+/// menu, and the row's command running — with the condition model
+/// visible in the row count along the way.
+///
+/// Omarchy's rows sit at the top level rather than behind a cascade,
+/// because this desktop presents *as* Omarchy rather than hosting it.
 #[test]
 #[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit --test omarchy_menu -- --ignored"]
-fn omarchy_submenu_lists_the_conditioned_rows_and_runs_a_picked_action() {
+fn omarchys_rows_are_the_root_menu_and_a_picked_action_runs() {
     let (mut session, markers) = boot("omarchy-menu", "");
     let metrics = MenuMetrics::at_scale_1();
     poll_until(Duration::from_secs(30), "the scratch menu to load (log line)", || {
@@ -111,21 +118,16 @@ fn omarchy_submenu_lists_the_conditioned_rows_and_runs_a_picked_action() {
     .expect("the shell should find the scratch OMARCHY_PATH");
     wait_for_conditions(&mut session);
 
-    // -- root menu carries the Omarchy row --------------------------------
+    // -- the root menu is Omarchy's own -----------------------------------
     let root = session
         .open_root_menu(&metrics, WITH_OMARCHY.row_count())
-        .expect("a right-click on the desktop should open the root menu with an Omarchy row");
+        .expect("a right-click on the desktop should open the root menu carrying Omarchy's rows");
     session.screenshot("root-menu").unwrap();
 
-    // -- Omarchy cascades to the scratch definition's top level ----------
-    // Two top-level rows: the `Test` submenu and the `Marked` action.
-    // `Test`'s three children are one level further in.
-    let omarchy = cascade_from(&mut session, &metrics, &root, WITH_OMARCHY.row_of("Omarchy").unwrap());
-    assert_eq!(metrics.rows_in(omarchy.h), Some(2), "Omarchy submenu should list Test and Marked (surface {omarchy:?})");
-    session.screenshot("omarchy-submenu").unwrap();
-
-    // -- Test cascades to exactly the two rows whose `when` allows -------
-    let test = cascade_from(&mut session, &metrics, &omarchy, 0);
+    // -- `Test` cascades straight from the root, with no wrapper ---------
+    // Its three children are one level in; exactly the two whose `when`
+    // allows are listed.
+    let test = cascade_from(&mut session, &metrics, &root, WITH_OMARCHY.row_of("Test").unwrap());
     assert_eq!(
         metrics.rows_in(test.h),
         Some(2),
@@ -170,9 +172,12 @@ fn escape_closes_the_root_menu_and_every_open_submenu_without_running_an_action(
     let root = session
         .open_root_menu(&metrics, WITH_OMARCHY.row_count())
         .expect("a right-click should open the root menu");
-    let omarchy = cascade_from(&mut session, &metrics, &root, WITH_OMARCHY.row_of("Omarchy").unwrap());
-    let _test = cascade_from(&mut session, &metrics, &omarchy, 0);
-    assert_eq!(session.world().unwrap().menus().len(), 3, "the root and both cascades are mapped before Escape");
+    // `Test` opens straight from the root now, so the deepest stack is
+    // two surfaces rather than three — Escape still has to close all of
+    // them, which is what this test is about.
+    let test = cascade_from(&mut session, &metrics, &root, WITH_OMARCHY.row_of("Test").unwrap());
+    let _ = &test;
+    assert_eq!(session.world().unwrap().menus().len(), 2, "the root and its cascade are mapped before Escape");
 
     session.door().tap_key(keys::ESC).expect("the test door should deliver Escape");
     let mut last = Vec::new();

--- a/crates/chonk-testkit/tests/omarchy_mode.rs
+++ b/crates/chonk-testkit/tests/omarchy_mode.rs
@@ -85,7 +85,7 @@ bright_magenta = "#bb9af7"
 /// The root menu the posture produces: a hosted shell, so the
 /// `Omarchy Bar` row is there, and the scratch Omarchy root below
 /// carries no menu definition, so the `Omarchy` submenu is not.
-const HOSTED: RootMenu = RootMenu { omarchy_bar: true, omarchy: false };
+const HOSTED: RootMenu = RootMenu { omarchy_bar: true, omarchy_rows: &[] };
 
 /// The Omarchy root the compositor will find: the QML file the launcher
 /// would hand Quickshell (never read), and a launcher that runs the

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -102,12 +102,24 @@ Background` whenever Omarchy has a current theme to read (a readable
 row to the Theme submenu), so a built-in theme can wear Omarchy's
 picture too.
 
-The bridge runs the other way too: `omarchy-export-themes` writes each
-built-in theme as an Omarchy theme -- `colors.toml` derived from the
-theme itself plus its wallpaper under `backgrounds/` -- into
+The bridge runs the other way too, and on a machine with Omarchy it is
+the *only* theme list there is: chonkstep offers no theme menu of its
+own when Omarchy's is readable, because two lists that disagree about
+which themes exist is the split system this desktop is trying not to
+have. `omarchy-export-themes` writes each built-in theme as an Omarchy
+theme -- `colors.toml` derived from the theme itself, its wallpaper
+under `backgrounds/`, and a `preview.png` for Omarchy's picker -- into
 `~/.config/omarchy/themes/` (or a directory you name), after which
 `omarchy-theme-set amber-phosphor` dresses the rest of the machine to
-match. It is built with the shell (`cargo build -p chonk-shell`) and
+match. `scripts/install.sh` runs it once so the themes are in the
+picker from the first login.
+
+The preview is *rendered*, not photographed: the theme's background
+with two of its own window frames on it, drawn through the same
+`ThemeEngine` the compositor decorates live windows with. A screenshot
+would be truer, and needs a running compositor on a real display --
+which an exporter that has to work over ssh, in a package build and in
+CI does not have. It is built with the shell (`cargo build -p chonk-shell`) and
 lives at `target/release/omarchy-export-themes` in a checkout, at
 `~/.local/bin/omarchy-export-themes` after `scripts/install.sh`, and at
 `/usr/bin/omarchy-export-themes` from the Arch package; the whole

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -293,6 +293,23 @@ install -d "$bin"
 ln -sfn "${repo}/scripts/chonk-get" "$bin/chonk-get"
 ln -sfn "${repo}/scripts/chonkstep-bugreport" "$bin/chonkstep-bugreport"
 ln -sfn "${repo}/target/release/omarchy-export-themes" "$bin/omarchy-export-themes"
+# ...and run it once, so this desktop's themes are in Omarchy's own
+# picker from the first login rather than after the user finds a
+# command they were never told about. This is the whole of "one theme
+# system": chonkstep offers no theme list of its own when Omarchy is
+# present (see the root menu in `chonk-shell`'s `desktop.rs`), so if the
+# built-ins are not exported they are not reachable at all.
+#
+# Writing into the user's config on install is a real intrusion, so it
+# is bounded: the exporter only ever touches `<target>/<theme id>/`
+# for ids this desktop ships, it writes nothing that runs code, and a
+# rerun refreshes those directories rather than adding more. A failure
+# is not fatal to the install — a machine without Omarchy has nowhere
+# to put them and does not need them.
+if [ -x "${repo}/target/release/omarchy-export-themes" ]; then
+    "${repo}/target/release/omarchy-export-themes" >/dev/null 2>&1 ||
+        echo "note: could not export themes into ~/.config/omarchy/themes; run omarchy-export-themes by hand" >&2
+fi
 # chonk-netjoin is the odd one out here: nobody types it. It is the
 # wifi passphrase dialog the LNK panel spawns when someone clicks a
 # secured network it has no saved profile for, and the dock launches it


### PR DESCRIPTION
Fixes #133

chonkstep is meant to be a replacement desktop environment for Omarchy, and the seams read the other way round: the root menu was titled `chonkstep` and offered Omarchy's menu as one submenu inside its own tree, with a second theme list beside Omarchy's own.

## The root menu is Omarchy's

With a menu definition to read, Omarchy's rows *are* the menu — at the top level, not behind an `Omarchy ▸` cascade. Two of this desk's rows are folded in rather than wrapping it:

- **`Applications` goes first**, and it has to. Omarchy's own `Apps` row is provider-backed, and `MenuModel::build` skips provider rows (`Skip::Provider`) — so promoting Omarchy's tree alone would leave the desktop with **no application launcher in its menu at all**. This was the one thing that could have gone quietly wrong; only two rows in the whole definition are skipped this way (`apps` and `style.font`), which is why everything else survives untouched.
- **`Dock` and `Omarchy Bar` go last**, before `Exit`: choices about this desk's furniture, with no counterpart in Omarchy's tree.

`Theme ▸` and `Wallpaper ▸` are deliberately **not** carried over — see below.

With no definition to read the menu is exactly as it was, because a machine without Omarchy still needs a way to pick a theme, a wallpaper and an application, and those are precisely the rows the other branch drops.

## One theme list

`style.theme` and `style.background` survive the filter, drive `omarchy-theme-set`, and this compositor already follows the symlink that writes. Offering a second list beside them is the split system this change exists to remove, so the root menu stops offering one.

chonkstep's built-ins reach that single list by being exported into `~/.config/omarchy/themes/` — machinery that already existed (`omarchy_export`, and the bidirectional palette conversion in `wm-theme::omarchy`). What was missing is that a user had to know to run it, so `scripts/install.sh` now runs it once. That is a real intrusion into the user's config and is bounded accordingly: only `<target>/<theme id>/` for ids this desktop ships, nothing that runs code, a rerun refreshes rather than accumulates, and a failure is not fatal to the install.

## Theme previews

An Omarchy theme without a `preview.png` is a blank tile in the picker, which is the one place a user looks at themes. The exporter now renders one: the theme's background with two of its own window frames on it, one focused and one not — the focused/unfocused distinction is what a picker most needs to show and what a colour swatch cannot.

Rendered, not photographed. A screenshot would be truer and needs a running compositor on a real display, which an exporter that runs over ssh, in a package build and in CI does not have. The chrome comes from the same `ThemeEngine` the compositor decorates live windows with, so what is in the tile is what the user gets; only the arrangement is invented.

**Two bugs I only found by looking at the output.** The first version filled each window's content *before* compositing its frame — and the decoration buffer covers the whole frame, content region included, opaque. Every preview had the right dimensions and a plausible file size, and every window was a black hole. The second was in my own test: I first asserted "the desk's corner differs from a window's middle", which is false for `ivory-halftone`, whose wallpaper and terminal background are the same ivory. The test now compares a window's titlebar against its content, and asserts the content equals the theme's own background — the exact regression, verified by removing the fill and watching it fail.

## De-branding

`ROOT_MENU_TITLE` is `Omarchy`, and the `About chonkstep` row is `About`. User-visible surfaces only: crate names, log lines, `docs/`, config paths, state directories and `HYPRLAND_INSTANCE_SIGNATURE` are untouched, because renaming those breaks existing installs and buys nothing anybody sees.

## Tests

`chonk-testkit`'s `RootMenu` model carried the menu's contract as a fixed row list; the contract now has two shapes, so the model does too — `omarchy_rows: &'static [&'static str]`, empty selecting the fallback tree. Updating it rather than patching around it is what keeps the harness honest about what the menu is.

- `the_root_menu_is_omarchys_tree_when_there_is_one_and_this_desks_own_when_there_is_not` (unit) — both shapes, and explicit assertions that no `Omarchy` wrapper and no second `Theme` list exist.
- `root_menu_rows_keep_their_order_in_both_shapes` (testkit) — the same contract from the harness's side.
- `omarchys_rows_are_the_root_menu_and_a_picked_action_runs` (e2e, renamed) — right-click, a row of Omarchy's own menu, the command running. The cascade now opens straight from the root, so the deepest stack is two surfaces rather than three, which `escape_closes_…` asserts.
- `every_theme_gets_a_preview_that_is_not_a_flat_rectangle` — dimensions, a frame actually drawn, and the content in the theme's own colour.

## Commands run

```
cargo test --workspace --all-targets                          all targets ok
cargo clippy --workspace --all-targets --no-deps -- \
  -D warnings -D clippy::disallowed_methods \
  -D clippy::disallowed_types \
  -D clippy::undocumented_unsafe_blocks                       clean
RUSTDOCFLAGS='-D warnings -A rustdoc::private_intra_doc_links' \
  cargo doc --workspace --no-deps --locked \
  --document-private-items                                    clean
git diff --check                                              clean
cargo test -p chonk-testkit --test omarchy_menu --test dock_toggle \
  --test omarchy_bar --test builtin_panel -- --ignored --test-threads=1
                                                              7 passed, 0 failed
```

`scripts/e2e.sh --headless` cannot run on the development machine: `weston`, `zenity` and `wlr-randr` are absent and the script refuses to start without them. CI's `wayland` job has the full client set.

## Known limitations / follow-up

- **Omarchy's menu still shows rows chonkstep refuses.** The mirror filters Hyprland-only actions, but the plugin menu reached by `super+space` is Omarchy's own and unfiltered — a gap noted in the plugin analysis, not addressed here.
- **`style.font` is skipped** as a provider row, so font selection is not reachable from the menu in either shape. It was not reachable before either.
- **The exported previews are 1280×800.** Omarchy's own are full-resolution screenshots; a picker scales what it is given, and matching their resolution would multiply the export's size for no visible gain at tile size.
- The About dialog's own contents were not audited for the product name beyond the menu row that opens it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
