### PR TITLE
wayland: complete compositor compatibility batch

### DIFF
--- a/crates/chonk-hyprland-ipc/src/dispatch.rs
+++ b/crates/chonk-hyprland-ipc/src/dispatch.rs
@@ -80,6 +80,11 @@ pub enum Action {
     /// Scale in protocol units (120 == 1.0), avoiding floating-point
     /// equality in an action that is compared in conformance tests.
     SetMonitorScale { output: String, scale_120: u32 },
+    /// Power one named output, or every output when `output` is `None`.
+    SetDpms { output: Option<String>, powered: bool },
+    /// Select a group from the seat keymap. Hyprland accepts next,
+    /// previous, or a zero-based numeric group.
+    SwitchKeyboardLayout { device: String, target: LayoutTarget },
     /// Hide or restore the compositor-owned pointer image. This is a
     /// live session property used by Omarchy's screensaver, not a
     /// persisted Hyprland configuration mutation.
@@ -107,6 +112,13 @@ pub enum Direction {
     Right,
     Up,
     Down,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutTarget {
+    Next,
+    Previous,
+    Index(u32),
 }
 
 /// The result of parsing one dispatch request.
@@ -163,7 +175,6 @@ const TILING_ONLY: &[(&str, &str)] = &[
     ("lockgroups", "chonkstep has no window groups"),
     ("togglespecialworkspace", "chonkstep has no special (scratchpad) workspaces"),
     ("workspaceopt", "chonkstep has no per-workspace layout options"),
-    ("dpms", "chonkstep does not control output power from IPC; dpmsStatus remains the real powered-on state"),
     ("submap", "chonkstep's keybindings do not have submaps"),
 ];
 
@@ -298,6 +309,7 @@ fn parse_classic(verb: &str, rest: &str, snapshot: &Snapshot) -> Outcome {
             .map(|window| Outcome::Run(Action::ConfirmFloating(window.id)))
             .unwrap_or_else(|| Outcome::Unsupported(format!("no window matches {rest:?}"))),
         "tagwindow" => classic_tag(rest, snapshot),
+        "dpms" => parse_dpms(rest, snapshot),
         "focusmonitor" | "movecurrentworkspacetomonitor" | "focuswindowbyclass" => {
             Outcome::Unsupported(format!("{verb} is not implemented yet"))
         }
@@ -373,7 +385,7 @@ fn parse_lua(rest: &str, snapshot: &Snapshot) -> Outcome {
         }
         "window.set_prop" => Outcome::Unsupported("window opacity and other dynamic properties are not modeled".to_string()),
         "cursor.move" => Outcome::Unsupported("chonkstep does not warp the pointer from IPC".to_string()),
-        "dpms" => Outcome::Unsupported("chonkstep does not control output power from IPC".to_string()),
+        "dpms" => parse_dpms_lua(body, snapshot),
         other => Outcome::Unknown(format!("unknown Lua dispatcher hl.dsp.{other}")),
     }
 }
@@ -428,6 +440,17 @@ pub fn parse_eval(source: &str, snapshot: &Snapshot) -> Outcome {
 /// supports. The broad namespace remains a refusal; this exception is
 /// the exact fallback shipped by Omarchy's screensaver.
 pub fn parse_keyword(source: &str) -> Outcome {
+    let source = source.trim();
+    if let Some(spec) = source.strip_prefix("monitor ") {
+        if let Some((name, operation)) = spec.split_once(',') {
+            if operation.trim().eq_ignore_ascii_case("disable") {
+                return Outcome::Unsupported(format!(
+                    "output {:?} cannot be disabled: chonkstep keeps every connected output in the desktop layout; configure persistent layout in ~/.config/hypr with hl.monitor, or use `hyprctl dispatch dpms off {}` for temporary power-off",
+                    name.trim(), name.trim()
+                ));
+            }
+        }
+    }
     let mut fields = source.split_whitespace();
     match (fields.next(), fields.next(), fields.next()) {
         (Some("cursor:invisible"), Some(value), None) => match parse_bool(value) {
@@ -445,6 +468,77 @@ pub fn parse_keyword(source: &str) -> Outcome {
                 .to_string(),
         ),
     }
+}
+
+/// Parse `switchxkblayout DEVICE next|prev|N` after the request table
+/// has separated the command name from its arguments.
+pub fn parse_switch_keyboard_layout(source: &str, snapshot: &Snapshot) -> Outcome {
+    let mut fields = source.split_whitespace();
+    let Some(device) = fields.next() else {
+        return Outcome::Unsupported("switchxkblayout requires a device and layout".to_string());
+    };
+    let Some(target) = fields.next() else {
+        return Outcome::Unsupported("switchxkblayout requires next, prev, or a layout index".to_string());
+    };
+    if fields.next().is_some() {
+        return Outcome::Unsupported("switchxkblayout accepts exactly one device and one layout".to_string());
+    }
+    if device != "all" && !snapshot.devices.keyboards.iter().any(|keyboard| keyboard.name == device) {
+        return Outcome::Unsupported(format!("switchxkblayout names unknown keyboard {device:?}"));
+    }
+    let target = match target.to_ascii_lowercase().as_str() {
+        "next" => LayoutTarget::Next,
+        "prev" | "previous" => LayoutTarget::Previous,
+        value => match value.parse::<u32>() {
+            Ok(index) => LayoutTarget::Index(index),
+            Err(_) => return Outcome::Unsupported("layout must be next, prev, or a zero-based index".to_string()),
+        },
+    };
+    Outcome::Run(Action::SwitchKeyboardLayout { device: device.to_string(), target })
+}
+
+fn parse_dpms(source: &str, snapshot: &Snapshot) -> Outcome {
+    let mut fields = source.split_whitespace();
+    let Some(state) = fields.next() else {
+        return Outcome::Unsupported("dpms requires on, off, or toggle".to_string());
+    };
+    let output = fields.next().map(str::to_string);
+    if fields.next().is_some() {
+        return Outcome::Unsupported("dpms accepts one optional output name".to_string());
+    }
+    if output.as_deref().is_some_and(|name| !snapshot.monitors.iter().any(|monitor| monitor.name == name)) {
+        return Outcome::Unsupported(format!("dpms names unknown output {:?}", output.as_deref().unwrap_or_default()));
+    }
+    let powered = match state.to_ascii_lowercase().as_str() {
+        "on" => true,
+        "off" => false,
+        "toggle" => {
+            let current = output.as_deref()
+                .and_then(|name| snapshot.monitors.iter().find(|monitor| monitor.name == name))
+                .or_else(|| snapshot.focused_monitor())
+                .is_none_or(|monitor| monitor.powered);
+            !current
+        }
+        _ => return Outcome::Unsupported("dpms state must be on, off, or toggle".to_string()),
+    };
+    Outcome::Run(Action::SetDpms { output, powered })
+}
+
+fn parse_dpms_lua(body: &str, snapshot: &Snapshot) -> Outcome {
+    let state = lua_field(body, "state")
+        .or_else(|| lua_field(body, "enabled"))
+        .or_else(|| lua_field(body, "action"))
+        .or_else(|| lua_string(body));
+    let Some(state) = state else {
+        return Outcome::Unsupported("hl.dsp.dpms requires state=on or state=off".to_string());
+    };
+    let state = match state.to_ascii_lowercase().as_str() {
+        "enable" | "enabled" => "on",
+        "disable" | "disabled" => "off",
+        _ => state.as_str(),
+    };
+    let output = lua_field(body, "output").or_else(|| lua_field(body, "monitor"));
+    parse_dpms(&format!("{}{}", state, output.map_or_else(String::new, |name| format!(" {name}"))), snapshot)
 }
 
 fn selected_window<'a>(selector: &str, snapshot: &'a Snapshot) -> Option<&'a Window> {

--- a/crates/chonk-hyprland-ipc/src/event.rs
+++ b/crates/chonk-hyprland-ipc/src/event.rs
@@ -37,7 +37,7 @@
 //! which was not previously tracked." So the emission order below is
 //! creations, then moves, then destructions:
 //!
-//! 1. `monitoraddedv2`, `createworkspacev2` — things others will refer to
+//! 1. `monitoradded`, `monitoraddedv2`, `createworkspacev2` — things others will refer to
 //! 2. `openwindow` — needs its workspace to exist
 //! 3. `movewindowv2`, `windowtitlev2`, `urgent` — need their window to exist
 //! 4. `workspacev2`, `focusedmon`, `activewindowv2`, `fullscreen` — focus
@@ -140,6 +140,10 @@ impl Differ {
         // --- 1. additions others will refer to -------------------------
         for monitor in &now.monitors {
             if !previous.monitors.iter().any(|old| old.id == monitor.id) {
+                // Legacy consumers subscribe to `monitoradded`; newer
+                // Hyprland clients prefer the richer v2 payload. Send
+                // both, legacy first, as Hyprland does.
+                events.push(Event::new("monitoradded", monitor.name.clone()));
                 events.push(Event::new(
                     "monitoraddedv2",
                     format!("{},{},{}", monitor.id, monitor.name, monitor.description),

--- a/crates/chonk-hyprland-ipc/src/server.rs
+++ b/crates/chonk-hyprland-ipc/src/server.rs
@@ -247,6 +247,14 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
                 _ => (response, None),
             }
         }
+        "switchxkblayout" => {
+            let outcome = dispatch::parse_switch_keyboard_layout(&request.args, snapshot);
+            let response = outcome.response();
+            match outcome {
+                Outcome::Run(action) => (response, Some(action)),
+                _ => (response, None),
+            }
+        }
         "eval" => {
             let outcome = dispatch::parse_eval(&request.args, snapshot);
             let response = outcome.response();
@@ -268,13 +276,12 @@ pub fn answer(request: &Request, snapshot: &Snapshot) -> (String, Option<Action>
         //  - `binds` and `devices` below report chonkstep's real seat.
         "getoption" => (
             if json {
-                // This is the complete Hyprland option shape. The
-                // value is explicitly unset rather than a fabricated
-                // compositor setting, so callers can use their own
-                // fallback without receiving `undefined` fields.
+                // Value fields are deliberately absent. QML's
+                // `Number(undefined)` is NaN and `undefined || fallback`
+                // selects the fallback; JSON null would coerce to zero
+                // and recreate the bug this shape prevents.
                 serde_json::json!({
-                    "option": request.args, "int": 0, "float": 0.0,
-                    "str": "", "data": "0", "css": "0px", "set": false
+                    "option": request.args, "set": false
                 }).to_string()
             } else {
                 "no such option".to_string()

--- a/crates/chonk-hyprland-ipc/src/state.rs
+++ b/crates/chonk-hyprland-ipc/src/state.rs
@@ -50,6 +50,12 @@ pub struct Monitor {
     pub width: i32,
     pub height: i32,
     pub scale: f64,
+    /// Whether the connector is currently powered. A powered-off
+    /// output remains in the layout and keeps its workspaces.
+    pub powered: bool,
+    /// Whether adaptive sync is supported and currently enabled.
+    pub vrr_supported: bool,
+    pub vrr_enabled: bool,
     /// Whether this is the output the session considers focused.
     pub focused: bool,
     /// The 0-based chonkstep workspace index active on this output.
@@ -458,8 +464,8 @@ impl Snapshot {
                     scale: monitor.scale,
                     transform: monitor.transform,
                     focused: monitor.focused,
-                    dpms_status: true,
-                    vrr: false,
+                    dpms_status: monitor.powered,
+                    vrr: monitor.vrr_enabled,
                     solitary_blocked_by: self.locked.then(|| "LOCK".to_string()).into_iter().collect(),
                     actively_tearing: false,
                     direct_scanout_to: None,

--- a/crates/chonk-hyprland-ipc/tests/protocol.rs
+++ b/crates/chonk-hyprland-ipc/tests/protocol.rs
@@ -9,10 +9,10 @@
 //! becomes a silent wrong answer downstream, which is the exact failure
 //! this whole crate is built to prevent.
 
-use chonk_hyprland_ipc::dispatch::{self, Action, Fullscreen};
+use chonk_hyprland_ipc::dispatch::{self, Action, Fullscreen, LayoutTarget};
 use chonk_hyprland_ipc::request::Request;
 use chonk_hyprland_ipc::server::answer_payload;
-use chonk_hyprland_ipc::state::{Devices, Monitor, MonitorMode, Snapshot, Window, Workspace};
+use chonk_hyprland_ipc::state::{Devices, Keyboard, Monitor, MonitorMode, Snapshot, Window, Workspace};
 use chonk_hyprland_ipc::{Differ, Outcome};
 
 fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monitor {
@@ -25,6 +25,9 @@ fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monit
         width: 2560,
         height: 1600,
         scale: 2.0,
+        powered: true,
+        vrr_supported: true,
+        vrr_enabled: false,
         focused,
         active_workspace,
         make: "Sharp".to_string(),
@@ -551,11 +554,17 @@ fn classic_geometry_distinguishes_relative_from_exact_for_every_target_form() {
 /// they are not running; the documented "unset" shape leaves Style.qml's
 /// `catch` to keep its previous value, which is the correct outcome.
 #[test]
-fn getoption_returns_a_complete_explicitly_unset_shape() {
+fn getoption_omits_values_that_javascript_would_coerce_to_zero() {
     let value = ask_json("j/getoption decoration:rounding", &desktop());
-    assert_eq!(value["int"], 0);
-    assert_eq!(value["css"], "0px");
+    assert!(value.get("int").is_none());
+    assert!(value.get("float").is_none());
+    assert!(value.get("css").is_none());
     assert_eq!(value["set"], serde_json::json!(false));
+    assert_eq!(
+        value.as_object().unwrap().keys().cloned().collect::<std::collections::BTreeSet<_>>(),
+        ["option".to_string(), "set".to_string()].into_iter().collect(),
+        "an unset reply must contain no value JavaScript can mistake for a configured zero"
+    );
 }
 
 /// `KeyboardLayout.qml` refuses to speak for the seat unless
@@ -565,6 +574,63 @@ fn getoption_returns_a_complete_explicitly_unset_shape() {
 fn devices_keeps_the_shape_the_keyboard_widget_tests_for() {
     let value = ask_json("j/devices", &desktop());
     assert!(value["keyboards"].is_array(), "keyboards must be an array");
+}
+
+#[test]
+fn dpms_dispatches_name_real_output_power_actions() {
+    for (request, output, powered) in [
+        ("/dispatch dpms off", None, false),
+        ("/dispatch dpms on eDP-1", Some("eDP-1"), true),
+        ("/dispatch dpms toggle eDP-1", Some("eDP-1"), false),
+    ] {
+        let (response, actions) = answer_payload(request.as_bytes(), &desktop());
+        assert_eq!(response.trim(), "ok", "{request}");
+        assert_eq!(
+            actions,
+            vec![Action::SetDpms { output: output.map(str::to_string), powered }],
+            "{request}"
+        );
+    }
+    let (response, actions) = answer_payload(b"/dispatch dpms off absent", &desktop());
+    assert!(response.contains("unknown output"));
+    assert!(actions.is_empty());
+
+    let (response, actions) = answer_payload(
+        br#"/dispatch hl.dsp.dpms({ action = "disable", monitor = "eDP-1" })"#,
+        &desktop(),
+    );
+    assert_eq!(response.trim(), "ok");
+    assert_eq!(
+        actions,
+        vec![Action::SetDpms { output: Some("eDP-1".into()), powered: false }]
+    );
+}
+
+#[test]
+fn switchxkblayout_is_a_named_group_action_not_an_unknown_request() {
+    let mut desk = desktop();
+    desk.devices.keyboards.push(Keyboard {
+        name: "at-translated-set-2-keyboard".into(),
+        layout: "English (US), German".into(),
+        active_keymap: "English (US)".into(),
+        active_layout_index: 0,
+    });
+    for (target, expected) in [
+        ("next", LayoutTarget::Next),
+        ("prev", LayoutTarget::Previous),
+        ("1", LayoutTarget::Index(1)),
+    ] {
+        let request = format!("/switchxkblayout at-translated-set-2-keyboard {target}");
+        let (response, actions) = answer_payload(request.as_bytes(), &desk);
+        assert_eq!(response.trim(), "ok", "{request}");
+        assert_eq!(
+            actions,
+            vec![Action::SwitchKeyboardLayout {
+                device: "at-translated-set-2-keyboard".into(),
+                target: expected,
+            }]
+        );
+    }
 }
 
 #[test]
@@ -600,6 +666,42 @@ fn workspace_switch_emits_workspacev2_with_the_hyprland_id() {
     let line = events.iter().find(|e| e.name() == "workspacev2").expect("workspacev2");
     assert_eq!(line.data(), "2,2", "chonkstep index 1 is Hyprland workspace 2");
     assert_eq!(line.line(), "workspacev2>>2,2\n");
+}
+
+#[test]
+fn adding_a_monitor_emits_legacy_then_v2_events() {
+    let mut differ = Differ::new();
+    let before = desktop();
+    differ.diff(&before);
+
+    let mut after = before;
+    after.monitors.push(monitor(1, "HDMI-A-1", false, 0));
+    let events = differ.diff(&after);
+    let names: Vec<_> = events.iter().map(chonk_hyprland_ipc::Event::name).collect();
+    let legacy = names.iter().position(|name| *name == "monitoradded").expect("monitoradded");
+    let v2 = names.iter().position(|name| *name == "monitoraddedv2").expect("monitoraddedv2");
+    assert!(legacy < v2, "legacy consumers must learn the monitor before richer events reference it");
+    assert_eq!(events[legacy].data(), "HDMI-A-1");
+}
+
+#[test]
+fn keyboard_group_change_emits_activelayout_with_the_human_name() {
+    let mut differ = Differ::new();
+    let mut before = desktop();
+    before.devices.keyboards.push(Keyboard {
+        name: "keyboard".into(),
+        layout: "English (US), German".into(),
+        active_keymap: "English (US)".into(),
+        active_layout_index: 0,
+    });
+    differ.diff(&before);
+    let mut after = before;
+    after.devices.keyboards[0].active_keymap = "German".into();
+    after.devices.keyboards[0].active_layout_index = 1;
+
+    let events = differ.diff(&after);
+    let event = events.iter().find(|event| event.name() == "activelayout").expect("activelayout");
+    assert_eq!(event.data(), "keyboard,German");
 }
 
 /// Quickshell's `openwindow` handler takes four comma-separated fields

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -1357,6 +1357,15 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             repeat_rate: next.input.repeat_rate,
             repeat_delay: next.input.repeat_delay,
         });
+        wm.backend_mut().set_pointer_config(wm_core::PointerConfig {
+            sensitivity: next.input.sensitivity,
+            natural_scroll: next.input.natural_scroll,
+            tap_to_click: next.input.tap_to_click,
+            clickfinger_behavior: next.input.clickfinger_behavior,
+            scroll_factor: next.input.scroll_factor,
+            left_handed: next.input.left_handed,
+            accel_profile: next.input.accel_profile.clone(),
+        });
         // ...and then re-ask for every window already on the desk. A
         // rule that only reached windows opened after it was written
         // would mean closing and reopening the very window whose chrome
@@ -1431,7 +1440,11 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         );
 
         // 3. The decoration engine, and with it every client's chrome.
-        wm.set_theme_engine(Box::new(RasterThemeEngine::with_fonts(self.theme.clone(), self.fonts.clone())));
+        wm.set_theme_engine(Box::new(RasterThemeEngine::with_fonts_at_scale(
+            self.theme.clone(),
+            self.fonts.clone(),
+            self.state.scale,
+        )));
         if scale_changed {
             // The only pixels in the session the theme engine does not
             // produce: the backend's own pointer cursors.

--- a/crates/chonk-testkit/tests/e2e.rs
+++ b/crates/chonk-testkit/tests/e2e.rs
@@ -32,6 +32,8 @@
 //! in or leaving the ledger, a geometry becoming true. The only
 //! `sleep` anywhere is the poll cadence inside `poll_until`.
 
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 use chonk_testkit::{is_dark, poll_until, Session, SessionOptions, WindowInfo};
@@ -66,6 +68,69 @@ fn csd_options() -> SessionOptions {
         config_extra: "[decorations]\nclient_side = [\"zenity\"]\n".to_string(),
         ..SessionOptions::default()
     }
+}
+
+fn hyprland_request(session: &Session, request: &str) -> Result<String, String> {
+    let log = session.log();
+    let line = log
+        .lines()
+        .find(|line| line.contains("hyprland ipc listening"))
+        .ok_or("the compositor did not announce its Hyprland IPC directory")?;
+    let directory = line
+        .split("directory=\"")
+        .nth(1)
+        .and_then(|tail| tail.split('"').next())
+        .ok_or_else(|| format!("could not parse Hyprland IPC directory from {line:?}"))?;
+    let mut socket = UnixStream::connect(std::path::Path::new(directory).join(".socket.sock"))
+        .map_err(|error| format!("connect to Hyprland IPC: {error}"))?;
+    socket
+        .set_read_timeout(Some(ACT))
+        .map_err(|error| format!("set Hyprland IPC timeout: {error}"))?;
+    socket
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("write Hyprland IPC request: {error}"))?;
+    socket
+        .shutdown(std::net::Shutdown::Write)
+        .map_err(|error| format!("finish Hyprland IPC request: {error}"))?;
+    let mut response = String::new();
+    socket
+        .read_to_string(&mut response)
+        .map_err(|error| format!("read Hyprland IPC response: {error}"))?;
+    Ok(response)
+}
+
+#[test]
+#[ignore = "needs a live Wayland session to nest in: scripts/e2e.sh, or cargo test -p chonk-testkit -- --ignored --test-threads=1"]
+fn keyboard_layout_ipc_switches_and_reports_the_active_group() {
+    let mut session = Session::boot(
+        "keyboard-layout-switch",
+        SessionOptions {
+            env: vec![("XKB_DEFAULT_LAYOUT".into(), "us,de".into())],
+            ..SessionOptions::default()
+        },
+    )
+    .unwrap();
+
+    let before: serde_json::Value =
+        serde_json::from_str(&hyprland_request(&session, "j/devices").unwrap()).unwrap();
+    let before = &before["keyboards"][0];
+    assert_eq!(before["active_layout_index"], 0);
+    assert_eq!(before["layout"], before["active_keymap"]);
+
+    assert_eq!(
+        hyprland_request(&session, "/switchxkblayout all next")
+            .unwrap()
+            .trim(),
+        "ok"
+    );
+    session.door().barrier().unwrap();
+
+    let after: serde_json::Value =
+        serde_json::from_str(&hyprland_request(&session, "j/devices").unwrap()).unwrap();
+    let after = &after["keyboards"][0];
+    assert_eq!(after["active_layout_index"], 1);
+    assert_eq!(after["layout"], after["active_keymap"]);
+    assert_ne!(after["active_keymap"], before["active_keymap"]);
 }
 
 /// Launches a zenity question dialog and waits for it to map. The

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -165,7 +165,7 @@ fn main() {
     // replacements around the same one on every later restyle — see
     // `wm_theme::FontState`.
     let fonts = FontState::new();
-    let engine = RasterThemeEngine::with_fonts(theme, fonts.clone());
+    let engine = RasterThemeEngine::with_fonts_at_scale(theme, fonts.clone(), state.scale);
 
     // The entire desktop shell — dock, Clip, launcher strip, menus,
     // wallpaper, the `.desktop` application index — is built here in
@@ -428,6 +428,9 @@ fn main() {
         // launcher running-state — everything the shell refreshes per
         // tick rather than per event.
         shell.tick(&mut wm);
+        // Interactive resize/move invalidations are coalesced across this
+        // entire input burst and rasterized once at its display boundary.
+        wm.flush_decorations();
 
         // The tick above may have consumed an appearance-request and
         // switched the session's mode; XSETTINGS is the binary's to

--- a/crates/wm-config/src/hyprland/conf.rs
+++ b/crates/wm-config/src/hyprland/conf.rs
@@ -81,6 +81,7 @@ pub fn read(
             } else if block
                 .first()
                 .is_some_and(|root| root.eq_ignore_ascii_case("input"))
+                && !name.eq_ignore_ascii_case("touchpad")
             {
                 out.push(Directive::Ignored {
                     kind: "input",
@@ -91,10 +92,14 @@ pub fn read(
             continue;
         }
         if !block.is_empty() {
-            if block.len() == 1 && block[0].eq_ignore_ascii_case("input") {
+            if !block.is_empty() && block[0].eq_ignore_ascii_case("input") {
                 match line.split_once('=') {
                     Some((name, value)) => out.push(Directive::Input {
-                        name: name.trim().to_ascii_lowercase(),
+                        name: if block.len() == 2 && block[1].eq_ignore_ascii_case("touchpad") {
+                            format!("touchpad:{}", name.trim().to_ascii_lowercase())
+                        } else {
+                            name.trim().to_ascii_lowercase()
+                        },
                         value: substitute(value.trim(), vars),
                     }),
                     None => out.push(Directive::Ignored {

--- a/crates/wm-config/src/hyprland/lua.rs
+++ b/crates/wm-config/src/hyprland/lua.rs
@@ -837,11 +837,23 @@ fn emit_config(value: &Value, out: &mut Vec<Directive>) {
     if let Some(Value::Table(fields)) = input {
         for (key, value) in fields {
             let Some(key) = key else { continue };
-            if matches!(value, Value::Table(_)) {
-                out.push(Directive::Ignored {
-                    kind: "input",
-                    detail: format!("nested input setting {key} is not implemented"),
-                });
+            if let Value::Table(nested) = value {
+                if key == "touchpad" {
+                    for (nested_key, nested_value) in nested {
+                        let Some(nested_key) = nested_key else { continue };
+                        if !matches!(nested_value, Value::Table(_)) {
+                            out.push(Directive::Input {
+                                name: format!("touchpad:{nested_key}"),
+                                value: property_text(nested_value),
+                            });
+                        }
+                    }
+                } else {
+                    out.push(Directive::Ignored {
+                        kind: "input",
+                        detail: format!("nested input setting {key} is not implemented"),
+                    });
+                }
             } else {
                 out.push(Directive::Input {
                     name: key.clone(),

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -963,6 +963,46 @@ fn input(reading: &mut Reading, name: &str, value: &str) {
                 why: "repeat delay must be an integer from 1 through 5000 milliseconds".into(),
             }),
         },
+        "sensitivity" => match value.parse::<f64>() {
+            Ok(speed) if speed.is_finite() && (-1.0..=1.0).contains(&speed) => {
+                reading.input.sensitivity = Some(speed)
+            }
+            _ => reading.skipped.push(Skipped {
+                kind: "input".into(),
+                what: format!("sensitivity = {value}"),
+                why: "pointer sensitivity must be between -1 and 1".into(),
+            }),
+        },
+        "natural_scroll" | "touchpad:natural_scroll" => {
+            parse_input_bool(reading, name, &value, |input, enabled| input.natural_scroll = Some(enabled))
+        }
+        "tap_to_click" | "touchpad:tap_to_click" => {
+            parse_input_bool(reading, name, &value, |input, enabled| input.tap_to_click = Some(enabled))
+        }
+        "clickfinger_behavior" | "touchpad:clickfinger_behavior" => {
+            parse_input_bool(reading, name, &value, |input, enabled| input.clickfinger_behavior = Some(enabled))
+        }
+        "left_handed" | "touchpad:left_handed" => {
+            parse_input_bool(reading, name, &value, |input, enabled| input.left_handed = Some(enabled))
+        }
+        "scroll_factor" | "touchpad:scroll_factor" => match value.parse::<f64>() {
+            Ok(factor) if factor.is_finite() && (0.01..=10.0).contains(&factor) => {
+                reading.input.scroll_factor = Some(factor)
+            }
+            _ => reading.skipped.push(Skipped {
+                kind: "input".into(),
+                what: format!("{name} = {value}"),
+                why: "scroll factor must be between 0.01 and 10".into(),
+            }),
+        },
+        "accel_profile" => match value.to_ascii_lowercase().as_str() {
+            "flat" | "adaptive" => reading.input.accel_profile = Some(value.to_ascii_lowercase()),
+            _ => reading.skipped.push(Skipped {
+                kind: "input".into(),
+                what: format!("accel_profile = {value}"),
+                why: "acceleration profile must be flat or adaptive".into(),
+            }),
+        },
         "follow_mouse" => reading.skipped.push(Skipped {
             kind: "input".into(),
             what: format!("follow_mouse = {value}"),
@@ -972,6 +1012,27 @@ fn input(reading: &mut Reading, name: &str, value: &str) {
             kind: "input".into(),
             what: format!("{other} = {value}"),
             why: "input setting is not implemented".into(),
+        }),
+    }
+}
+
+fn parse_input_bool(
+    reading: &mut Reading,
+    name: &str,
+    value: &str,
+    assign: impl FnOnce(&mut crate::InputConfig, bool),
+) {
+    let enabled = match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    };
+    match enabled {
+        Some(enabled) => assign(&mut reading.input, enabled),
+        None => reading.skipped.push(Skipped {
+            kind: "input".into(),
+            what: format!("{name} = {value}"),
+            why: "input toggle must be true or false".into(),
         }),
     }
 }

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -476,7 +476,11 @@ fn keyboard_input_is_carried_but_hyprlands_focus_policy_is_not() {
 hl.config({ input = {
   kb_layout = "de", kb_variant = "nodeadkeys", kb_model = "pc105",
   kb_options = "compose:caps", repeat_rate = 40, repeat_delay = 250,
-  follow_mouse = 1,
+  follow_mouse = 1, sensitivity = -0.25, accel_profile = "flat",
+  touchpad = {
+    natural_scroll = true, tap_to_click = false,
+    clickfinger_behavior = true, scroll_factor = 0.4,
+  },
 } })
 o.bind("XF86TouchpadToggle", "Touchpad", "touchpad toggle")
 o.bind("XF86TouchpadOn", "Touchpad on", "touchpad on")
@@ -491,6 +495,12 @@ o.bind("SUPER + SHIFT + code:201", "Menu", "omarchy-menu")
     assert_eq!(reading.input.options.as_deref(), Some("compose:caps"));
     assert_eq!(reading.input.repeat_rate, Some(40));
     assert_eq!(reading.input.repeat_delay, Some(250));
+    assert_eq!(reading.input.sensitivity, Some(-0.25));
+    assert_eq!(reading.input.accel_profile.as_deref(), Some("flat"));
+    assert_eq!(reading.input.natural_scroll, Some(true));
+    assert_eq!(reading.input.tap_to_click, Some(false));
+    assert_eq!(reading.input.clickfinger_behavior, Some(true));
+    assert_eq!(reading.input.scroll_factor, Some(0.4));
     assert!(
         skipped_why(&reading, "follow_mouse")
             .is_some_and(|why| why.contains("focus policy belongs to chonkstep")),
@@ -2014,7 +2024,7 @@ fn the_numbers_the_documents_quote_are_the_numbers_this_machine_produces() {
     // number there is the normal case rather than a fault.
     assert_eq!(
         reading.skipped.len(),
-        175,
+        173,
         "directives this desktop has its own answer for"
     );
     const GUIDE: &str = include_str!("../../../../docs/hyprland-config.md");
@@ -2024,7 +2034,7 @@ fn the_numbers_the_documents_quote_are_the_numbers_this_machine_produces() {
     );
     assert!(
         GUIDE.contains("files=42 bindings=153 commands=113 env=8 autostart=4")
-            && GUIDE.contains("float_rules=45 monitors=1 skipped=175"),
+            && GUIDE.contains("float_rules=45 monitors=1 skipped=173"),
         "the guide's sample log line no longer matches what this machine reports"
     );
 }

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -56,6 +56,15 @@
 //! server_side = ["bare.kde.app"]     # frame a client whose own chrome never shows up
 //! client_side = ["borderless-game"]  # let an xdg client stay bare
 //!
+//! [input]                            # optional; live libinput configuration
+//! sensitivity = 0.0                 # -1.0 through 1.0
+//! accel_profile = "adaptive"         # or "flat"
+//! left_handed = false
+//!
+//! [input.touchpad]
+//! natural_scroll = true
+//! scroll_factor = 0.4
+//!
 //! [keybindings]
 //! "alt+shift+return" = "spawn-terminal"
 //! "super+t" = "spawn-terminal"       # extra binding for the same action
@@ -222,7 +231,7 @@ pub struct Binding {
 }
 
 /// Keyboard settings imported from Hyprland's `input {}` table.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct InputConfig {
     pub rules: Option<String>,
     pub model: Option<String>,
@@ -231,6 +240,15 @@ pub struct InputConfig {
     pub options: Option<String>,
     pub repeat_rate: Option<i32>,
     pub repeat_delay: Option<i32>,
+    /// Libinput pointer/touchpad settings. `scroll_factor` is applied
+    /// after libinput so it scales both continuous and v120 axes.
+    pub sensitivity: Option<f64>,
+    pub natural_scroll: Option<bool>,
+    pub tap_to_click: Option<bool>,
+    pub clickfinger_behavior: Option<bool>,
+    pub scroll_factor: Option<f64>,
+    pub left_handed: Option<bool>,
+    pub accel_profile: Option<String>,
 }
 
 /// Maps a kebab-case action name from a config file to its [`Action`].
@@ -1019,6 +1037,71 @@ fn edge_resistance_from_value(value: &toml::Value) -> Option<u32> {
     u32::try_from(*px).ok()
 }
 
+fn input_number(value: &toml::Value) -> Option<f64> {
+    match value {
+        toml::Value::Float(number) if number.is_finite() => Some(*number),
+        toml::Value::Integer(number) => Some(*number as f64),
+        _ => None,
+    }
+}
+
+/// Apply chonkstep's native `[input]` spelling over whichever pointer
+/// defaults came from a preset or the Hyprland compatibility reader.
+///
+/// `touchpad` is accepted as a nested table because that is the shape
+/// Omarchy users already know. Until per-device matching lands, both the
+/// flat and nested spellings describe the libinput pointer fallback; the
+/// nested table is applied last so an explicitly touchpad-shaped value wins.
+fn apply_input_table(config: &mut InputConfig, entries: &toml::Table, prefix: &str) {
+    for (key, value) in entries {
+        let setting = if prefix.is_empty() {
+            key.to_string()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match key.as_str() {
+            "sensitivity" => match input_number(value) {
+                Some(speed) if (-1.0..=1.0).contains(&speed) => config.sensitivity = Some(speed),
+                _ => tracing::warn!(key = %setting, value = ?value, "config: input sensitivity must be a number from -1 to 1, ignoring it"),
+            },
+            "natural_scroll" => match value.as_bool() {
+                Some(enabled) => config.natural_scroll = Some(enabled),
+                None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
+            },
+            "tap_to_click" => match value.as_bool() {
+                Some(enabled) => config.tap_to_click = Some(enabled),
+                None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
+            },
+            "clickfinger_behavior" => match value.as_bool() {
+                Some(enabled) => config.clickfinger_behavior = Some(enabled),
+                None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
+            },
+            "left_handed" => match value.as_bool() {
+                Some(enabled) => config.left_handed = Some(enabled),
+                None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
+            },
+            "scroll_factor" => match input_number(value) {
+                Some(factor) if factor > 0.0 => config.scroll_factor = Some(factor),
+                _ => tracing::warn!(key = %setting, value = ?value, "config: input scroll_factor must be a positive number, ignoring it"),
+            },
+            "accel_profile" => match value.as_str().map(str::trim) {
+                Some(profile) if profile.eq_ignore_ascii_case("flat") => {
+                    config.accel_profile = Some("flat".into())
+                }
+                Some(profile) if profile.eq_ignore_ascii_case("adaptive") => {
+                    config.accel_profile = Some("adaptive".into())
+                }
+                _ => tracing::warn!(key = %setting, value = ?value, "config: input accel_profile must be \"flat\" or \"adaptive\", ignoring it"),
+            },
+            "touchpad" if prefix.is_empty() => match value.as_table() {
+                Some(touchpad) => apply_input_table(config, touchpad, "touchpad"),
+                None => tracing::warn!(value = ?value, "config: [input.touchpad] must be a table, ignoring it"),
+            },
+            unknown => tracing::warn!(key = %setting, name = %unknown, "config: unknown input setting, ignoring it"),
+        }
+    }
+}
+
 /// The pure core [`load`] wraps: parses config-file text into a
 /// [`Config`], merging over [`Config::default_config`].
 ///
@@ -1307,6 +1390,13 @@ pub fn parse_with(
                     "config: [decorations] must be a table, ignoring it"
                 ),
             },
+            "input" => match value {
+                toml::Value::Table(entries) => apply_input_table(&mut config.input, entries, ""),
+                other => tracing::warn!(
+                    value = ?other,
+                    "config: [input] must be a table, ignoring it"
+                ),
+            },
             "commands" => match value {
                 toml::Value::Table(entries) => {
                     for (name, value) in entries {
@@ -1422,6 +1512,7 @@ pub fn parse_with(
             "terminal" if argv_from_value(value, "terminal").is_some() => Some("terminal"),
             "self_decorating_apps" if value.is_array() => Some("decorations"),
             "decorations" if value.is_table() => Some("decorations"),
+            "input" if value.is_table() => Some("input"),
             "commands" if value.is_table() => Some("commands"),
             "autostart" if value.is_array() => Some("autostart"),
             "keybindings" if value.is_table() => Some("keybindings"),
@@ -1946,6 +2037,34 @@ mod tests {
         // the whole point: the lists are exceptions, not the policy.
         assert_eq!(config.decorations.decision_for(Some("foot")), None);
         assert_eq!(config.decorations.decision_for(None), None);
+    }
+
+    #[test]
+    fn native_input_table_overrides_imported_pointer_defaults() {
+        let config = parse(
+            r#"
+[input]
+sensitivity = -0.35
+accel_profile = "FLAT"
+left_handed = true
+
+[input.touchpad]
+natural_scroll = true
+tap_to_click = true
+clickfinger_behavior = true
+scroll_factor = 0.4
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.input.sensitivity, Some(-0.35));
+        assert_eq!(config.input.accel_profile.as_deref(), Some("flat"));
+        assert_eq!(config.input.left_handed, Some(true));
+        assert_eq!(config.input.natural_scroll, Some(true));
+        assert_eq!(config.input.tap_to_click, Some(true));
+        assert_eq!(config.input.clickfinger_behavior, Some(true));
+        assert_eq!(config.input.scroll_factor, Some(0.4));
+        assert_eq!(config.provenance.get("input").map(String::as_str), Some("config file"));
     }
 
     #[test]

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -274,7 +274,13 @@ pub trait Backend {
         let _ = window;
         self.destroy_decoration(frame);
     }
-    fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer);
+    fn paint_decoration(&mut self, frame: Self::FrameId, surface: &wm_theme_api::DecorationSurface);
+    /// Physical scale of the output containing most of `frame`. Backends with
+    /// one global pixel scale keep the default.
+    fn decoration_scale(&self, frame: Rect) -> f32 {
+        let _ = frame;
+        1.0
+    }
     /// Sets the frame's cursor to indicate a resize is available along
     /// `edge` — `None` for the plain default cursor. Called on hover
     /// (see `WindowManager`'s handling of `BackendEvent::PointerMotion`'s
@@ -473,6 +479,9 @@ pub trait Backend {
     /// this verb existed the reload path answered `ok` and changed
     /// nothing.
     fn set_keyboard_config(&mut self, _config: KeyboardConfig) {}
+    /// Applies libinput-owned pointer settings where the backend owns
+    /// those devices. X11 leaves them to its display server.
+    fn set_pointer_config(&mut self, _config: crate::PointerConfig) {}
     /// Whether the client has already drawn its own window chrome, and
     /// so must not be framed. See [`crate::ClientChrome`] for why this is not
     /// derivable from [`Self::window_type`].

--- a/crates/wm-core/src/client.rs
+++ b/crates/wm-core/src/client.rs
@@ -1,5 +1,5 @@
 use slotmap::new_key_type;
-use wm_theme_api::{DecorationLayout, Rect};
+use wm_theme_api::{DecorationLayout, DecorationRequest, Rect, Size};
 
 use crate::backend::Backend;
 use crate::types::ClientChrome;
@@ -171,6 +171,11 @@ pub struct Client<B: Backend> {
     /// Kept in core state so IPC queries and rule-driven behavior see
     /// the same lifetime as the managed window.
     pub tags: Vec<String>,
+    /// Last pixels handed to the backend. Together these fields make an
+    /// identical repaint a true no-op and preserve stable renderer element ids.
+    pub(crate) last_decoration_request: Option<DecorationRequest>,
+    pub(crate) last_decoration_frame_size: Size,
+    pub(crate) last_decoration_scale_bits: u32,
 }
 
 impl<B: Backend> Client<B> {
@@ -203,6 +208,9 @@ impl<B: Backend> Client<B> {
             // output is unplugged out from under it.
             monitor: MonitorId::default(),
             tags: Vec::new(),
+            last_decoration_request: None,
+            last_decoration_frame_size: Size::default(),
+            last_decoration_scale_bits: 0,
         }
     }
 }

--- a/crates/wm-core/src/fake_backend.rs
+++ b/crates/wm-core/src/fake_backend.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use wm_theme_api::{
-    ButtonKind, DecorationBuffer, DecorationLayout, DecorationRequest, Point, Rect, ResizeEdge,
-    Size, ThemeEngine,
+    ButtonKind, DecorationBuffer, DecorationLayout, DecorationRequest, DecorationSurface, Point,
+    Rect, ResizeEdge, Size, ThemeEngine,
 };
 
 use crate::backend::Backend;
@@ -88,6 +88,7 @@ pub struct FakeBackend {
     /// disagrees with `last_frame_geometry` is a visible bug there even
     /// though X11's server-side clipping would hide it.
     pub last_paint_size: HashMap<FakeFrameId, Size>,
+    pub last_paint_bytes: HashMap<FakeFrameId, usize>,
     pub last_frame_geometry: HashMap<FakeFrameId, Rect>,
     /// Where each client window was last positioned directly. For a
     /// framed window this is its offset inside its frame; for a
@@ -408,10 +409,11 @@ impl Backend for FakeBackend {
         self.destroyed_frames.insert(frame);
     }
 
-    fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
+    fn paint_decoration(&mut self, frame: Self::FrameId, surface: &DecorationSurface) {
         self.painted_frames.insert(frame);
         *self.paint_count.entry(frame).or_insert(0) += 1;
-        self.last_paint_size.insert(frame, Size::new(buffer.width, buffer.height));
+        self.last_paint_size.insert(frame, surface.frame_size);
+        self.last_paint_bytes.insert(frame, surface.retained_bytes());
     }
 
     fn set_frame_cursor(&mut self, frame: Self::FrameId, edge: Option<ResizeEdge>) {

--- a/crates/wm-core/src/lib.rs
+++ b/crates/wm-core/src/lib.rs
@@ -43,6 +43,7 @@ pub use placement::{place_frame, FloatDecision, FloatPolicy, PlacementPolicy, Wi
 pub use snap::snap_position;
 pub use types::{
     BackendEvent, ClientChrome, DecorationRules, DragHandle, KeyCombo, KeyboardConfig, Modifiers, MouseButton, NetState,
+    PointerConfig,
     NetStateAction, NetStateSnapshot, ScrollDelta, SizeHints, SurfaceRef, WindowType, WmClass, WmProtocol,
 };
 pub use wm_theme_api::{Point, Rect, Size};

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -310,6 +310,9 @@ pub struct WindowManager<B: Backend> {
     /// back to the *maximized* rect, and reusing maximize's slot would
     /// either clobber its own pre-maximize snapshot or restore too far.
     fullscreen_restore: HashMap<ClientId, Rect>,
+    /// Chrome invalidated by an interactive drag. Drains once at the render
+    /// boundary, not once per input event.
+    pending_decorations: HashSet<ClientId>,
 }
 
 struct CycleSession {
@@ -380,6 +383,7 @@ impl<B: Backend> WindowManager<B> {
             managed_order: Vec::new(),
             focus_history: Vec::new(),
             fullscreen_restore: HashMap::new(),
+            pending_decorations: HashSet::new(),
         }
     }
 
@@ -496,6 +500,9 @@ impl<B: Backend> WindowManager<B> {
     /// scan) and this crate only knows it has a new source of layouts.
     pub fn set_theme_engine(&mut self, theme: Box<dyn ThemeEngine>) {
         self.theme = theme;
+        for client in self.clients.values_mut() {
+            client.last_decoration_request = None;
+        }
         self.relayout_all_clients();
     }
 
@@ -1494,8 +1501,9 @@ impl<B: Backend> WindowManager<B> {
         // A client-decorated window is laid out as though the frame were
         // exactly its content, so every placement and geometry
         // calculation below reads the same for both kinds.
+        let mut decoration_scale = self.backend.decoration_scale(content);
         let mut layout = match chrome {
-            ClientChrome::ServerDrawn => self.theme.layout(&request),
+            ClientChrome::ServerDrawn => self.theme.layout_at(&request, decoration_scale),
             ClientChrome::ClientDrawn => frameless_layout(content.size),
         };
         // The one rule that keys on *who* the window is: Omarchy's own
@@ -1529,7 +1537,7 @@ impl<B: Backend> WindowManager<B> {
             // one it got is a frame with a seam in it.
             request = Self::decoration_request(&client, None);
             layout = match chrome {
-                ClientChrome::ServerDrawn => self.theme.layout(&request),
+                ClientChrome::ServerDrawn => self.theme.layout_at(&request, decoration_scale),
                 ClientChrome::ClientDrawn => frameless_layout(size),
             };
         }
@@ -1597,6 +1605,12 @@ impl<B: Backend> WindowManager<B> {
             self.placements += 1;
             pos
         };
+        let provisional_frame = Rect { pos: frame_pos, size: layout.frame_size };
+        let target_scale = self.backend.decoration_scale(provisional_frame);
+        if chrome == ClientChrome::ServerDrawn && target_scale.to_bits() != decoration_scale.to_bits() {
+            decoration_scale = target_scale;
+            layout = self.theme.layout_at(&request, decoration_scale);
+        }
         let frame_geom = Rect { pos: frame_pos, size: layout.frame_size };
         client.geometry.pos =
             Point::new(frame_geom.pos.x + layout.client_offset.x, frame_geom.pos.y + layout.client_offset.y);
@@ -1616,8 +1630,11 @@ impl<B: Backend> WindowManager<B> {
                     // accompanies them").
                     self.backend.resize_client(window, client.geometry.size);
                 }
-                let buffer = self.theme.render(&request, &layout);
-                self.backend.paint_decoration(frame, &buffer);
+                let surface = self.theme.render_surface_at(&request, &layout, decoration_scale);
+                self.backend.paint_decoration(frame, &surface);
+                client.last_decoration_request = Some(request.clone());
+                client.last_decoration_frame_size = surface.frame_size;
+                client.last_decoration_scale_bits = decoration_scale.to_bits();
                 self.backend.map_frame(frame);
                 Some(frame)
             }
@@ -2266,6 +2283,14 @@ impl<B: Backend> WindowManager<B> {
         } else {
             client.layout.frame_size
         };
+        let old_frame = Rect {
+            pos: Point::new(
+                client.geometry.pos.x - client.layout.client_offset.x,
+                client.geometry.pos.y - client.layout.client_offset.y,
+            ),
+            size: frame_size,
+        };
+        let old_scale = self.backend.decoration_scale(old_frame);
         let (surface_frame, surface_window) = (client.frame, client.window);
         let raw_pos = Point::new(root.x - grab_offset.x, root.y - grab_offset.y);
 
@@ -2303,6 +2328,10 @@ impl<B: Backend> WindowManager<B> {
             new_frame_pos.x + client.layout.client_offset.x,
             new_frame_pos.y + client.layout.client_offset.y,
         );
+        let new_scale = self.backend.decoration_scale(Rect { pos: new_frame_pos, size: frame_size });
+        if old_scale.to_bits() != new_scale.to_bits() {
+            self.reflow_frame(client_id);
+        }
     }
 
     /// Recomputes content size/position fresh from `start_frame` and
@@ -2483,7 +2512,9 @@ impl<B: Backend> WindowManager<B> {
             return;
         }
         let request = Self::decoration_request(client, None);
-        let layout = self.theme.layout(&request);
+        let current_frame = client_frame_rect(client);
+        let scale = self.backend.decoration_scale(current_frame);
+        let layout = self.theme.layout_at(&request, scale);
         // Shaded windows show only the titlebar — the frame's *visible*
         // height is overridden to `shaded_frame_height`, but the client's
         // own content geometry (and everything the theme computed from
@@ -2499,19 +2530,10 @@ impl<B: Backend> WindowManager<B> {
         };
         let window = client.window;
         let content_size = client.geometry.size;
+        let frame = client.frame;
 
-        if let Some(frame) = client.frame {
+        if let Some(frame) = frame {
             self.backend.set_frame_geometry(frame, frame_geom);
-            // Painted from the shade's *own* inputs, never the unshaded
-            // `layout` — see `shaded_paint_inputs` for why the frame
-            // rect alone is not enough.
-            let buffer = if shaded {
-                let (shaded_request, shaded_layout) = shaded_paint_inputs(&request, &layout);
-                self.theme.render(&shaded_request, &shaded_layout)
-            } else {
-                self.theme.render(&request, &layout)
-            };
-            self.backend.paint_decoration(frame, &buffer);
         }
         self.backend.position_client(window, layout.client_offset);
         self.backend.resize_client(window, content_size);
@@ -2520,6 +2542,13 @@ impl<B: Backend> WindowManager<B> {
             client.layout = layout;
         }
         self.publish_frame_extents(id);
+        if frame.is_some() {
+            if self.interactive_drag_client() == Some(id) {
+                self.pending_decorations.insert(id);
+            } else {
+                self.paint_decoration_now(id);
+            }
+        }
     }
 
     /// Grows `id` to fill the usable screen area along `directions`,
@@ -3513,7 +3542,8 @@ impl<B: Backend> WindowManager<B> {
                     .get(id)
                     .map(|client| Self::decoration_request(client, None))
                     .unwrap_or_else(|| Self::decoration_request(&Client::new(window, String::new()), None));
-                let layout = self.theme.layout(&request);
+                let scale = self.backend.decoration_scale(content);
+                let layout = self.theme.layout_at(&request, scale);
                 let frame = self.backend.create_decoration(window, &layout);
                 // Anchor the *content* where it already is; the frame is
                 // built around it, extending up and left by the chrome's
@@ -3545,14 +3575,17 @@ impl<B: Backend> WindowManager<B> {
                     tracing::debug!(?window, ?shift, "moved a window so the frame it just gained is on screen");
                 }
                 self.backend.set_frame_geometry(frame, frame_geom);
-                let buffer = self.theme.render(&request, &layout);
-                self.backend.paint_decoration(frame, &buffer);
+                let surface = self.theme.render_surface_at(&request, &layout, scale);
+                self.backend.paint_decoration(frame, &surface);
                 self.backend.map_frame(frame);
                 self.frame_index.insert(frame, id);
                 if let Some(client) = self.clients.get_mut(id) {
                     client.frame = Some(frame);
                     client.chrome = ClientChrome::ServerDrawn;
                     client.layout = layout;
+                    client.last_decoration_request = Some(request);
+                    client.last_decoration_frame_size = surface.frame_size;
+                    client.last_decoration_scale_bits = scale.to_bits();
                 }
             }
         }
@@ -3812,10 +3845,16 @@ impl<B: Backend> WindowManager<B> {
     /// that "the drag is over" and "the pointer is free" cannot come
     /// apart. Safe to call when nothing is dragging.
     fn end_active_drag(&mut self) {
+        let client = self.interactive_drag_client();
         self.active_move = None;
         self.active_resize = None;
         if let Some(handle) = self.drag_grab.take() {
             self.backend.ungrab_pointer(handle);
+        }
+        // Settle per-output scale and the last constrained size once, after
+        // dropping the drag flag so this final paint is immediate.
+        if let Some(client) = client {
+            self.reflow_frame(client);
         }
     }
 
@@ -3857,6 +3896,25 @@ impl<B: Backend> WindowManager<B> {
     }
 
     fn repaint_decoration(&mut self, id: ClientId) {
+        if self.interactive_drag_client() == Some(id) {
+            self.pending_decorations.insert(id);
+        } else {
+            self.paint_decoration_now(id);
+        }
+    }
+
+    /// Realizes all chrome invalidated during this event-loop pass. Backends
+    /// call this immediately before rendering/presenting, which caps an input
+    /// burst at one raster per client per frame.
+    pub fn flush_decorations(&mut self) {
+        let pending: Vec<_> = self.pending_decorations.drain().collect();
+        for id in pending {
+            self.paint_decoration_now(id);
+        }
+    }
+
+    fn paint_decoration_now(&mut self, id: ClientId) {
+        self.pending_decorations.remove(&id);
         let Some(client) = self.clients.get(id) else {
             return;
         };
@@ -3878,13 +3936,33 @@ impl<B: Backend> WindowManager<B> {
         // update, the button release that immediately follows the
         // shading double-click itself — has to re-derive the shade's
         // paint inputs rather than hand the theme that layout.
-        let buffer = if client.flags.contains(ClientFlags::SHADED) {
+        let (paint_request, paint_layout) = if client.flags.contains(ClientFlags::SHADED) {
             let (shaded_request, shaded_layout) = shaded_paint_inputs(&request, &client.layout);
-            self.theme.render(&shaded_request, &shaded_layout)
+            (shaded_request, shaded_layout)
         } else {
-            self.theme.render(&request, &client.layout)
+            (request, client.layout.clone())
         };
-        self.backend.paint_decoration(frame, &buffer);
+        let frame_rect = Rect {
+            pos: Point::new(
+                client.geometry.pos.x - client.layout.client_offset.x,
+                client.geometry.pos.y - client.layout.client_offset.y,
+            ),
+            size: paint_layout.frame_size,
+        };
+        let scale = self.backend.decoration_scale(frame_rect);
+        if client.last_decoration_request.as_ref() == Some(&paint_request)
+            && client.last_decoration_frame_size == paint_layout.frame_size
+            && client.last_decoration_scale_bits == scale.to_bits()
+        {
+            return;
+        }
+        let surface = self.theme.render_surface_at(&paint_request, &paint_layout, scale);
+        self.backend.paint_decoration(frame, &surface);
+        if let Some(client) = self.clients.get_mut(id) {
+            client.last_decoration_request = Some(paint_request);
+            client.last_decoration_frame_size = surface.frame_size;
+            client.last_decoration_scale_bits = scale.to_bits();
+        }
     }
 
     fn decoration_request(client: &Client<B>, pressed_button: Option<ButtonKind>) -> DecorationRequest {
@@ -6877,6 +6955,50 @@ mod tests {
         let client = wm.client(id).unwrap();
         assert_eq!(client.geometry.size, Size::new(150, 150));
         assert_eq!(client.geometry.pos, Point::new(50, 70), "growing from the SE corner must not move the frame");
+    }
+
+    #[test]
+    fn resize_chrome_is_rasterized_once_at_the_frame_boundary_and_identical_work_is_skipped() {
+        let (mut wm, _id, frame) = client_for_resize(FakeBackend::new());
+        let initial = wm.backend().paint_count.get(&frame).copied().unwrap_or(0);
+        wm.dispatch(frame_press(frame, Point::new(95, 115)));
+        for point in [Point::new(160, 170), Point::new(180, 190), Point::new(200, 220)] {
+            wm.dispatch(BackendEvent::PointerMotion { root: point, surface_local: None });
+        }
+        assert_eq!(
+            wm.backend().paint_count.get(&frame).copied().unwrap_or(0),
+            initial,
+            "input events only invalidate chrome"
+        );
+        wm.flush_decorations();
+        assert_eq!(wm.backend().paint_count.get(&frame).copied().unwrap_or(0), initial + 1);
+
+        wm.dispatch(BackendEvent::PointerMotion { root: Point::new(200, 220), surface_local: None });
+        wm.flush_decorations();
+        assert_eq!(wm.backend().paint_count.get(&frame).copied().unwrap_or(0), initial + 1);
+    }
+
+    #[test]
+    fn synthetic_125_hz_resize_tracks_sixty_hz_frame_boundaries_not_input_rate() {
+        let (mut wm, _id, frame) = client_for_resize(FakeBackend::new());
+        let initial = wm.backend().paint_count.get(&frame).copied().unwrap_or(0);
+        wm.dispatch(frame_press(frame, Point::new(95, 115)));
+
+        // 125 distinct samples over a synthetic second, flushed on the
+        // nearest integer approximation of sixty presentation boundaries.
+        for sample in 0..125 {
+            wm.dispatch(BackendEvent::PointerMotion {
+                root: Point::new(150 + sample, 170 + sample),
+                surface_local: None,
+            });
+            if (sample + 1) * 60 / 125 != sample * 60 / 125 {
+                wm.flush_decorations();
+            }
+        }
+        wm.flush_decorations();
+
+        let rasters = wm.backend().paint_count.get(&frame).copied().unwrap_or(0) - initial;
+        assert_eq!(rasters, 60, "one raster per synthetic frame, never one per input sample");
     }
 
     #[test]

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -427,6 +427,17 @@ pub struct KeyboardConfig {
     pub repeat_delay: Option<i32>,
 }
 
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PointerConfig {
+    pub sensitivity: Option<f64>,
+    pub natural_scroll: Option<bool>,
+    pub tap_to_click: Option<bool>,
+    pub clickfinger_behavior: Option<bool>,
+    pub scroll_factor: Option<f64>,
+    pub left_handed: Option<bool>,
+    pub accel_profile: Option<String>,
+}
+
 
 impl DecorationRules {
     /// The override for `identity`, if any: `Some(true)` to force this

--- a/crates/wm-theme-api/src/decoration.rs
+++ b/crates/wm-theme-api/src/decoration.rs
@@ -75,6 +75,40 @@ pub struct DecorationBuffer {
     pub pixels: Vec<u8>,
 }
 
+/// One independently retained piece of window chrome. Decorations are
+/// deliberately sparse: the client owns the large interior of a frame, so
+/// retaining that interior in a theme buffer wastes memory and turns a tiny
+/// titlebar change into full-window damage.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecorationPart {
+    pub offset: Point,
+    pub buffer: DecorationBuffer,
+}
+
+/// Rasterized chrome for one frame. `frame_size` describes the complete frame
+/// for placement and gap filling; `parts` contain only visible chrome bands.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecorationSurface {
+    pub frame_size: Size,
+    pub parts: Vec<DecorationPart>,
+}
+
+impl DecorationSurface {
+    /// Compatibility adapter for simple themes that still paint one rectangle.
+    pub fn full(buffer: DecorationBuffer) -> Self {
+        Self {
+            frame_size: Size::new(buffer.width, buffer.height),
+            parts: vec![DecorationPart { offset: Point::new(0, 0), buffer }],
+        }
+    }
+
+    /// Exact retained CPU pixel storage, useful for diagnostics and regression
+    /// tests which assert that cost follows the chrome perimeter.
+    pub fn retained_bytes(&self) -> usize {
+        self.parts.iter().map(|part| part.buffer.pixels.len()).sum()
+    }
+}
+
 /// The boundary `wm-core` depends on. Implemented by `wm-theme`, which
 /// owns the theme data model and rendering stack — `wm-core` never sees
 /// a `Theme`, a color, or a font, only this trait's inputs/outputs.
@@ -82,7 +116,31 @@ pub trait ThemeEngine {
     /// Cheap, no rasterization — safe to call on every state change.
     fn layout(&self, request: &DecorationRequest) -> DecorationLayout;
 
+    /// Scale-aware layout hook. Existing themes remain valid at scale 1;
+    /// engines which cache per-output variants override this method.
+    fn layout_at(&self, request: &DecorationRequest, scale: f32) -> DecorationLayout {
+        let _ = scale;
+        self.layout(request)
+    }
+
     /// Rasterizes the decoration. Callers should only invoke this when
     /// `request` actually changed since the last render.
     fn render(&self, request: &DecorationRequest, layout: &DecorationLayout) -> DecorationBuffer;
+
+    /// Sparse decoration output. The default preserves source compatibility;
+    /// real raster engines should emit only the chrome bands.
+    fn render_surface(&self, request: &DecorationRequest, layout: &DecorationLayout) -> DecorationSurface {
+        DecorationSurface::full(self.render(request, layout))
+    }
+
+    /// Scale-aware sparse render companion to [`Self::layout_at`].
+    fn render_surface_at(
+        &self,
+        request: &DecorationRequest,
+        layout: &DecorationLayout,
+        scale: f32,
+    ) -> DecorationSurface {
+        let _ = scale;
+        self.render_surface(request, layout)
+    }
 }

--- a/crates/wm-theme-api/src/lib.rs
+++ b/crates/wm-theme-api/src/lib.rs
@@ -10,8 +10,8 @@ mod geometry;
 mod popup;
 
 pub use decoration::{
-    ButtonKind, ButtonRuntimeState, DecorationBuffer, DecorationLayout, DecorationRequest,
-    ResizeEdge, ThemeEngine,
+    ButtonKind, ButtonRuntimeState, DecorationBuffer, DecorationLayout, DecorationPart,
+    DecorationRequest, DecorationSurface, ResizeEdge, ThemeEngine,
 };
 pub use geometry::{
     clamp_client_size, client_size_limit, subsurface_link_exceeds_depth, Point, Rect, Size,

--- a/crates/wm-theme/src/raster.rs
+++ b/crates/wm-theme/src/raster.rs
@@ -5,12 +5,13 @@
 //! doc comment in `lib.rs`.
 
 use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
 use tiny_skia::Pixmap;
 use wm_theme_api::{
-    ButtonKind, DecorationBuffer, DecorationLayout, DecorationRequest, Point, Rect, ResizeEdge,
-    Size, ThemeEngine,
+    ButtonKind, DecorationBuffer, DecorationLayout, DecorationPart, DecorationRequest,
+    DecorationSurface, Point, Rect, ResizeEdge, Size, ThemeEngine,
 };
 
 use crate::model::Theme;
@@ -109,6 +110,9 @@ impl Default for FontState {
 pub struct RasterThemeEngine {
     theme: Theme,
     fonts: FontState,
+    base_scale: f32,
+    scaled_themes: RefCell<HashMap<u32, Theme>>,
+    title_cache: RefCell<VecDeque<(u32, DecorationRequest, DecorationBuffer)>>,
 }
 
 impl RasterThemeEngine {
@@ -124,13 +128,27 @@ impl RasterThemeEngine {
     /// the engine it swaps in. See [`FontState`] for why this is not
     /// simply another [`Self::new`].
     pub fn with_fonts(theme: Theme, fonts: FontState) -> Self {
+        Self::with_fonts_at_scale(theme, fonts, 1.0)
+    }
+
+    /// Builds an engine whose supplied theme has already been scaled by
+    /// `base_scale`. Other output scales are derived relative to that base and
+    /// cached, so a mixed-DPI desk does not rescan fonts or mutate one global
+    /// theme as windows cross outputs.
+    pub fn with_fonts_at_scale(theme: Theme, fonts: FontState, base_scale: f32) -> Self {
         if !fonts.has_family(&theme.titlebar.font.family) {
             tracing::warn!(
                 family = %theme.titlebar.font.family,
                 "configured theme font not found on the system; text will render with whatever fallback sans font fontdb picks"
             );
         }
-        Self { theme, fonts }
+        Self {
+            theme,
+            fonts,
+            base_scale: base_scale.max(0.125),
+            scaled_themes: RefCell::new(HashMap::new()),
+            title_cache: RefCell::new(VecDeque::new()),
+        }
     }
 
     /// Convenience constructor wrapping the flagship built-in theme.
@@ -163,6 +181,60 @@ impl ThemeEngine for RasterThemeEngine {
             layout,
         )
     }
+
+    fn layout_at(&self, request: &DecorationRequest, scale: f32) -> DecorationLayout {
+        if same_scale(scale, self.base_scale) {
+            return layout_decoration(&self.theme, request);
+        }
+        let key = normalized_scale(scale).to_bits();
+        let mut themes = self.scaled_themes.borrow_mut();
+        let theme = themes.entry(key).or_insert_with(|| self.theme.scaled(scale / self.base_scale));
+        layout_decoration(theme, request)
+    }
+
+    fn render_surface(&self, request: &DecorationRequest, layout: &DecorationLayout) -> DecorationSurface {
+        render_sparse_decoration(
+            &self.theme,
+            &mut self.fonts.font_system.borrow_mut(),
+            &mut self.fonts.swash_cache.borrow_mut(),
+            &mut self.title_cache.borrow_mut(),
+            self.base_scale.to_bits(),
+            request,
+            layout,
+        )
+    }
+
+    fn render_surface_at(
+        &self,
+        request: &DecorationRequest,
+        layout: &DecorationLayout,
+        scale: f32,
+    ) -> DecorationSurface {
+        if same_scale(scale, self.base_scale) {
+            return self.render_surface(request, layout);
+        }
+        let scale = normalized_scale(scale);
+        let key = scale.to_bits();
+        let mut themes = self.scaled_themes.borrow_mut();
+        let theme = themes.entry(key).or_insert_with(|| self.theme.scaled(scale / self.base_scale));
+        render_sparse_decoration(
+            theme,
+            &mut self.fonts.font_system.borrow_mut(),
+            &mut self.fonts.swash_cache.borrow_mut(),
+            &mut self.title_cache.borrow_mut(),
+            key,
+            request,
+            layout,
+        )
+    }
+}
+
+fn normalized_scale(scale: f32) -> f32 {
+    if scale.is_finite() { scale.max(0.125) } else { 1.0 }
+}
+
+fn same_scale(a: f32, b: f32) -> bool {
+    (normalized_scale(a) - normalized_scale(b)).abs() < 0.001
 }
 
 /// Pure arithmetic — no rasterization. Miniaturize sits at the
@@ -283,6 +355,121 @@ fn layout_decoration(theme: &Theme, request: &DecorationRequest) -> DecorationLa
         resize_hitboxes,
         shaded_frame_height: titlebar_height + border * 2,
     }
+}
+
+/// Paints only the four visible chrome bands. The frame interior is filled by
+/// each backend with a cheap solid element/window background, preserving the
+/// old mid-resize gap behavior without retaining a client-sized RGBA image.
+fn render_sparse_decoration(
+    theme: &Theme,
+    font_system: &mut cosmic_text::FontSystem,
+    swash_cache: &mut cosmic_text::SwashCache,
+    title_cache: &mut VecDeque<(u32, DecorationRequest, DecorationBuffer)>,
+    scale_key: u32,
+    request: &DecorationRequest,
+    layout: &DecorationLayout,
+) -> DecorationSurface {
+    let frame = layout.frame_size;
+    let border = theme.border.width as u32;
+    let top_h = layout.client_offset.y.max(0) as u32;
+    let bottom_h = frame
+        .h
+        .saturating_sub(top_h)
+        .saturating_sub(request.content_size.h);
+    let mut parts = Vec::with_capacity(4);
+
+    if frame.w > 0 && top_h > 0 {
+        // Height does not affect title shaping. Normalizing it gives repeated
+        // focus/title repaints and constrained resize passes a small bounded
+        // cache keyed by the visible inputs: title/font scale/frame width.
+        let mut title_key = request.clone();
+        title_key.content_size.h = 0;
+        let cached = title_cache
+            .iter()
+            .find(|(cached_scale, cached_request, _)| {
+                *cached_scale == scale_key && cached_request == &title_key
+            })
+            .map(|(_, _, buffer)| buffer.clone());
+        let was_cached = cached.is_some();
+        let top = cached.unwrap_or_else(|| {
+            // Give the existing whole-frame painter one disposable bottom
+            // border row-band and crop it away. This keeps its exact classic
+            // bevel/button output while allocating only titlebar-sized memory.
+            let mut top_layout = layout.clone();
+            top_layout.frame_size = Size::new(frame.w, top_h.saturating_add(border));
+            let mut top_request = request.clone();
+            top_request.content_size.h = 0;
+            top_request.resizable = false;
+            let rendered = render_decoration(theme, font_system, swash_cache, &top_request, &top_layout);
+            crop_rows(&rendered, 0, top_h)
+        });
+        if !was_cached {
+            title_cache.push_back((scale_key, title_key, top.clone()));
+            while title_cache.len() > 16 {
+                title_cache.pop_front();
+            }
+        }
+        parts.push(DecorationPart { offset: Point::new(0, 0), buffer: top });
+    }
+
+    if frame.w > 0 && bottom_h > 0 {
+        // The full painter puts the resize bar immediately above its bottom
+        // border. Add a disposable top border and crop it off.
+        let mut bottom_layout = DecorationLayout {
+            frame_size: Size::new(frame.w, bottom_h.saturating_add(border)),
+            client_offset: Point::new(border as i32, border as i32),
+            titlebar_height: 0,
+            button_hitboxes: Vec::new(),
+            resize_hitboxes: Vec::new(),
+            shaded_frame_height: 0,
+        };
+        // `render_decoration` only consults this field for geometry already
+        // represented above; keep it explicit for future theme additions.
+        bottom_layout.client_offset.y = border as i32;
+        let mut bottom_request = request.clone();
+        bottom_request.content_size = Size::new(frame.w.saturating_sub(border * 2), 0);
+        bottom_request.title.clear();
+        bottom_request.buttons.clear();
+        let rendered = render_decoration(theme, font_system, swash_cache, &bottom_request, &bottom_layout);
+        let bottom = crop_rows(&rendered, border, bottom_h);
+        parts.push(DecorationPart {
+            offset: Point::new(0, frame.h.saturating_sub(bottom_h) as i32),
+            buffer: bottom,
+        });
+    }
+
+    if border > 0 && request.content_size.h > 0 {
+        let color = if request.focused { theme.border.color_active } else { theme.border.color_inactive };
+        let strip = solid_buffer(border, request.content_size.h, color);
+        parts.push(DecorationPart { offset: Point::new(0, top_h as i32), buffer: strip.clone() });
+        parts.push(DecorationPart {
+            offset: Point::new(frame.w.saturating_sub(border) as i32, top_h as i32),
+            buffer: strip,
+        });
+    }
+
+    DecorationSurface { frame_size: frame, parts }
+}
+
+fn crop_rows(buffer: &DecorationBuffer, first: u32, height: u32) -> DecorationBuffer {
+    let first = first.min(buffer.height);
+    let height = height.min(buffer.height.saturating_sub(first));
+    let stride = buffer.width as usize * 4;
+    let start = first as usize * stride;
+    let end = start + height as usize * stride;
+    DecorationBuffer {
+        width: buffer.width,
+        height,
+        pixels: buffer.pixels.get(start..end).unwrap_or_default().to_vec(),
+    }
+}
+
+fn solid_buffer(width: u32, height: u32, color: crate::model::Color) -> DecorationBuffer {
+    let mut pixels = vec![0; width as usize * height as usize * 4];
+    for rgba in pixels.as_chunks_mut::<4>().0 {
+        rgba.copy_from_slice(&[color.r, color.g, color.b, 0xff]);
+    }
+    DecorationBuffer { width, height, pixels }
 }
 
 fn render_decoration(
@@ -651,6 +838,64 @@ mod tests {
                 .iter()
                 .all(|pixel| pixel[3] == 255),
             "server decorations are an opaque plane and may be submitted as one"
+        );
+    }
+
+    #[test]
+    fn sparse_storage_follows_the_chrome_perimeter_not_the_client_area() {
+        let engine = RasterThemeEngine::nextstep_classic();
+        let mut request = sample_request("large terminal", true);
+        request.content_size = Size::new(1600, 1000);
+        let layout = engine.layout(&request);
+        let surface = engine.render_surface(&request, &layout);
+        let full_bytes = layout.frame_size.w as usize * layout.frame_size.h as usize * 4;
+
+        assert_eq!(surface.frame_size, layout.frame_size);
+        assert_eq!(surface.parts.len(), 4, "top, bottom, left and right chrome bands");
+        assert!(
+            surface.retained_bytes() < full_bytes / 8,
+            "{} sparse bytes should be perimeter-sized, not {} full-frame bytes",
+            surface.retained_bytes(),
+            full_bytes
+        );
+        for part in &surface.parts {
+            assert_eq!(
+                part.buffer.pixels.len(),
+                part.buffer.width as usize * part.buffer.height as usize * 4
+            );
+        }
+    }
+
+    #[test]
+    fn one_engine_selects_the_output_scale_without_rescanning_fonts() {
+        let base = crate::default_theme::nextstep_classic();
+        let fonts = FontState::new();
+        let engine = RasterThemeEngine::with_fonts_at_scale(base.scaled(2.0), fonts, 2.0);
+        let request = sample_request("mixed dpi", true);
+        let one_x = engine.layout_at(&request, 1.0);
+        let two_x = engine.layout_at(&request, 2.0);
+
+        assert!(two_x.titlebar_height > one_x.titlebar_height);
+        assert!(two_x.client_offset.y > one_x.client_offset.y);
+        assert_eq!(engine.layout_at(&request, 1.0), one_x, "cached scale variants are stable");
+    }
+
+    #[test]
+    fn changing_only_content_height_reuses_the_shaped_title_band() {
+        let engine = RasterThemeEngine::nextstep_classic();
+        let request = sample_request("shape me once", true);
+        let layout = engine.layout(&request);
+        let _ = engine.render_surface(&request, &layout);
+        assert_eq!(engine.title_cache.borrow().len(), 1);
+
+        let mut taller = request.clone();
+        taller.content_size.h += 400;
+        let taller_layout = engine.layout(&taller);
+        let _ = engine.render_surface(&taller, &taller_layout);
+        assert_eq!(
+            engine.title_cache.borrow().len(),
+            1,
+            "title, font scale and available width are unchanged"
         );
     }
 

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -51,12 +51,13 @@ use wm_core::{
     Backend, BackendEvent, DragHandle, KeyCombo, MonitorInfo, MouseButton, ScrollDelta, SizeHints, WindowType, WmClass,
     WmProtocol,
 };
-use wm_theme_api::{DecorationBuffer, DecorationLayout, Point, Rect, ResizeEdge, Size};
+use wm_theme_api::{DecorationBuffer, DecorationLayout, DecorationSurface, Point, Rect, ResizeEdge, Size};
 
 use crate::input::DragGrab;
 use crate::state::{
-    ensure_stack_entry, raise_stack_entry, replace_stack_entry, FrameRecord, ManagedSurface, PointerGrabChange,
-    RootBackground, ShellRecord, StackEntry, WaylandBackend, WlFrameId, WlShellId, WlWindowId,
+    ensure_stack_entry, raise_stack_entry, replace_stack_entry, FramePart, FrameRecord, ManagedSurface,
+    PointerGrabChange, RootBackground, ShellRecord, StackEntry, WaylandBackend, WlFrameId, WlShellId,
+    WlWindowId,
 };
 
 /// `wm-theme` rect -> smithay logical rect. The theme side is
@@ -225,6 +226,10 @@ impl Backend for WaylandBackend {
 
     fn monitors_ref(&self) -> &[MonitorInfo] {
         &self.monitors
+    }
+
+    fn decoration_scale(&self, frame: Rect) -> f32 {
+        self.scale_at(frame) as f32
     }
 
     fn diagnostic_snapshot(&self) -> String {
@@ -802,7 +807,16 @@ impl Backend for WaylandBackend {
             record.content.pos = Point::new(layout.client_offset.x, layout.client_offset.y);
             record.mapped = true;
         }
-        self.frames.insert(frame, FrameRecord { window, geometry, buffer: None, mapped: false });
+        self.frames.insert(
+            frame,
+            FrameRecord {
+                window,
+                geometry,
+                parts: Vec::new(),
+                fill_id: smithay::backend::renderer::element::Id::new(),
+                mapped: false,
+            },
+        );
         // A window arriving here with a `StackEntry::Window` slot is one
         // that changed its mind: it mapped client-decorated, and a
         // `_MOTIF_WM_HINTS` rewrite has since made `wm-core` decide it
@@ -867,12 +881,40 @@ impl Backend for WaylandBackend {
         self.mark_damaged();
     }
 
-    fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
+    fn paint_decoration(&mut self, frame: Self::FrameId, surface: &DecorationSurface) {
         if let Some(record) = self.frames.get_mut(&frame) {
-            if let Some(imported) = import_buffer(buffer, true) {
-                record.buffer = Some(imported);
-                self.mark_damaged();
+            let mut previous = std::mem::take(&mut record.parts).into_iter();
+            let mut imported = Vec::with_capacity(surface.parts.len());
+            for part in &surface.parts {
+                let size = Size::new(part.buffer.width, part.buffer.height);
+                if size.w == 0 || size.h == 0 {
+                    continue;
+                }
+                let old = previous.next();
+                let buffer = match old {
+                    Some(mut old) if old.offset == part.offset && old.size == size => {
+                        let pixels = &part.buffer.pixels;
+                        let mut render = old.buffer.render();
+                        let _ = render.draw(|memory| {
+                            if memory.len() == pixels.len() {
+                                memory.copy_from_slice(pixels);
+                            }
+                            Ok::<_, std::convert::Infallible>(vec![SmithayRect::<i32, Buffer>::from_size(
+                                (size.w as i32, size.h as i32).into(),
+                            )])
+                        });
+                        drop(render);
+                        old.buffer
+                    }
+                    _ => match import_buffer(&part.buffer, true) {
+                        Some(buffer) => buffer,
+                        None => continue,
+                    },
+                };
+                imported.push(FramePart { offset: part.offset, size, buffer });
             }
+            record.parts = imported;
+            self.mark_damaged();
         }
     }
 
@@ -1666,6 +1708,11 @@ impl Backend for WaylandBackend {
         // verb only ever sees the ledger. `apply_pending_keyboard`
         // installs it at the top of the next dispatch pass.
         self.pending_keyboard = Some(config);
+    }
+
+    fn set_pointer_config(&mut self, config: wm_core::PointerConfig) {
+        self.pointer_config = config.clone();
+        self.pending_pointer = Some(config);
     }
 
     fn set_decoration_rules(&mut self, rules: wm_core::DecorationRules) {

--- a/crates/wm-wayland/src/core_protocols.rs
+++ b/crates/wm-wayland/src/core_protocols.rs
@@ -31,15 +31,35 @@ use smithay::wayland::xdg_activation::{
 };
 use smithay::wayland::xdg_foreign::{XdgForeignHandler, XdgForeignState};
 use smithay::{
-    delegate_cursor_shape, delegate_keyboard_shortcuts_inhibit,
+    delegate_commit_timing, delegate_cursor_shape, delegate_fifo, delegate_keyboard_shortcuts_inhibit,
     delegate_pointer_constraints, delegate_pointer_gestures, delegate_presentation, delegate_relative_pointer,
     delegate_single_pixel_buffer, delegate_text_input_manager, delegate_xdg_activation, delegate_xdg_dialog,
-    delegate_tablet_manager, delegate_xdg_foreign, delegate_xdg_system_bell, delegate_xdg_toplevel_tag,
+    delegate_security_context, delegate_tablet_manager, delegate_xdg_foreign, delegate_xdg_system_bell, delegate_xdg_toplevel_tag,
 };
 
 use wm_core::BackendEvent;
 
 use crate::state::Compositor;
+
+impl smithay::wayland::security_context::SecurityContextHandler for Compositor {
+    fn context_created(
+        &mut self,
+        source: smithay::wayland::security_context::SecurityContextListenerSource,
+        context: smithay::wayland::security_context::SecurityContext,
+    ) {
+        let mut display = self.display_handle.clone();
+        if let Err(error) = self.loop_handle.insert_source(source, move |stream, _, _comp| {
+            if let Err(error) = display.insert_client(
+                stream,
+                std::sync::Arc::new(crate::state::ClientState::confined(context.clone())),
+            ) {
+                tracing::warn!(?error, "failed to admit a security-context client");
+            }
+        }) {
+            tracing::warn!(?error, "failed to register a security-context listener");
+        }
+    }
+}
 
 /// Activation tokens are launch hand-offs, not session-long capabilities.
 /// Five minutes leaves ample room for a cold application start without
@@ -112,6 +132,9 @@ pub(crate) struct CoreProtocols {
     pub _cursor_shape: smithay::wayland::cursor_shape::CursorShapeManagerState,
     pub _single_pixel: smithay::wayland::single_pixel_buffer::SinglePixelBufferState,
     pub _presentation: smithay::wayland::presentation::PresentationState,
+    pub _fifo: smithay::wayland::fifo::FifoManagerState,
+    pub _commit_timing: smithay::wayland::commit_timing::CommitTimingManagerState,
+    pub _security_context: smithay::wayland::security_context::SecurityContextState,
     pub _relative_pointer: smithay::wayland::relative_pointer::RelativePointerManagerState,
     pub _pointer_constraints: PointerConstraintsState,
     pub _pointer_gestures: smithay::wayland::pointer_gestures::PointerGesturesState,
@@ -138,12 +161,21 @@ pub(crate) fn init(display: &DisplayHandle) -> CoreProtocols {
         // Linux CLOCK_MONOTONIC. Presentation timestamps emitted by
         // the renderer use the same monotonic time base.
         _presentation: smithay::wayland::presentation::PresentationState::new::<Compositor>(display, 1),
+        _fifo: smithay::wayland::fifo::FifoManagerState::new::<Compositor>(display),
+        _commit_timing: smithay::wayland::commit_timing::CommitTimingManagerState::new::<Compositor>(display),
+        _security_context: smithay::wayland::security_context::SecurityContextState::new::<Compositor, _>(
+            display,
+            crate::state::security_context_global_visible,
+        ),
         _relative_pointer: smithay::wayland::relative_pointer::RelativePointerManagerState::new::<Compositor>(display),
         _pointer_constraints: PointerConstraintsState::new::<Compositor>(display),
         _pointer_gestures: smithay::wayland::pointer_gestures::PointerGesturesState::new::<Compositor>(display),
         _tablet: smithay::wayland::tablet_manager::TabletManagerState::new::<Compositor>(display),
         _text_input: smithay::wayland::text_input::TextInputManagerState::new::<Compositor>(display),
-        _input_method: InputMethodManagerState::new::<Compositor, _>(display, |_| true),
+        _input_method: InputMethodManagerState::new::<Compositor, _>(
+            display,
+            crate::state::privileged_global_visible,
+        ),
         _xdg_dialog: smithay::wayland::shell::xdg::dialog::XdgDialogState::new::<Compositor>(display),
         _system_bell: smithay::wayland::xdg_system_bell::XdgSystemBellState::new::<Compositor>(display),
         _toplevel_tag: smithay::wayland::xdg_toplevel_tag::XdgToplevelTagManager::new::<Compositor>(display),
@@ -402,6 +434,46 @@ delegate_xdg_activation!(Compositor);
 delegate_cursor_shape!(Compositor);
 delegate_single_pixel_buffer!(Compositor);
 delegate_presentation!(Compositor);
+delegate_fifo!(Compositor);
+delegate_commit_timing!(Compositor);
+delegate_security_context!(Compositor);
+
+#[cfg(test)]
+mod security_context_tests {
+    use super::*;
+    use smithay::reexports::wayland_server::Display;
+    use std::sync::Arc;
+
+    #[test]
+    fn confined_clients_cannot_nest_security_contexts_but_keep_current_policy() {
+        let display = Display::<Compositor>::new().expect("wayland display");
+        let mut handle = display.handle();
+        let (creator_socket, _creator_peer) =
+            std::os::unix::net::UnixStream::pair().expect("creator socketpair");
+        let creator = handle
+            .insert_client(creator_socket, Arc::new(crate::state::ClientState::default()))
+            .expect("admit creator");
+        let context = smithay::wayland::security_context::SecurityContext {
+            sandbox_engine: Some("test".into()),
+            app_id: Some("org.chonkstep.test".into()),
+            instance_id: None,
+            creator_client_id: creator.id(),
+        };
+        let (confined_socket, _confined_peer) =
+            std::os::unix::net::UnixStream::pair().expect("confined socketpair");
+        let confined = handle
+            .insert_client(
+                confined_socket,
+                Arc::new(crate::state::ClientState::confined(context)),
+            )
+            .expect("admit confined client");
+
+        assert!(crate::state::security_context_global_visible(&creator));
+        assert!(!crate::state::security_context_global_visible(&confined));
+        assert!(crate::state::privileged_global_visible(&creator));
+        assert!(crate::state::privileged_global_visible(&confined));
+    }
+}
 delegate_relative_pointer!(Compositor);
 delegate_pointer_constraints!(Compositor);
 delegate_pointer_gestures!(Compositor);

--- a/crates/wm-wayland/src/ctm.rs
+++ b/crates/wm-wayland/src/ctm.rs
@@ -70,6 +70,10 @@ impl GlobalDispatch<HyprlandCtmControlManagerV1, ()> for Compositor {
             tracing::info!("CTM manager blocked: another color-control client owns the outputs");
         }
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 fn owns(state: &Compositor, resource: &HyprlandCtmControlManagerV1) -> bool {

--- a/crates/wm-wayland/src/data_control.rs
+++ b/crates/wm-wayland/src/data_control.rs
@@ -70,15 +70,13 @@
 //! to know that; it is a property of smithay dispatching every
 //! selection provider through one handler.
 //!
-//! # No filter
+//! # Shared security-context gate
 //!
-//! Both globals are visible to every client. Data control is a
-//! read-anything-on-the-clipboard capability and a sandboxing story
-//! would want it gated — `GlobalDispatch::can_view` (which is what the
-//! filter closures below feed) is the hook — but chonkstep runs one
-//! user's session, where a clipboard manager, a terminal and a browser
-//! are all equally that user's own programs. The same reasoning
-//! `state.rs` records for leaving session-lock unfiltered.
+//! Data control is a read-anything-on-the-clipboard capability, so both
+//! globals consult `state::privileged_global_visible`. Security-context
+//! clients are now tagged and can be distinguished there. The current
+//! single-user policy remains permissive, where a clipboard manager, a
+//! terminal and a browser are all equally that user's own programs.
 
 use smithay::reexports::wayland_server::DisplayHandle;
 use smithay::wayland::selection::ext_data_control::{
@@ -117,8 +115,16 @@ pub(crate) struct DataControl {
 /// `primary` is not optional on purpose — see the module docs for the
 /// silent half-working session that `None` produces.
 pub(crate) fn init(display_handle: &DisplayHandle, primary: &PrimarySelectionState) -> DataControl {
-    let wlr = WlrDataControlState::new::<Compositor, _>(display_handle, Some(primary), |_| true);
-    let ext = ExtDataControlState::new::<Compositor, _>(display_handle, Some(primary), |_| true);
+    let wlr = WlrDataControlState::new::<Compositor, _>(
+        display_handle,
+        Some(primary),
+        crate::state::privileged_global_visible,
+    );
+    let ext = ExtDataControlState::new::<Compositor, _>(
+        display_handle,
+        Some(primary),
+        crate::state::privileged_global_visible,
+    );
     tracing::info!("data-control advertised on both the wlr and ext interfaces");
     DataControl { wlr, ext }
 }

--- a/crates/wm-wayland/src/diagnostics.rs
+++ b/crates/wm-wayland/src/diagnostics.rs
@@ -9,6 +9,7 @@ static IDLE_LOG: AtomicBool = AtomicBool::new(false);
 static FULL_DAMAGE: AtomicBool = AtomicBool::new(false);
 static NO_DIRECT_SCANOUT: AtomicBool = AtomicBool::new(false);
 static NO_CURSOR_PLANE: AtomicBool = AtomicBool::new(false);
+static NO_VRR: AtomicBool = AtomicBool::new(false);
 
 type ReloadFilter = dyn Fn(&str) -> Result<(), String> + Send + Sync;
 static LOG_FILTER: OnceLock<Box<ReloadFilter>> = OnceLock::new();
@@ -24,6 +25,7 @@ pub(crate) fn init() {
         FULL_DAMAGE.store(env_enabled("CHONKSTEP_FULL_DAMAGE"), Ordering::Relaxed);
         NO_DIRECT_SCANOUT.store(env_enabled("CHONKSTEP_NO_DIRECT_SCANOUT"), Ordering::Relaxed);
         NO_CURSOR_PLANE.store(env_enabled("CHONKSTEP_NO_CURSOR_PLANE"), Ordering::Relaxed);
+        NO_VRR.store(env_enabled("CHONKSTEP_NO_VRR"), Ordering::Relaxed);
     });
 }
 
@@ -35,6 +37,7 @@ fn value(name: &str) -> Option<&'static AtomicBool> {
         "full-damage" => Some(&FULL_DAMAGE),
         "no-direct-scanout" => Some(&NO_DIRECT_SCANOUT),
         "no-cursor-plane" => Some(&NO_CURSOR_PLANE),
+        "no-vrr" => Some(&NO_VRR),
         _ => None,
     }
 }
@@ -46,7 +49,7 @@ pub(crate) fn enabled(name: &str) -> bool {
 pub(crate) fn set(name: &str, enabled: bool) -> Result<(), String> {
     let value = value(name).ok_or_else(|| {
         format!(
-            "unknown diagnostic {name}; expected damage-log, idle-log, full-damage, no-direct-scanout or no-cursor-plane"
+            "unknown diagnostic {name}; expected damage-log, idle-log, full-damage, no-direct-scanout, no-cursor-plane or no-vrr"
         )
     })?;
     value.store(enabled, Ordering::Relaxed);
@@ -61,6 +64,7 @@ pub(crate) fn describe() -> String {
         "full-damage",
         "no-direct-scanout",
         "no-cursor-plane",
+        "no-vrr",
     ]
     .into_iter()
     .map(|name| format!("{name}={}", enabled(name)))

--- a/crates/wm-wayland/src/focus_grab.rs
+++ b/crates/wm-wayland/src/focus_grab.rs
@@ -687,6 +687,10 @@ impl GlobalDispatch<HyprlandFocusGrabManagerV1, ()> for Compositor {
         // record here — the grabs record themselves.
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<HyprlandFocusGrabManagerV1, ()> for Compositor {

--- a/crates/wm-wayland/src/gamma.rs
+++ b/crates/wm-wayland/src/gamma.rs
@@ -711,6 +711,10 @@ impl GlobalDispatch<ZwlrGammaControlManagerV1, ()> for Compositor {
         // tracks.
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<ZwlrGammaControlManagerV1, ()> for Compositor {

--- a/crates/wm-wayland/src/global_shortcuts.rs
+++ b/crates/wm-wayland/src/global_shortcuts.rs
@@ -103,6 +103,10 @@ impl GlobalDispatch<HyprlandGlobalShortcutsManagerV1, ()> for Compositor {
     ) {
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<HyprlandGlobalShortcutsManagerV1, ()> for Compositor {

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -35,9 +35,9 @@
 //! the pattern `docs/control-socket.md` established and the one
 //! `clippy.toml`'s incident report exists to protect.
 
-use smithay::input::keyboard::{xkb, Keysym};
+use smithay::input::keyboard::{xkb, Keysym, Layout};
 
-use chonk_hyprland_ipc::dispatch::{Action, Fullscreen};
+use chonk_hyprland_ipc::dispatch::{Action, Fullscreen, LayoutTarget};
 use chonk_hyprland_ipc::state::{Binding, Devices, Keyboard, Monitor, PointerDevice, Snapshot, Window, Workspace};
 use chonk_hyprland_ipc::Server;
 use wm_core::{Backend, BackendEvent, Lifecycle, WindowManager};
@@ -140,6 +140,9 @@ fn build_snapshot(
             width: i32::try_from(info.geometry.size.w).unwrap_or(i32::MAX),
             height: i32::try_from(info.geometry.size.h).unwrap_or(i32::MAX),
             scale: wm.backend().monitor_scales.get(index).copied().unwrap_or(1.0),
+            powered: hardware(wm, index).is_none_or(|out| out.powered),
+            vrr_supported: hardware(wm, index).is_some_and(|out| out.vrr_supported),
+            vrr_enabled: hardware(wm, index).is_some_and(|out| out.vrr_enabled),
             // chonkstep has a single global current workspace rather
             // than one per output, so exactly one monitor is focused
             // and every monitor shows the same workspace. Saying
@@ -284,7 +287,7 @@ fn build_snapshot(
     // whose layout libxkbcommon rejected keeps the previous one. The
     // config value remains the fallback for a backend that installs no
     // keymap of its own.
-    let layout = {
+    let configured_layout = {
         let installed = wm.backend().keyboard_layout.clone();
         if installed.is_empty() {
             session.input.layout.clone().unwrap_or_else(|| "us".to_string())
@@ -292,11 +295,21 @@ fn build_snapshot(
             installed
         }
     };
+    let active_layout_index = wm.backend().active_keyboard_layout;
+    let active_keymap = wm
+        .backend()
+        .keyboard_layouts
+        .get(active_layout_index as usize)
+        .cloned()
+        .unwrap_or_else(|| configured_layout.clone());
     let mut devices = Devices::default();
     for device in &wm.backend().input_devices {
         if device.keyboard {
             devices.keyboards.push(Keyboard {
-                name: device.name.clone(), layout: layout.clone(), active_keymap: layout.clone(), active_layout_index: 0,
+                name: device.name.clone(),
+                layout: active_keymap.clone(),
+                active_keymap: active_keymap.clone(),
+                active_layout_index,
             });
         }
         let entry = PointerDevice { name: device.name.clone() };
@@ -313,9 +326,9 @@ fn build_snapshot(
     if devices.keyboards.is_empty() {
         devices.keyboards.push(Keyboard {
             name: "chonkstep-keyboard".into(),
-            layout: layout.clone(),
-            active_keymap: layout,
-            active_layout_index: 0,
+            layout: active_keymap.clone(),
+            active_keymap,
+            active_layout_index,
         });
     }
     if devices.mice.is_empty() {
@@ -581,6 +594,8 @@ pub(crate) fn apply(comp: &mut Compositor, action: Action) -> bool {
         Action::SetTag { window, tag, present } => client_of(wm, window).is_some_and(|id| wm.set_client_tag(id, &tag, present)),
         Action::ConfirmFloating(window) => client_of(wm, window).is_some(),
         Action::SetMonitorScale { output, scale_120 } => comp.set_output_scale(&output, scale_120 as f64 / 120.0),
+        Action::SetDpms { output, powered } => crate::output_power::set_from_ipc(comp, output.as_deref(), powered),
+        Action::SwitchKeyboardLayout { device, target } => switch_keyboard_layout(comp, &device, target),
         Action::SetCursorHidden(hidden) => {
             let owner = hidden.then(|| {
                 comp.seat
@@ -641,6 +656,60 @@ fn window_of(wm: &WindowManager<WaylandBackend>, id: u64) -> Option<<WaylandBack
     wm.iter_clients()
         .find(|(candidate, _): &(wm_core::ClientId, _)| candidate.as_u64() == id)
         .map(|(_, client)| client.window)
+}
+
+pub(crate) fn refresh_keyboard_layout(comp: &mut Compositor) {
+    let Some(keyboard) = comp.seat.get_keyboard() else {
+        return;
+    };
+    let (layouts, active) = keyboard.with_xkb_state(comp, |context| {
+        let xkb = context.xkb().lock().expect("keyboard XKB mutex poisoned");
+        let active = xkb.active_layout().0;
+        let layouts = xkb.layouts().map(|layout| xkb.layout_name(layout).to_string()).collect();
+        (layouts, active)
+    });
+    let backend = comp.wm.backend_mut();
+    backend.keyboard_layouts = layouts;
+    backend.active_keyboard_layout = active;
+}
+
+fn switch_keyboard_layout(comp: &mut Compositor, device: &str, target: LayoutTarget) -> bool {
+    if device != "all"
+        && !comp
+            .wm
+            .backend()
+            .input_devices
+            .iter()
+            .any(|input| input.keyboard && input.name == device)
+        && device != "chonkstep-keyboard"
+    {
+        return false;
+    }
+    let Some(keyboard) = comp.seat.get_keyboard() else {
+        return false;
+    };
+    let changed = keyboard.with_xkb_state(comp, |mut context| {
+        let (current, count) = {
+            let xkb = context.xkb().lock().expect("keyboard XKB mutex poisoned");
+            (xkb.active_layout().0, xkb.layouts().count() as u32)
+        };
+        if count == 0 {
+            return false;
+        }
+        let next = match target {
+            LayoutTarget::Next => (current + 1) % count,
+            LayoutTarget::Previous => (count + current - 1) % count,
+            LayoutTarget::Index(index) if index < count => index,
+            LayoutTarget::Index(_) => return false,
+        };
+        context.set_layout(Layout(next));
+        true
+    });
+    if changed {
+        refresh_keyboard_layout(comp);
+        comp.mark_hyprland_state_dirty();
+    }
+    changed
 }
 
 #[cfg(test)]

--- a/crates/wm-wayland/src/image_capture.rs
+++ b/crates/wm-wayland/src/image_capture.rs
@@ -157,39 +157,50 @@ pub(crate) fn refresh(comp: &mut Compositor) {
             capture.frame.failed(FailureReason::Unknown);
             continue;
         }
-        let pixels = match capture.shared.target.as_ref() {
-            Some(CaptureTarget::Output(name)) => comp
-                .outputs
-                .iter()
-                .find(|entry| entry.output.name() == *name)
-                .map(|entry| Rect::new(entry.position, entry.size))
-                .and_then(|region| {
-                    crate::protocols::capture_region(
+        let size = match capture.shared.target.as_ref() {
+            Some(CaptureTarget::Output(name)) => {
+                let region = comp
+                    .outputs
+                    .iter()
+                    .find(|entry| entry.output.name() == *name)
+                    .map(|entry| Rect::new(entry.position, entry.size));
+                region.and_then(|region| {
+                    match crate::protocols::capture_region_into(
                         comp,
                         region,
                         Transform::Normal,
                         capture.shared.paint_cursors,
-                    )
-                }),
-            Some(CaptureTarget::Toplevel(window)) => {
-                crate::capture::capture_window_full(comp, *window, capture.shared.paint_cursors)
+                        &capture.buffer,
+                    ) {
+                        Ok(size) => Some(size),
+                        Err(error) => {
+                            tracing::warn!(%error, "ext image-copy-capture could not capture the output");
+                            None
+                        }
+                    }
+                })
             }
+            Some(CaptureTarget::Toplevel(window)) => crate::capture::capture_window_full(
+                    comp,
+                    *window,
+                    capture.shared.paint_cursors,
+                )
+                .and_then(|pixels| match crate::protocols::write_capture(&capture.buffer, &pixels) {
+                    Ok(()) => Some(Size::new(pixels.width, pixels.height)),
+                    Err(error) => {
+                        tracing::warn!(%error, "ext image-copy-capture could not write the client buffer");
+                        None
+                    }
+                }),
             None => None,
         };
-        let Some(pixels) = pixels else {
+        let Some(size) = size else {
             capture.frame.failed(FailureReason::Unknown);
             continue;
         };
-        if let Err(error) = crate::protocols::write_capture(&capture.buffer, &pixels) {
-            tracing::warn!(%error, "ext image-copy-capture could not write the client buffer");
-            capture.frame.failed(FailureReason::BufferConstraints);
-            continue;
-        }
 
         capture.frame.transform(wl_output::Transform::Normal);
-        capture
-            .frame
-            .damage(0, 0, pixels.width as i32, pixels.height as i32);
+        capture.frame.damage(0, 0, size.w as i32, size.h as i32);
         let stamp = Duration::from(Clock::<Monotonic>::new().now());
         capture.frame.presentation_time(
             (stamp.as_secs() >> 32) as u32,
@@ -295,6 +306,10 @@ impl GlobalDispatch<ExtOutputImageCaptureSourceManagerV1, ()> for Compositor {
     ) {
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<ExtOutputImageCaptureSourceManagerV1, ()> for Compositor {
@@ -332,6 +347,10 @@ impl GlobalDispatch<ExtForeignToplevelImageCaptureSourceManagerV1, ()> for Compo
         data_init: &mut DataInit<'_, Self>,
     ) {
         data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
     }
 }
 
@@ -385,6 +404,10 @@ impl GlobalDispatch<ExtImageCopyCaptureManagerV1, ()> for Compositor {
         data_init: &mut DataInit<'_, Self>,
     ) {
         data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
     }
 }
 

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -737,6 +737,7 @@ pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event
     // The exhaustive family classifier and its table-driven test make
     // a newly routed family state that policy before it can compile.
     if family.resets_idle() {
+        crate::output_power::wake_all(state);
         crate::idle::note_activity(state);
     }
     // Buttons, scroll and gestures are delivered against the seat's
@@ -1227,6 +1228,7 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
     let Some(keyboard) = state.seat.get_keyboard() else {
         return;
     };
+    let active_layout_before = state.wm.backend().active_keyboard_layout;
     let seat = state.seat.clone();
     let shortcuts_inhibited = seat.keyboard_shortcuts_inhibited();
     keyboard.input::<(), _>(state, keycode, key_state, serial, time, |data, mods, handle| {
@@ -1362,6 +1364,14 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
             }
         }
     });
+    // XKB options such as `grp:alt_shift_toggle` change the active group
+    // inside `KeyboardHandle::input`, without going through the IPC action.
+    // Mirror that state after every physical key transition so the next
+    // snapshot emits `activelayout` for both switching paths.
+    crate::hyprland_ipc::refresh_keyboard_layout(state);
+    if state.wm.backend().active_keyboard_layout != active_layout_before {
+        state.mark_hyprland_state_dirty();
+    }
 }
 
 /// Queues due compositor-side repeats. Called once per event-loop
@@ -2431,25 +2441,28 @@ fn on_pointer_axis<I: InputBackend>(state: &mut Compositor, event: I::PointerAxi
     if route_shell_scroll::<I>(state, &event) {
         return;
     }
+    let factor = state.wm.backend().scroll_factor;
     let horizontal = event
         .amount(Axis::Horizontal)
-        .unwrap_or_else(|| event.amount_v120(Axis::Horizontal).unwrap_or(0.0) * 15.0 / 120.0);
+        .unwrap_or_else(|| event.amount_v120(Axis::Horizontal).unwrap_or(0.0) * 15.0 / 120.0)
+        * factor;
     let vertical =
-        event.amount(Axis::Vertical).unwrap_or_else(|| event.amount_v120(Axis::Vertical).unwrap_or(0.0) * 15.0 / 120.0);
+        event.amount(Axis::Vertical).unwrap_or_else(|| event.amount_v120(Axis::Vertical).unwrap_or(0.0) * 15.0 / 120.0)
+            * factor;
 
     let mut frame = AxisFrame::new(event.time_msec()).source(event.source());
     if horizontal != 0.0 {
         frame = frame.relative_direction(Axis::Horizontal, event.relative_direction(Axis::Horizontal));
         frame = frame.value(Axis::Horizontal, horizontal);
         if let Some(discrete) = event.amount_v120(Axis::Horizontal) {
-            frame = frame.v120(Axis::Horizontal, discrete as i32);
+            frame = frame.v120(Axis::Horizontal, (discrete * factor).round() as i32);
         }
     }
     if vertical != 0.0 {
         frame = frame.relative_direction(Axis::Vertical, event.relative_direction(Axis::Vertical));
         frame = frame.value(Axis::Vertical, vertical);
         if let Some(discrete) = event.amount_v120(Axis::Vertical) {
-            frame = frame.v120(Axis::Vertical, discrete as i32);
+            frame = frame.v120(Axis::Vertical, (discrete * factor).round() as i32);
         }
     }
     // A finger lifting off a touchpad ends kinetic scroll with an
@@ -2572,12 +2585,13 @@ fn route_shell_scroll<I: InputBackend>(
     state: &mut Compositor,
     event: &I::PointerAxisEvent,
 ) -> bool {
+    let factor = state.wm.backend().scroll_factor;
     route_shell_scroll_values(
         state,
-        event.amount(Axis::Horizontal),
-        event.amount_v120(Axis::Horizontal),
-        event.amount(Axis::Vertical),
-        event.amount_v120(Axis::Vertical),
+        event.amount(Axis::Horizontal).map(|value| value * factor),
+        event.amount_v120(Axis::Horizontal).map(|value| value * factor),
+        event.amount(Axis::Vertical).map(|value| value * factor),
+        event.amount_v120(Axis::Vertical).map(|value| value * factor),
         event.source(),
     )
 }

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -49,6 +49,7 @@ mod input;
 mod layers;
 mod lock;
 mod output_mgmt;
+mod output_power;
 mod protocols;
 mod renderer;
 mod session;

--- a/crates/wm-wayland/src/output_mgmt.rs
+++ b/crates/wm-wayland/src/output_mgmt.rs
@@ -32,12 +32,14 @@
 //! - **Transform** applies on the DRM session backend for the four
 //!   non-flipped rotations; the nested backend truthfully refuses it
 //!   because its one output is the host window.
-//! - **Disable and adaptive sync** are refused with `failed()` and a
-//!   log line naming the gap. Disabling means tearing an output
+//! - **Disable** is refused with `failed()` and a log line naming the
+//!   gap. Disabling means tearing an output
 //!   out of three index-aligned lists (`Compositor::outputs`, the
 //!   ledger's monitors, the session's crtcs) that the lock module and
 //!   the shell hold indices into. A truthful `failed` beats a lying
 //!   `succeeded`.
+//! - **Adaptive sync** is capability-checked and controls permission for
+//!   the renderer's conservative direct-scanout-only runtime gate.
 //!
 //! When no output manager is bound, publication is an immediate fast
 //! path. Once one binds, retained snapshots keep unchanged passes both
@@ -137,6 +139,7 @@ struct HeadSnapshot {
     scale: f64,
     current_mode: usize,
     transform: Transform,
+    adaptive_sync: bool,
 }
 
 /// What one configuration asked for on one head.
@@ -312,6 +315,7 @@ fn head_snapshot(entry: &crate::state::OutputEntry) -> HeadSnapshot {
         scale: entry.scale,
         current_mode: current_mode_index(entry),
         transform: entry.transform,
+        adaptive_sync: entry.vrr_requested,
     }
 }
 
@@ -439,7 +443,11 @@ fn announce_head(
     head.transform(protocol_transform(entry.transform));
     head.scale(entry.scale);
     if version >= 4 {
-        head.adaptive_sync(AdaptiveSyncState::Disabled);
+        head.adaptive_sync(if entry.vrr_requested {
+            AdaptiveSyncState::Enabled
+        } else {
+            AdaptiveSyncState::Disabled
+        });
     }
     manager.heads.push(HeadInstance { index, resource: head, modes });
 }
@@ -460,6 +468,13 @@ fn update_head(head: &HeadInstance, entry: &crate::state::OutputEntry, previous:
         if let Some(mode) = head.modes.get(current) {
             head.resource.current_mode(mode);
         }
+    }
+    if entry.vrr_requested != previous.adaptive_sync && head.resource.version() >= 4 {
+        head.resource.adaptive_sync(if entry.vrr_requested {
+            AdaptiveSyncState::Enabled
+        } else {
+            AdaptiveSyncState::Disabled
+        });
     }
 }
 
@@ -493,8 +508,13 @@ fn validate(comp: &Compositor, config: &ConfigState) -> Result<Vec<(usize, HeadC
                 return Err(format!("rotating {name}: the nested backend reserves its transform for the host surface"));
             }
         }
-        if head.adaptive_sync == Some(true) {
-            return Err(format!("adaptive sync on {name}: not supported"));
+        if head.adaptive_sync == Some(true) && !entry.vrr_supported {
+            return Err(format!(
+                "adaptive sync on {name}: the connector does not advertise VRR capability"
+            ));
+        }
+        if head.adaptive_sync == Some(true) && crate::diagnostics::enabled("no-vrr") {
+            return Err(format!("adaptive sync on {name}: disabled by CHONKSTEP_NO_VRR"));
         }
         if let Some(scale) = head.scale {
             if !(0.125..=8.0).contains(&scale) {
@@ -542,8 +562,32 @@ fn perform_pending_apply(comp: &mut Compositor) {
     };
     let mut scaled_any = false;
     let mut moved_any = false;
+    let mut adaptive_any = false;
     let mut first_error: Option<String> = None;
     for (index, head) in &pending.heads {
+        if let Some(enabled) = head.adaptive_sync {
+            if comp.outputs[*index].vrr_requested != enabled {
+                match crate::session::set_adaptive_sync(&mut comp.graphics, *index, enabled) {
+                    Ok(()) => {
+                        comp.outputs[*index].vrr_requested = enabled;
+                        adaptive_any = true;
+                        tracing::info!(
+                            output = %comp.outputs[*index].output.name(),
+                            enabled,
+                            "adaptive sync policy changed"
+                        );
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            output = %comp.outputs[*index].output.name(),
+                            "adaptive sync change failed"
+                        );
+                        first_error.get_or_insert(error);
+                    }
+                }
+            }
+        }
         if let Some(scale) = head.scale {
             let entry = &mut comp.outputs[*index];
             if (entry.scale - scale).abs() > f64::EPSILON {
@@ -597,7 +641,7 @@ fn perform_pending_apply(comp: &mut Compositor) {
     if moved_any {
         normalize_layout(comp);
     }
-    if scaled_any || moved_any {
+    if scaled_any || moved_any || adaptive_any {
         comp.output_mgmt.mark_dirty();
         comp.session_lock.mark_dirty();
         comp.sync_monitor_scales();
@@ -694,6 +738,10 @@ impl GlobalDispatch<ZwlrOutputManagerV1, ()> for Compositor {
         // Announced on the next `refresh`, exactly like a foreign-
         // toplevel manager: the bind callback runs mid-dispatch.
         state.output_mgmt.managers.push(Manager { resource, announced: false, heads: Vec::new() });
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
     }
 }
 

--- a/crates/wm-wayland/src/output_power.rs
+++ b/crates/wm-wayland/src/output_power.rs
@@ -1,0 +1,180 @@
+//! `zwlr_output_power_management_v1`: DPMS without removing outputs.
+//!
+//! A power control is exclusive per output as the protocol requires.
+//! Turning a connector off clears its DRM surface, but its Wayland
+//! global, geometry, workspaces and shell placement remain intact; the
+//! first frame after power-on restores scanout.
+
+use smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_manager_v1::{
+    self, ZwlrOutputPowerManagerV1,
+};
+use smithay::reexports::wayland_protocols_wlr::output_power_management::v1::server::zwlr_output_power_v1::{
+    self, Mode, ZwlrOutputPowerV1,
+};
+use smithay::reexports::wayland_server::backend::{ClientId, GlobalId, ObjectId};
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, New, Resource, WEnum,
+};
+
+use crate::state::{Compositor, Graphics};
+
+const VERSION: u32 = 1;
+
+pub(crate) struct OutputPower {
+    _global: Option<GlobalId>,
+    owners: Vec<Option<ObjectId>>,
+}
+
+struct PowerData {
+    index: usize,
+}
+
+pub(crate) fn init(display: &DisplayHandle, graphics: &Graphics) -> OutputPower {
+    if !crate::session::has_physical_outputs(graphics) {
+        tracing::info!("no physical outputs; wlr-output-power-management is not advertised");
+        return OutputPower { _global: None, owners: Vec::new() };
+    }
+    let global = display.create_global::<Compositor, ZwlrOutputPowerManagerV1, ()>(VERSION, ());
+    tracing::info!(version = VERSION, "wlr-output-power-management advertised");
+    OutputPower { _global: Some(global), owners: Vec::new() }
+}
+
+pub(crate) fn set_from_ipc(comp: &mut Compositor, name: Option<&str>, powered: bool) -> bool {
+    let targets: Vec<usize> = comp
+        .outputs
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| name.is_none_or(|name| entry.output.name() == name))
+        .map(|(index, _)| index)
+        .collect();
+    if targets.is_empty() {
+        return false;
+    }
+    targets.into_iter().all(|index| set(comp, index, powered))
+}
+
+/// Wake every powered-down screen on real user activity. Device
+/// hotplug events do not call this; keyboard, pointer, touch, tablet
+/// and switch input do.
+pub(crate) fn wake_all(comp: &mut Compositor) {
+    let sleeping = comp.outputs.iter().any(|entry| !entry.powered);
+    if sleeping {
+        let _ = set_from_ipc(comp, None, true);
+    }
+}
+
+fn set(comp: &mut Compositor, index: usize, powered: bool) -> bool {
+    let Some(entry) = comp.outputs.get(index) else {
+        return false;
+    };
+    if entry.powered == powered {
+        notify_owner(comp, index, powered);
+        return true;
+    }
+    let name = entry.output.name();
+    match crate::session::set_output_power(&mut comp.graphics, index, powered) {
+        Ok(()) => {
+            comp.outputs[index].powered = powered;
+            if !powered {
+                comp.outputs[index].vrr_enabled = false;
+            }
+            comp.wm.backend_mut().mark_damaged();
+            comp.sync_monitor_outputs();
+            comp.mark_hyprland_state_dirty();
+            notify_owner(comp, index, powered);
+            tracing::info!(output = %name, powered, "output power changed");
+            true
+        }
+        Err(error) => {
+            tracing::warn!(output = %name, %error, "output power change failed");
+            false
+        }
+    }
+}
+
+fn notify_owner(comp: &Compositor, index: usize, powered: bool) {
+    let Some(Some(owner)) = comp.output_power.owners.get(index) else {
+        return;
+    };
+    if let Ok(resource) = ZwlrOutputPowerV1::from_id(&comp.display_handle, owner.clone()) {
+        resource.mode(if powered { Mode::On } else { Mode::Off });
+    }
+}
+
+impl GlobalDispatch<ZwlrOutputPowerManagerV1, ()> for Compositor {
+    fn bind(
+        _state: &mut Self,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: New<ZwlrOutputPowerManagerV1>,
+        _global_data: &(),
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
+}
+
+impl Dispatch<ZwlrOutputPowerManagerV1, ()> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        _resource: &ZwlrOutputPowerManagerV1,
+        request: zwlr_output_power_manager_v1::Request,
+        _data: &(),
+        _handle: &DisplayHandle,
+        data_init: &mut DataInit<'_, Self>,
+    ) {
+        if let zwlr_output_power_manager_v1::Request::GetOutputPower { id, output } = request {
+            let index = crate::gamma::output_index(state, &output);
+            let resource = data_init.init(id, PowerData { index: index.unwrap_or(usize::MAX) });
+            let Some(index) = index else {
+                resource.failed();
+                return;
+            };
+            state.output_power.owners.resize_with(state.outputs.len(), || None);
+            if state.output_power.owners[index].is_some() {
+                resource.failed();
+                return;
+            }
+            state.output_power.owners[index] = Some(resource.id());
+            resource.mode(if state.outputs[index].powered { Mode::On } else { Mode::Off });
+        }
+    }
+}
+
+impl Dispatch<ZwlrOutputPowerV1, PowerData> for Compositor {
+    fn request(
+        state: &mut Self,
+        _client: &Client,
+        resource: &ZwlrOutputPowerV1,
+        request: zwlr_output_power_v1::Request,
+        data: &PowerData,
+        _handle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, Self>,
+    ) {
+        if let zwlr_output_power_v1::Request::SetMode { mode } = request {
+            let powered = match mode {
+                WEnum::Value(Mode::On) => true,
+                WEnum::Value(Mode::Off) => false,
+                WEnum::Unknown(_) => {
+                    resource.post_error(zwlr_output_power_v1::Error::InvalidMode, "unknown output power mode");
+                    return;
+                }
+                _ => return,
+            };
+            if !set(state, data.index, powered) {
+                resource.failed();
+            }
+        }
+    }
+
+    fn destroyed(state: &mut Self, _client: ClientId, resource: &ZwlrOutputPowerV1, data: &PowerData) {
+        if state.output_power.owners.get(data.index).and_then(Option::as_ref) == Some(&resource.id()) {
+            state.output_power.owners[data.index] = None;
+        }
+    }
+}

--- a/crates/wm-wayland/src/protocols.rs
+++ b/crates/wm-wayland/src/protocols.rs
@@ -100,27 +100,25 @@
 //!
 //! # Screencopy: the same capture path as everything else
 //!
-//! Capture goes through [`crate::capture`]'s approach — build the scene
-//! with [`build_scene`], draw it into an offscreen GLES texture, read
-//! the pixels back with `ExportMem` — and inherits its three hard-won
+//! Capture builds the scene into retained scratch storage, draws it into
+//! a cached offscreen GLES texture, and reads the pixels with `ExportMem`.
+//! It inherits [`crate::capture`]'s three hard-won
 //! facts verbatim: no vertical flip is needed (the renderer's baked-in
 //! 180° projection and `glReadPixels`' bottom-up order cancel, which is
 //! why the `y_invert` flag below is never set), `Fourcc::Abgr8888` is
 //! the RGBA byte order, and the pixels come out premultiplied. Read
-//! that module's header before touching [`render_offscreen`] here.
+//! that module's header before touching [`capture_region_into`] here.
 //!
 //! It differs from `capture.rs` in exactly one thing, and that one
 //! thing matters: this applies the source output's transform (see
-//! [`capture_region`]), because a screencopy client is handed the
+//! [`capture_region_into`]), because a screencopy client is handed the
 //! output's *buffer* and un-transforms it itself, whereas a screenshot
 //! PNG is looked at directly and wants logical orientation.
 //!
-//! The other reason it does not simply *call* `capture.rs` is reach:
-//! that module's offscreen renderer is a private helper and this file
-//! cannot widen it. The duplication should collapse the moment someone
-//! owns both files — lift `capture::render_offscreen` to `pub(crate)`,
-//! give it the transform argument [`render_offscreen`] here takes, and
-//! delete this copy.
+//! The mapped readback remains borrowed while it is copied into each client
+//! buffer. The cached texture and its damage tracker therefore stay together:
+//! retained pixels make incremental damage valid, while no frame-sized CPU
+//! `Vec` is allocated between GLES and the Wayland buffer.
 //!
 //! Only `wl_shm` buffers are offered. The `linux_dmabuf` event that
 //! protocol version 3 also allows is deliberately never sent, which
@@ -135,7 +133,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::gles::{GlesRenderer, GlesTexture};
-use smithay::backend::renderer::{Bind, Color32F, ExportMem, Offscreen};
+use smithay::backend::renderer::{Bind, ExportMem, Offscreen};
 use smithay::input::pointer::CursorImageStatus;
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols_wlr::foreign_toplevel::v1::server::zwlr_foreign_toplevel_handle_v1::{
@@ -161,10 +159,10 @@ use smithay::reexports::wayland_server::{Client, DataInit, Dispatch, DisplayHand
 use smithay::utils::{Buffer as BufferCoords, Physical, Rectangle as SRect, Size as SSize, Transform};
 use smithay::wayland::shm::{with_buffer_contents, with_buffer_contents_mut, BufferData};
 
-use wm_core::{BackendEvent, ClientFlags, Lifecycle, NetState, NetStateAction};
+use wm_core::{Backend, BackendEvent, ClientFlags, Lifecycle, NetState, NetStateAction};
 use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
 
-use crate::renderer::{build_scene, SceneElement};
+use crate::renderer::{build_scene_into, SceneElement};
 use crate::state::{Compositor, Graphics, ManagedSurface, WaylandBackend, WlFrameId, WlWindowId};
 
 type WmEvent = BackendEvent<WlWindowId, WlFrameId>;
@@ -231,6 +229,21 @@ pub(crate) struct ProtocolState {
     minimize_requests: Vec<(WlWindowId, bool)>,
     /// Capture requests waiting for a frame to answer them.
     captures: Vec<PendingCapture>,
+    /// A small retained pool keyed by capture geometry. A recorder normally
+    /// uses one entry for its entire life; the bound prevents a hostile stream
+    /// of odd sizes from retaining unbounded GPU memory.
+    capture_targets: Vec<CaptureTarget>,
+}
+
+struct CaptureTarget {
+    region: Rect,
+    size: Size,
+    transform: Transform,
+    overlay_cursor: bool,
+    texture: GlesTexture,
+    damage_tracker: OutputDamageTracker,
+    scene_scratch: Vec<SceneElement<GlesRenderer>>,
+    rendered: bool,
 }
 
 /// Resolve an ext foreign-toplevel resource back to its managed window.
@@ -345,7 +358,7 @@ impl ToplevelStates {
 /// Held rather than serviced inline because a `copy` arrives in the
 /// middle of protocol dispatch, where the renderer is not ours to
 /// borrow and — for `copy_with_damage` — the answer is "not yet"
-/// anyway. [`refresh`] drains this once per pass.
+/// anyway. The presentation-paced drain coalesces matching requests.
 #[derive(Clone)]
 struct PendingCapture {
     frame: ZwlrScreencopyFrameV1,
@@ -353,7 +366,7 @@ struct PendingCapture {
     /// Source rectangle in compositor-global logical coordinates,
     /// already clipped to its output.
     region: Rect,
-    /// Its output's transform — see [`capture_region`].
+    /// Its output's transform — see [`capture_region_into`].
     transform: Transform,
     overlay_cursor: bool,
     /// `copy_with_damage` rather than `copy`: answer only on a pass
@@ -371,7 +384,7 @@ pub(crate) struct ScreencopyFrameData {
     /// it.
     region: Rect,
     /// The transform of the output this region belongs to. See
-    /// [`capture_region`]: the buffer a screencopy client is handed is
+    /// [`capture_region_into`]: the buffer a screencopy client is handed is
     /// in the output's *buffer* space, not its logical one.
     transform: Transform,
     overlay_cursor: bool,
@@ -385,11 +398,11 @@ pub(crate) struct ScreencopyFrameData {
 /// Registers both globals. Called once from `run` — see the module's
 /// integration contract for where.
 ///
-/// Never fails, and neither global is gated: a screenshot tool and a
-/// bar are ordinary desktop software, and chonkstep runs one user's
-/// session rather than a multi-tenant kiosk. A `wp_security_context`
-/// filter (Smithay supports one through `GlobalDispatch::can_view`) is
-/// the hook to add if sandboxed clients ever need to be told "no".
+/// Never fails. Both globals consult the shared security-context-aware
+/// predicate. That predicate remains permissive today because chonkstep
+/// runs one user's session rather than a multi-tenant kiosk, but clients
+/// admitted through `wp_security_context_v1` are now identifiable when
+/// that policy changes.
 pub(crate) fn init(display_handle: &DisplayHandle) -> ProtocolState {
     // The `GlobalId`s are dropped deliberately: dropping one does not
     // withdraw the global (that takes `DisplayHandle::remove_global`),
@@ -410,6 +423,7 @@ pub(crate) fn init(display_handle: &DisplayHandle) -> ProtocolState {
         toplevels: HashMap::new(),
         minimize_requests: Vec::new(),
         captures: Vec::new(),
+        capture_targets: Vec::new(),
     }
 }
 
@@ -427,7 +441,6 @@ pub(crate) fn refresh(comp: &mut Compositor) {
         sync_toplevels(comp);
         comp.foreign_toplevel_dirty = false;
     }
-    service_captures(comp);
 }
 
 /// Keeps ext-foreign-toplevel-list in step with the same authoritative
@@ -914,6 +927,10 @@ impl GlobalDispatch<ZwlrForeignToplevelManagerV1, ()> for Compositor {
         // the next `refresh` is the only place handles are minted.
         state.protocols.managers.push(ManagerInstance { resource, announced: false });
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<ZwlrForeignToplevelManagerV1, ()> for Compositor {
@@ -1059,6 +1076,10 @@ impl GlobalDispatch<ZwlrScreencopyManagerV1, ()> for Compositor {
     ) {
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<ZwlrScreencopyManagerV1, ()> for Compositor {
@@ -1195,6 +1216,11 @@ impl Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData> for Compositor {
             overlay_cursor: data.overlay_cursor,
             with_damage,
         });
+        // A plain copy is paced by presenting one compositor frame. Damage-
+        // aware copies deliberately wait for a real scene change instead.
+        if !with_damage {
+            state.wm.backend_mut().damage = true;
+        }
     }
 
     fn destroyed(
@@ -1207,61 +1233,207 @@ impl Dispatch<ZwlrScreencopyFrameV1, ScreencopyFrameData> for Compositor {
     }
 }
 
-/// Answers every capture that is due this pass.
-///
-/// `copy` is answered on the next pass regardless; `copy_with_damage`
-/// waits for a pass where the scene actually changed, which is what
-/// stops a recorder from spinning at dispatch rate over a still
-/// desktop. `WaylandBackend::damage` is the compositor's single
-/// scene-changed flag, and this runs before `render_frame` clears it.
-fn service_captures(comp: &mut Compositor) {
-    if comp.protocols.captures.is_empty() {
+/// Called once after the compositor submitted a visible frame. This is the
+/// screencopy pacing clock: protocol dispatch can run many times between
+/// presentations, but it cannot trigger extra readbacks.
+pub(crate) fn frame_presented(comp: &mut Compositor, presented: bool) {
+    if !presented || comp.protocols.captures.is_empty() {
         return;
     }
-    let damaged = comp.wm.backend().damage;
+
+    // Pick at most one distinct capture geometry per output this frame. All
+    // consumers asking for that exact geometry share the render/readback.
+    let monitors = comp.wm.backend().monitors();
+    let mut selected: HashMap<usize, (Rect, Transform, bool)> = HashMap::new();
     let mut due: Vec<PendingCapture> = Vec::new();
     comp.protocols.captures.retain(|capture| {
         if !capture.frame.is_alive() {
             return false;
         }
-        if capture.with_damage && !damaged {
-            return true;
+        let output = monitors
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, monitor)| overlap_area(capture.region, monitor.geometry))
+            .map(|(index, _)| index)
+            .unwrap_or(usize::MAX);
+        let key = (capture.region, capture.transform, capture.overlay_cursor);
+        match selected.get(&output) {
+            Some(existing) if existing != &key => true,
+            Some(_) => {
+                due.push(capture.clone());
+                false
+            }
+            None => {
+                selected.insert(output, key);
+                due.push(capture.clone());
+                false
+            }
         }
-        due.push(capture.clone());
-        false
     });
 
-    for capture in due {
-        let Some(pixels) = capture_region(comp, capture.region, capture.transform, capture.overlay_cursor) else {
-            capture.frame.failed();
-            continue;
-        };
-        if let Err(error) = write_capture(&capture.buffer, &pixels) {
-            tracing::warn!(%error, "screencopy could not write into the client's buffer");
-            capture.frame.failed();
-            continue;
+    while let Some(first) = due.pop() {
+        let mut group = vec![first.clone()];
+        let mut index = 0;
+        while index < due.len() {
+            if due[index].region == first.region
+                && due[index].transform == first.transform
+                && due[index].overlay_cursor == first.overlay_cursor
+            {
+                group.push(due.swap_remove(index));
+            } else {
+                index += 1;
+            }
         }
-        // Never y-inverted: `capture.rs` explains why the renderer's
-        // baked-in flip and `glReadPixels`' bottom-up order cancel.
-        capture.frame.flags(zwlr_screencopy_frame_v1::Flags::empty());
-        if capture.with_damage {
-            // The whole region, because that is the truth: this
-            // compositor repaints the full scene every frame on purpose
-            // (see `renderer`'s module docs), so there is no smaller
-            // damage rectangle to report.
-            capture.frame.damage(0, 0, pixels.width, pixels.height);
-        }
-        // Monotonic since session start. The protocol allows "an
-        // arbitrary offset at start" precisely so a compositor can use
-        // its own presentation clock, and this is the one every other
-        // timestamp in this process is measured against.
-        let stamp = comp.start_time.elapsed();
-        capture.frame.ready(
-            (stamp.as_secs() >> 32) as u32,
-            (stamp.as_secs() & 0xFFFF_FFFF) as u32,
-            stamp.subsec_nanos(),
-        );
+        service_capture_group(comp, &group);
     }
+
+    // A client may have queued different regions for the same output. Keep
+    // them paced: book one more presentation rather than draining them in the
+    // same dispatch turn.
+    if comp.protocols.captures.iter().any(|capture| !capture.with_damage) {
+        comp.wm.backend_mut().damage = true;
+    }
+}
+
+/// Whether a one-shot screencopy is waiting for the presentation it was
+/// promised when `copy` arrived.
+///
+/// Merely setting the compositor's coarse damage bit is not enough to make
+/// that presentation happen: the output damage tracker can quite correctly
+/// decide that an otherwise-idle scene has no changed pixels and skip the
+/// submit. The renderer uses this predicate to force one full output repaint,
+/// after which [`frame_presented`] drains the request. Damage-aware streams do
+/// not force frames; they continue to sleep until the scene really changes.
+pub(crate) fn plain_capture_pending(state: &ProtocolState) -> bool {
+    state.captures.iter().any(|capture| !capture.with_damage && capture.frame.is_alive())
+}
+
+fn overlap_area(a: Rect, b: Rect) -> u64 {
+    intersection(a, b)
+        .map(|rect| rect.size.w as u64 * rect.size.h as u64)
+        .unwrap_or(0)
+}
+
+fn service_capture_group(comp: &mut Compositor, captures: &[PendingCapture]) {
+    let Some(first) = captures.first() else { return };
+    let target_size = buffer_size(first.region.size, first.transform);
+    if target_size.w == 0 || target_size.h == 0 {
+        for capture in captures {
+            capture.frame.failed();
+        }
+        return;
+    }
+
+    let Compositor { wm, graphics, pointer_location, cursor_status, cursors, protocols, start_time, .. } = comp;
+    let cache_index = protocols
+        .capture_targets
+        .iter()
+        .position(|target| {
+            target.region == first.region
+                && target.size == target_size
+                && target.transform == first.transform
+                && target.overlay_cursor == first.overlay_cursor
+        });
+    let renderer = graphics_renderer(graphics);
+    let mut target = match cache_index {
+        Some(index) => protocols.capture_targets.swap_remove(index),
+        None => {
+            let width = target_size.w as i32;
+            let height = target_size.h as i32;
+            let texture = match renderer.create_buffer(
+                Fourcc::Abgr8888,
+                SSize::<i32, BufferCoords>::from((width, height)),
+            ) {
+                Ok(texture) => texture,
+                Err(error) => {
+                    tracing::warn!(?error, width, height, "could not allocate a screencopy buffer");
+                    for capture in captures { capture.frame.failed(); }
+                    return;
+                }
+            };
+            CaptureTarget {
+                region: first.region,
+                size: target_size,
+                transform: first.transform,
+                overlay_cursor: first.overlay_cursor,
+                texture,
+                damage_tracker: OutputDamageTracker::new(
+                    SSize::<i32, Physical>::from((width, height)),
+                    1.0,
+                    first.transform,
+                ),
+                scene_scratch: Vec::new(),
+                rendered: false,
+            }
+        }
+    };
+
+    let hidden = CursorImageStatus::Hidden;
+    let status = if first.overlay_cursor { &*cursor_status } else { &hidden };
+    let clear_color = build_scene_into(
+        &mut target.scene_scratch,
+        wm.backend(),
+        renderer,
+        *pointer_location,
+        status,
+        cursors,
+        first.region,
+    );
+    let width = target_size.w as i32;
+    let height = target_size.h as i32;
+    let success = (|| {
+        let mut framebuffer = renderer.bind(&mut target.texture).map_err(|error| format!("bind: {error:?}"))?;
+        // A plain `copy` is an independent snapshot, often from a new
+        // one-shot client such as grim. Redraw it in full: unlike an output
+        // swapchain, an offscreen pool has no externally supplied buffer-age
+        // contract, and carrying an incremental state across independent
+        // clients can preserve the image captured between a layer mapping and
+        // its first pixels. A `copy_with_damage` stream is explicitly paced
+        // across scene changes and may safely reuse the retained target.
+        let incremental = captures.iter().all(|capture| capture.with_damage);
+        let age = capture_buffer_age(target.rendered, incremental);
+        target
+            .damage_tracker
+            .render_output(renderer, &mut framebuffer, age, &target.scene_scratch, clear_color)
+            .map_err(|error| format!("render: {error:?}"))?;
+        target.rendered = true;
+        let region = SRect::from_size(SSize::<i32, BufferCoords>::from((width, height)));
+        let mapping = renderer
+            .copy_framebuffer(&framebuffer, region, Fourcc::Abgr8888)
+            .map_err(|error| format!("readback: {error:?}"))?;
+        let pixels = renderer.map_texture(&mapping).map_err(|error| format!("map: {error:?}"))?;
+        for capture in captures {
+            match write_capture_bytes(&capture.buffer, target_size, pixels) {
+                Ok(()) => finish_capture(start_time.elapsed(), capture, target_size),
+                Err(error) => {
+                    tracing::warn!(%error, "screencopy could not write into the client's buffer");
+                    capture.frame.failed();
+                }
+            }
+        }
+        Ok::<(), String>(())
+    })();
+    target.scene_scratch.clear();
+    if let Err(error) = success {
+        tracing::warn!(%error, "screencopy render failed");
+        for capture in captures { capture.frame.failed(); }
+    }
+    protocols.capture_targets.push(target);
+    if protocols.capture_targets.len() > 8 {
+        protocols.capture_targets.remove(0);
+    }
+}
+
+fn finish_capture(stamp: std::time::Duration, capture: &PendingCapture, size: Size) {
+    capture.frame.flags(zwlr_screencopy_frame_v1::Flags::empty());
+    if capture.with_damage {
+        capture.frame.damage(0, 0, size.w, size.h);
+    }
+    capture.frame.ready(
+        (stamp.as_secs() >> 32) as u32,
+        (stamp.as_secs() & 0xFFFF_FFFF) as u32,
+        stamp.subsec_nanos(),
+    );
 }
 
 /// The region of the compositor-global scene this output covers and
@@ -1316,7 +1488,7 @@ fn intersection(a: Rect, b: Rect) -> Option<Rect> {
 /// Draws the scene as it stands into an RGBA buffer covering `region`.
 ///
 /// The cursor is composited only when the client asked for it:
-/// `CursorImageStatus::Hidden` is the one status [`build_scene`] draws
+/// `CursorImageStatus::Hidden` is the one status [`build_scene_into`] draws
 /// nothing for, so suppressing the pointer needs no special case in the
 /// shared scene builder.
 ///
@@ -1335,18 +1507,91 @@ fn intersection(a: Rect, b: Rect) -> Option<Rect> {
 /// wrong in the preview" failure mode `capture.rs` warns about, arrived
 /// at from the other direction, and it was observed before it was
 /// argued: `grim` against a nested session came back upside down.
-pub(crate) fn capture_region(
+pub(crate) fn capture_region_into(
     comp: &mut Compositor,
     region: Rect,
     transform: Transform,
     overlay_cursor: bool,
-) -> Option<DecorationBuffer> {
-    let Compositor { wm, graphics, pointer_location, cursor_status, cursors, .. } = comp;
+    buffer: &WlBuffer,
+) -> Result<Size, String> {
+    let target_size = buffer_size(region.size, transform);
+    if target_size.w == 0 || target_size.h == 0 {
+        return Err("capture region is empty".to_string());
+    }
+
+    let Compositor { wm, graphics, pointer_location, cursor_status, cursors, protocols, .. } = comp;
+    let cache_index = protocols
+        .capture_targets
+        .iter()
+        .position(|target| {
+            target.region == region
+                && target.size == target_size
+                && target.transform == transform
+                && target.overlay_cursor == overlay_cursor
+        });
     let renderer = graphics_renderer(graphics);
+    let mut target = match cache_index {
+        Some(index) => protocols.capture_targets.swap_remove(index),
+        None => {
+            let width = target_size.w as i32;
+            let height = target_size.h as i32;
+            let texture = renderer
+                .create_buffer(Fourcc::Abgr8888, SSize::<i32, BufferCoords>::from((width, height)))
+                .map_err(|error| format!("allocate: {error:?}"))?;
+            CaptureTarget {
+                region,
+                size: target_size,
+                transform,
+                overlay_cursor,
+                texture,
+                damage_tracker: OutputDamageTracker::new(
+                    SSize::<i32, Physical>::from((width, height)),
+                    1.0,
+                    transform,
+                ),
+                scene_scratch: Vec::new(),
+                rendered: false,
+            }
+        }
+    };
+
     let hidden = CursorImageStatus::Hidden;
     let status = if overlay_cursor { &*cursor_status } else { &hidden };
-    let (elements, clear_color) = build_scene(wm.backend(), renderer, *pointer_location, status, cursors, region);
-    render_offscreen(renderer, &elements, region.size, transform, clear_color)
+    let clear_color = build_scene_into(
+        &mut target.scene_scratch,
+        wm.backend(),
+        renderer,
+        *pointer_location,
+        status,
+        cursors,
+        region,
+    );
+    let width = target_size.w as i32;
+    let height = target_size.h as i32;
+    let result = (|| {
+        let mut framebuffer = renderer.bind(&mut target.texture).map_err(|error| format!("bind: {error:?}"))?;
+        // Ext-image-copy captures are independent snapshots too; retain the
+        // expensive storage, but make every returned image authoritative.
+        let age = capture_buffer_age(target.rendered, false);
+        target
+            .damage_tracker
+            .render_output(renderer, &mut framebuffer, age, &target.scene_scratch, clear_color)
+            .map_err(|error| format!("render: {error:?}"))?;
+        target.rendered = true;
+        let readback = SRect::from_size(SSize::<i32, BufferCoords>::from((width, height)));
+        let mapping = renderer
+            .copy_framebuffer(&framebuffer, readback, Fourcc::Abgr8888)
+            .map_err(|error| format!("readback: {error:?}"))?;
+        let pixels = renderer.map_texture(&mapping).map_err(|error| format!("map: {error:?}"))?;
+        write_capture_bytes(buffer, target_size, pixels)
+    })();
+
+    target.scene_scratch.clear();
+    protocols.capture_targets.push(target);
+    if protocols.capture_targets.len() > 8 {
+        protocols.capture_targets.remove(0);
+    }
+    result.map(|()| target_size)
 }
 
 /// The session's `GlesRenderer`, whichever graphics stack is running.
@@ -1361,75 +1606,8 @@ fn graphics_renderer(graphics: &mut Graphics) -> &mut GlesRenderer {
     }
 }
 
-/// Draws `elements` into a fresh offscreen texture and downloads the
-/// result, at scale 1 — the scale every element in this compositor's
-/// scene is built at.
-///
-/// `size` is the region in *logical* coordinates, which is the space
-/// `elements` are in; the texture is allocated at the transformed size,
-/// and [`OutputDamageTracker`] applies `transform` while drawing
-/// (it inverts the output transform internally, exactly as a real
-/// output's frame does).
-///
-/// Otherwise a near-duplicate of `capture::render_offscreen`, for reach
-/// rather than for difference: see the module docs for the change that
-/// lets this be deleted. The fresh tracker per call, at age 0, is
-/// deliberate for the same reason it is there — the target texture is
-/// new and entirely stale, and a carried tracker would compute
-/// incremental damage against a buffer that no longer exists and skip
-/// drawing outright.
-fn render_offscreen(
-    renderer: &mut GlesRenderer,
-    elements: &[SceneElement<GlesRenderer>],
-    size: Size,
-    transform: Transform,
-    clear_color: Color32F,
-) -> Option<DecorationBuffer> {
-    let target = buffer_size(size, transform);
-    if target.w == 0 || target.h == 0 {
-        return None;
-    }
-    let width = target.w as i32;
-    let height = target.h as i32;
-
-    let mut texture: GlesTexture =
-        match renderer.create_buffer(Fourcc::Abgr8888, SSize::<i32, BufferCoords>::from((width, height))) {
-            Ok(texture) => texture,
-            Err(error) => {
-                tracing::warn!(?error, width, height, "could not allocate a screencopy buffer");
-                return None;
-            }
-        };
-    let mut framebuffer = match renderer.bind(&mut texture) {
-        Ok(framebuffer) => framebuffer,
-        Err(error) => {
-            tracing::warn!(?error, "could not bind the screencopy buffer");
-            return None;
-        }
-    };
-
-    let mut damage_tracker = OutputDamageTracker::new(SSize::<i32, Physical>::from((width, height)), 1.0, transform);
-    if let Err(error) = damage_tracker.render_output(renderer, &mut framebuffer, 0, elements, clear_color) {
-        tracing::warn!(?error, "screencopy render failed");
-        return None;
-    }
-
-    let region = SRect::from_size(SSize::<i32, BufferCoords>::from((width, height)));
-    let mapping = match renderer.copy_framebuffer(&framebuffer, region, Fourcc::Abgr8888) {
-        Ok(mapping) => mapping,
-        Err(error) => {
-            tracing::warn!(?error, "could not read back the screencopy buffer");
-            return None;
-        }
-    };
-    let pixels = match renderer.map_texture(&mapping) {
-        Ok(pixels) => pixels.to_vec(),
-        Err(error) => {
-            tracing::warn!(?error, "could not map the captured pixels");
-            return None;
-        }
-    };
-    Some(DecorationBuffer { width: target.w, height: target.h, pixels })
+fn capture_buffer_age(rendered: bool, incremental: bool) -> usize {
+    usize::from(rendered && incremental)
 }
 
 /// Validates a client buffer against what this frame advertised and
@@ -1484,11 +1662,18 @@ fn pixel_layout(format: wl_shm::Format) -> Option<(bool, bool)> {
 /// `argb8888` is defined premultiplied — so nothing but the channel
 /// order changes.
 pub(crate) fn write_capture(buffer: &WlBuffer, capture: &DecorationBuffer) -> Result<(), String> {
-    let data = shm_layout(buffer, Size::new(capture.width, capture.height))?;
+    write_capture_bytes(buffer, Size::new(capture.width, capture.height), &capture.pixels)
+}
+
+fn write_capture_bytes(buffer: &WlBuffer, size: Size, pixels: &[u8]) -> Result<(), String> {
+    let data = shm_layout(buffer, size)?;
     let (swap_rb, opaque) = pixel_layout(data.format).ok_or("unsupported buffer format")?;
-    let width = capture.width as usize;
-    let height = capture.height as usize;
+    let width = size.w as usize;
+    let height = size.h as usize;
     let row_bytes = width * BYTES_PER_PIXEL;
+    if pixels.len() < row_bytes.saturating_mul(height) {
+        return Err("captured pixel mapping is shorter than its dimensions".to_string());
+    }
     let stride = data.stride as usize;
     let offset = data.offset.max(0) as usize;
 
@@ -1501,7 +1686,7 @@ pub(crate) fn write_capture(buffer: &WlBuffer, capture: &DecorationBuffer) -> Re
             return Err(format!("buffer holds {len} bytes, the capture needs {needed}"));
         }
         for y in 0..height {
-            let source = &capture.pixels[y * row_bytes..y * row_bytes + row_bytes];
+            let source = &pixels[y * row_bytes..y * row_bytes + row_bytes];
             // SAFETY: `ptr`/`len` describe the client's mapped pool for
             // the duration of this closure (that is the contract of
             // `with_buffer_contents_mut`, which also traps SIGBUS on a
@@ -1618,5 +1803,13 @@ mod tests {
         assert_eq!(pixel_layout(wl_shm::Format::Xbgr8888), Some((false, true)));
         // Anything else is refused rather than written wrong.
         assert_eq!(pixel_layout(wl_shm::Format::Rgb565), None);
+    }
+
+    #[test]
+    fn only_a_continuing_damage_stream_uses_retained_capture_pixels() {
+        assert_eq!(capture_buffer_age(false, false), 0);
+        assert_eq!(capture_buffer_age(false, true), 0);
+        assert_eq!(capture_buffer_age(true, false), 0);
+        assert_eq!(capture_buffer_age(true, true), 1);
     }
 }

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -305,18 +305,18 @@ pub(crate) fn build_scene_into(
                     push_window_content(elements, renderer, backend, record.content, record, viewport);
                 }
             }
-            if let Some(buffer) = &frame.buffer {
-                if overlap_area(frame.geometry, viewport) == 0 {
-                    continue;
-                }
+            if overlap_area(frame.geometry, viewport) == 0 {
+                continue;
+            }
+            for part in &frame.parts {
                 let location = SPoint::<f64, Physical>::from((
-                    (frame.geometry.pos.x - viewport.pos.x) as f64,
-                    (frame.geometry.pos.y - viewport.pos.y) as f64,
+                    (frame.geometry.pos.x + part.offset.x - viewport.pos.x) as f64,
+                    (frame.geometry.pos.y + part.offset.y - viewport.pos.y) as f64,
                 ));
                 match MemoryRenderBufferRenderElement::from_buffer(
                     renderer,
                     location,
-                    buffer,
+                    &part.buffer,
                     None,
                     None,
                     None,
@@ -326,6 +326,28 @@ pub(crate) fn build_scene_into(
                     Err(error) => tracing::warn!(?error, "failed to import a decoration buffer"),
                 }
             }
+            // Preserve the opaque mid-resize/unshade gap that the former
+            // window-sized pixel buffer supplied, but as four floats plus a
+            // stable id instead of frame-width * frame-height * 4 retained
+            // bytes. It is behind both the client content and sparse chrome.
+            let geometry = SRect::<i32, Physical>::new(
+                (
+                    frame.geometry.pos.x - viewport.pos.x,
+                    frame.geometry.pos.y - viewport.pos.y,
+                )
+                    .into(),
+                (frame.geometry.size.w as i32, frame.geometry.size.h as i32).into(),
+            );
+            elements.push(
+                SolidColorRenderElement::new(
+                    frame.fill_id.clone(),
+                    geometry,
+                    CommitCounter::default(),
+                    Color32F::new(0.0, 0.0, 0.0, 1.0),
+                    Kind::Unspecified,
+                )
+                .into(),
+            );
         }
     }
 
@@ -397,6 +419,7 @@ pub(crate) fn send_frame_callbacks(
 ) {
     let throttle = frame_interval(output);
     let send_tree = |surface: &WlSurface| {
+        signal_pacing_barriers(surface);
         send_frames_surface_tree(surface, output, elapsed, throttle, |_, _| Some(output.clone()));
     };
     // While locked, ONLY lock surfaces hear about frames: withholding
@@ -470,6 +493,30 @@ pub(crate) fn send_frame_callbacks(
             send_tree(popup.wl_surface());
         }
     }
+}
+
+/// Release a FIFO barrier only once its surface tree has actually appeared at
+/// a presentation boundary. Commit timing is clock-driven instead and is
+/// serviced by `Compositor::service_surface_pacing`; coupling it to a frame
+/// would deadlock the commit whose pixels are waiting behind that timer.
+fn signal_pacing_barriers(surface: &WlSurface) {
+    compositor::with_surface_tree_downward(
+        surface,
+        (),
+        |_, _, &()| TraversalAction::DoChildren(()),
+        |_, states, &()| {
+            if let Some(barrier) = states
+                .cached_state
+                .get::<smithay::wayland::fifo::FifoBarrierCachedState>()
+                .current()
+                .barrier
+                .take()
+            {
+                barrier.signal();
+            }
+        },
+        |_, _, &()| true,
+    );
 }
 
 /// Drain presentation requests for the surfaces whose primary output
@@ -676,13 +723,17 @@ pub(crate) fn note_frame_success() {
 /// flip) and live with their backends; everything visible above them
 /// is [`build_scene`].
 pub(crate) fn render_frame(comp: &mut Compositor) -> bool {
+    // A plain screencopy must complete even when it lands on an idle desktop.
+    // The coarse damage bit gets us here; forcing age zero below makes the
+    // output damage tracker produce the actual presentation that paces it.
+    let plain_capture_pending = crate::protocols::plain_capture_pending(&comp.protocols);
     match comp.graphics {
         Graphics::Session(_) => {
             // Snapshot readback is deliberately outside the deadline
             // path. It is synchronous on some drivers; doing it after
             // the flip is queued spends post-submit slack rather than
             // making fresh input miss the vblank we just scheduled for.
-            let drew = crate::session::render_frame_session(comp);
+            let drew = crate::session::render_frame_session(comp, plain_capture_pending);
             if drew {
                 crate::capture::refresh_snapshots(comp);
             }
@@ -692,12 +743,12 @@ pub(crate) fn render_frame(comp: &mut Compositor) -> bool {
             // The nested backend has no vblank clock of its own; keep
             // its existing immediate ordering under the host compositor.
             crate::capture::refresh_snapshots(comp);
-            render_frame_winit(comp)
+            render_frame_winit(comp, plain_capture_pending)
         }
     }
 }
 
-fn render_frame_winit(comp: &mut Compositor) -> bool {
+fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> bool {
     // Disjoint field borrows: the winit backend (renderer +
     // framebuffer) mutates while the ledger is read — both live on
     // `Compositor`, so destructure instead of going through `&mut
@@ -736,7 +787,11 @@ fn render_frame_winit(comp: &mut Compositor) -> bool {
     // old always-full-frame behaviour, honestly forced rather than
     // silently assumed. `CHONKSTEP_FULL_DAMAGE=1` forces 0 for the same
     // escape-hatch reason `session.rs` documents.
-    let age = if crate::session::full_damage_forced() { 0 } else { winit_backend.buffer_age().unwrap_or(0) };
+    let age = if crate::session::full_damage_forced() || plain_capture_pending {
+        0
+    } else {
+        winit_backend.buffer_age().unwrap_or(0)
+    };
     let render_states = {
         let (renderer, mut framebuffer) = match winit_backend.bind() {
             Ok(bound) => bound,

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -65,11 +65,15 @@ use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use smithay::backend::allocator::format::FormatSet;
+use smithay::backend::input::InputEvent;
 use smithay::backend::allocator::gbm::{GbmAllocator, GbmBufferFlags, GbmDevice};
 use smithay::backend::allocator::{Format, Fourcc, Modifier};
 use smithay::backend::drm::compositor::{DrmCompositor, FrameError, FrameFlags, PrimaryPlaneElement};
 use smithay::backend::drm::exporter::gbm::GbmFramebufferExporter;
-use smithay::backend::drm::{DrmDevice, DrmDeviceFd, DrmDeviceNotifier, DrmEvent, DrmEventTime, DrmNode, NodeType, PlaneInfo};
+use smithay::backend::drm::{
+    DrmDevice, DrmDeviceFd, DrmDeviceNotifier, DrmEvent, DrmEventTime, DrmNode, NodeType,
+    PlaneInfo, VrrSupport,
+};
 use smithay::backend::egl::{EGLContext, EGLDisplay};
 use smithay::backend::libinput::{LibinputInputBackend, LibinputSessionInterface};
 use smithay::backend::renderer::gles::GlesRenderer;
@@ -82,7 +86,7 @@ use smithay::reexports::drm::control::{
     connector, crtc, plane, Device as ControlDevice, Mode as DrmMode, ModeFlags, ModeTypeFlags,
     PlaneType, ResourceHandles,
 };
-use smithay::reexports::input::Libinput;
+use smithay::reexports::input::{self as libinput_crate, Libinput};
 use smithay::reexports::rustix::fs::OFlags;
 use smithay::reexports::wayland_server::DisplayHandle;
 use smithay::utils::{Clock, DeviceFd, Monotonic, Transform};
@@ -617,6 +621,9 @@ pub(crate) struct SessionGraphics {
     /// and resume it. The `LibinputInputBackend` calloop owns holds its
     /// own clone of the same underlying context.
     libinput: Libinput,
+    /// Live libinput device handles retained so config reloads can
+    /// update already-connected hardware, not only future hotplug.
+    input_devices: Vec<libinput_crate::Device>,
     /// When [`service_pending_flips`] last ran. The gap between
     /// consecutive visits is how long the main thread was away, which
     /// is time no flip should be charged for — see [`LOOP_BLOCK_GRACE`].
@@ -682,6 +689,8 @@ struct SessionOutput {
     /// into the many, and [`redraw_pending`] is what keeps the dispatch
     /// loop coming back until every output has caught up.
     dirty: bool,
+    /// False after DPMS off; the head remains in the logical layout.
+    powered: bool,
     /// Reusable scene-construction storage. Draining this into
     /// `pending_scene` preserves the allocation for the next frame
     /// while the latter owns any client buffers until vblank.
@@ -718,6 +727,11 @@ struct SessionOutput {
     /// Cached solely for transition telemetry; unlike inspecting the
     /// scene, this costs no walk in the vblank callback.
     direct_scanout_active: bool,
+    /// Connector capability and the user's policy are separate from the live
+    /// DRM property. The latter is enabled only for a frame the renderer has
+    /// proved will directly scan out.
+    vrr_supported: bool,
+    vrr_requested: bool,
     /// Presentation requests drained for the page flip in flight.
     /// They are completed with the kernel's vblank timestamp, never
     /// merely when rendering finished.
@@ -1332,6 +1346,7 @@ pub(crate) fn init(
         .map_err(|()| format!("libinput could not take seat {seat_name}; no keyboard or mouse would work"))?;
     loop_handle
         .insert_source(LibinputInputBackend::new(libinput.clone()), |event, _, comp: &mut Compositor| {
+            note_libinput_device(comp, &event);
             crate::input::process_input_event(comp, event);
         })
         .map_err(|error| format!("failed to register the libinput event source: {error}"))?;
@@ -1412,6 +1427,19 @@ pub(crate) fn init(
                         // the switch but mean nothing now: the foreign
                         // session painted over the screen.
                         output.drm_compositor.reset_buffers();
+                        // `activate(true)` resets connector state, including
+                        // DPMS. Reassert logical sleep before the render loop
+                        // can touch this output; powered-off outputs are
+                        // intentionally skipped below.
+                        if !output.powered {
+                            if let Err(error) = output.drm_compositor.clear() {
+                                tracing::warn!(
+                                    ?error,
+                                    output = %output.name,
+                                    "could not restore powered-off state after VT resume"
+                                );
+                            }
+                        }
                         output.frame_pending = None;
                         output.last_vblank = None;
                         clear_scene_holds(
@@ -1471,6 +1499,7 @@ pub(crate) fn init(
             render_formats,
             outputs: session_outputs,
             libinput,
+            input_devices: Vec::new(),
             last_service: Instant::now(),
             strict_release,
             hotplug_due: None,
@@ -1615,7 +1644,7 @@ fn attach_output(
         "DRM planes available to this crtc"
     );
 
-    let drm_compositor = SessionDrmCompositor::new(
+    let mut drm_compositor = SessionDrmCompositor::new(
         OutputModeSource::Static {
             size: wl_mode.size,
             scale: smithay::utils::Scale::from(1.0),
@@ -1639,6 +1668,28 @@ fn attach_output(
         Some(gbm.clone()),
     )
     .map_err(|error| format!("could not set up scanout: {error}"))?;
+    let vrr_supported = match drm_compositor.vrr_supported(info.handle()) {
+        Ok(VrrSupport::Supported) => true,
+        // Runtime desktop toggles must never silently modeset/flicker an HDMI
+        // output. Smithay distinguishes this case precisely for that reason.
+        Ok(VrrSupport::RequiresModeset) => {
+            tracing::info!(output = %name, "adaptive sync requires a modeset; runtime VRR disabled");
+            false
+        }
+        Ok(VrrSupport::NotSupported) => false,
+        Err(error) => {
+            tracing::warn!(?error, output = %name, "could not query adaptive-sync capability");
+            false
+        }
+    };
+    let vrr_requested = vrr_supported && !crate::diagnostics::enabled("no-vrr");
+    let mut vrr_enabled = drm_compositor.vrr_enabled();
+    if vrr_enabled {
+        match drm_compositor.use_vrr(false) {
+            Ok(()) => vrr_enabled = false,
+            Err(error) => tracing::warn!(?error, output = %name, "could not disable inherited adaptive-sync state"),
+        }
+    }
 
     Ok((
         SessionOutput {
@@ -1653,10 +1704,13 @@ fn attach_output(
             frame_pending: None,
             // Nothing has ever been drawn on it.
             dirty: true,
+            powered: true,
             scene_scratch: Vec::new(),
             pending_scene: Vec::new(),
             scanout_scene: Vec::new(),
             direct_scanout_active: false,
+            vrr_supported,
+            vrr_requested,
             presentation: None,
             last_vblank: None,
             refresh: if wl_mode.refresh > 0 {
@@ -1675,6 +1729,10 @@ fn attach_output(
             transform: Transform::Normal,
             requested_mode: None,
             modes,
+            powered: true,
+            vrr_supported,
+            vrr_requested,
+            vrr_enabled,
         },
     ))
 }
@@ -1706,7 +1764,10 @@ pub(crate) fn redraw_pending(graphics: &Graphics) -> bool {
     match graphics {
         Graphics::Winit(_) => false,
         Graphics::Session(session) => {
-            session.outputs.iter().any(|output| output.dirty || output.frame_pending.is_some())
+            session
+                .outputs
+                .iter()
+                .any(|output| output.powered && (output.dirty || output.frame_pending.is_some()))
         }
     }
 }
@@ -2090,6 +2151,164 @@ pub(crate) fn apply_output_setups(graphics: &mut Graphics, setups: &mut [OutputS
     }
 }
 
+/// Switch one connector's DPMS state while retaining its output,
+/// geometry, workspaces and protocol globals. Smithay re-enables a
+/// cleared DRM surface when the next frame is queued.
+pub(crate) fn set_output_power(graphics: &mut Graphics, index: usize, powered: bool) -> Result<(), String> {
+    let Graphics::Session(session) = graphics else {
+        return Err("the nested backend has no physical output power control".to_string());
+    };
+    let output = session
+        .outputs
+        .get_mut(index)
+        .ok_or_else(|| format!("output index {index} does not exist"))?;
+    if output.powered == powered {
+        return Ok(());
+    }
+    if powered {
+        output.powered = true;
+        output.dirty = true;
+        output.drm_compositor.reset_buffer_ages();
+        output.frame_clock.disarm();
+    } else {
+        if output.drm_compositor.vrr_enabled() {
+            if let Err(error) = output.drm_compositor.use_vrr(false) {
+                tracing::warn!(?error, output = %output.name, "could not disable adaptive sync before DPMS off");
+            }
+        }
+        output
+            .drm_compositor
+            .clear()
+            .map_err(|error| format!("DPMS off failed: {error}"))?;
+        output.powered = false;
+        output.dirty = false;
+        output.frame_pending = None;
+        output.last_vblank = None;
+        output.frame_clock.disarm();
+        clear_scene_holds(
+            &mut output.pending_scene,
+            &mut output.scanout_scene,
+            &mut output.direct_scanout_active,
+        );
+        if let Some(mut feedback) = output.presentation.take() {
+            feedback.discarded();
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn has_physical_outputs(graphics: &Graphics) -> bool {
+    matches!(graphics, Graphics::Session(session) if !session.outputs.is_empty())
+}
+
+fn note_libinput_device(comp: &mut Compositor, event: &InputEvent<LibinputInputBackend>) {
+    match event {
+        InputEvent::DeviceAdded { device } => {
+            let config = comp.wm.backend().pointer_config.clone();
+            let mut device = device.clone();
+            configure_libinput_device(&mut device, &config);
+            if let Graphics::Session(session) = &mut comp.graphics {
+                if !session.input_devices.iter().any(|held| held.sysname() == device.sysname()) {
+                    session.input_devices.push(device);
+                }
+            }
+        }
+        InputEvent::DeviceRemoved { device } => {
+            if let Graphics::Session(session) = &mut comp.graphics {
+                session.input_devices.retain(|held| held.sysname() != device.sysname());
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn apply_pointer_config(graphics: &mut Graphics, config: &wm_core::PointerConfig) {
+    let Graphics::Session(session) = graphics else {
+        return;
+    };
+    for device in &mut session.input_devices {
+        configure_libinput_device(device, config);
+    }
+}
+
+fn configure_libinput_device(device: &mut libinput_crate::Device, config: &wm_core::PointerConfig) {
+    use libinput_crate::{AccelProfile, ClickMethod};
+
+    let mut rejected = Vec::new();
+    if let Some(speed) = config.sensitivity {
+        if !device.config_accel_is_available() {
+            rejected.push("sensitivity: unsupported".to_string());
+        } else if let Err(error) = device.config_accel_set_speed(speed) {
+            rejected.push(format!("sensitivity: {error:?}"));
+        }
+    }
+    if let Some(profile) = config.accel_profile.as_deref() {
+        let profile = if profile.eq_ignore_ascii_case("flat") {
+            AccelProfile::Flat
+        } else {
+            AccelProfile::Adaptive
+        };
+        if !device.config_accel_profiles().contains(&profile) {
+            rejected.push("accel_profile: unsupported".to_string());
+        } else if let Err(error) = device.config_accel_set_profile(profile) {
+            rejected.push(format!("accel_profile: {error:?}"));
+        }
+    }
+    if let Some(enabled) = config.natural_scroll {
+        if !device.config_scroll_has_natural_scroll() {
+            rejected.push("natural_scroll: unsupported".to_string());
+        } else if let Err(error) = device.config_scroll_set_natural_scroll_enabled(enabled) {
+            rejected.push(format!("natural_scroll: {error:?}"));
+        }
+    }
+    if let Some(enabled) = config.tap_to_click {
+        if device.config_tap_finger_count() == 0 {
+            rejected.push("tap_to_click: unsupported".to_string());
+        } else if let Err(error) = device.config_tap_set_enabled(enabled) {
+            rejected.push(format!("tap_to_click: {error:?}"));
+        }
+    }
+    if let Some(clickfinger) = config.clickfinger_behavior {
+        let method = if clickfinger { ClickMethod::Clickfinger } else { ClickMethod::ButtonAreas };
+        if !device.config_click_methods().contains(&method) {
+            rejected.push("clickfinger_behavior: unsupported".to_string());
+        } else if let Err(error) = device.config_click_set_method(method) {
+            rejected.push(format!("clickfinger_behavior: {error:?}"));
+        }
+    }
+    if let Some(enabled) = config.left_handed {
+        if !device.config_left_handed_is_available() {
+            rejected.push("left_handed: unsupported".to_string());
+        } else if let Err(error) = device.config_left_handed_set(enabled) {
+            rejected.push(format!("left_handed: {error:?}"));
+        }
+    }
+    if rejected.is_empty() {
+        tracing::info!(device = device.name(), "libinput configuration applied");
+    } else {
+        tracing::debug!(device = device.name(), rejected = ?rejected, "some libinput settings are unsupported by this device");
+    }
+}
+
+pub(crate) fn set_adaptive_sync(graphics: &mut Graphics, index: usize, enabled: bool) -> Result<(), String> {
+    let Graphics::Session(session) = graphics else {
+        return Err("the nested backend has no adaptive-sync output".to_string());
+    };
+    let output = session
+        .outputs
+        .get_mut(index)
+        .ok_or_else(|| format!("output index {index} does not exist"))?;
+    if enabled && !output.vrr_supported {
+        return Err(format!("{} does not support runtime adaptive sync", output.name));
+    }
+    if enabled && crate::diagnostics::enabled("no-vrr") {
+        return Err("adaptive sync is disabled by CHONKSTEP_NO_VRR".to_string());
+    }
+    output.vrr_requested = enabled;
+    output.dirty = true;
+    Ok(())
+}
+
 /// The gamma ramp length each output's hardware wants, index-aligned
 /// with `Compositor::outputs` — the number `zwlr_gamma_control_v1`
 /// advertises as `gamma_size`, and the number of entries a client's
@@ -2250,7 +2469,7 @@ pub(crate) fn change_vt(comp: &mut Compositor, vt: i32) -> bool {
 /// sets dirty, dirty clears on a successful submit, and a blocked or
 /// failed frame is retried on the next wakeup.
 #[cfg_attr(feature = "profile", profiling::function)]
-pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
+pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending: bool) -> bool {
     // Disjoint field borrows: the graphics stack mutates while the
     // ledger is read. Both live on `Compositor`, so destructure rather
     // than going through `&mut self` methods.
@@ -2258,6 +2477,8 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
         wm,
         graphics,
         outputs: output_entries,
+        output_mgmt,
+        hyprland_state_dirty,
         pointer_location,
         cursor_status,
         cursors,
@@ -2291,6 +2512,9 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
     let strict_release = *strict_release;
     let mut drew_any = false;
     for (output_index, output) in session_outputs.iter_mut().enumerate() {
+        if !output.powered {
+            continue;
+        }
         if output.frame_pending.is_some() {
             // A page flip is in flight on this crtc. Rendering now would
             // burn a swapchain slot on a frame the display cannot show
@@ -2340,7 +2564,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
         // stale rectangles rather than a crash — the kind of bug a user
         // hits before a developer does, and one that would otherwise
         // require a rebuild to escape.
-        if full_damage_forced() {
+        if full_damage_forced() || plain_capture_pending {
             output.drm_compositor.reset_buffer_ages();
         }
 
@@ -2401,6 +2625,46 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
                 continue;
             }
         };
+
+        // VRR is deliberately narrower than "the connector can do it". A
+        // composited desktop has independent cursor, bar and notification
+        // clocks; varying that output's refresh makes their pacing erratic.
+        // Smithay's actual primary-plane decision is the authoritative gate:
+        // enable only for a direct-scanout frame, disable before any
+        // composited frame is queued, and never runtime-modeset an output.
+        let desired_vrr = runtime_vrr_enabled(
+            output.vrr_supported,
+            output.vrr_requested,
+            direct_scanout,
+            crate::diagnostics::enabled("no-vrr"),
+        );
+        let live_vrr = output.drm_compositor.vrr_enabled();
+        if desired_vrr != live_vrr {
+            match output.drm_compositor.use_vrr(desired_vrr) {
+                Ok(()) => {
+                    if let Some(entry) = output_entries.get_mut(output_index) {
+                        entry.vrr_enabled = desired_vrr;
+                    }
+                    if let Some(monitor) = wm.backend_mut().monitor_outputs.get_mut(output_index) {
+                        monitor.vrr_enabled = desired_vrr;
+                    }
+                    output_mgmt.mark_dirty();
+                    *hyprland_state_dirty = true;
+                    tracing::info!(
+                        output = %output.name,
+                        enabled = desired_vrr,
+                        direct_scanout,
+                        "adaptive sync runtime state changed"
+                    );
+                }
+                Err(error) => tracing::warn!(
+                    ?error,
+                    output = %output.name,
+                    enabled = desired_vrr,
+                    "adaptive sync runtime transition failed"
+                ),
+            }
+        }
 
         let mut frame_queued = false;
         if rendered {
@@ -2503,6 +2767,15 @@ pub(crate) fn render_frame_session(comp: &mut Compositor) -> bool {
         crate::renderer::note_frame_success();
     }
     drew_any
+}
+
+fn runtime_vrr_enabled(
+    supported: bool,
+    requested: bool,
+    direct_scanout: bool,
+    forced_off: bool,
+) -> bool {
+    supported && requested && direct_scanout && !forced_off
 }
 
 /// One opened, mode-set-capable DRM device together with every output
@@ -2901,6 +3174,15 @@ mod tests {
         assert_eq!(configured_frame_flags(Some("1".into()), None), primary);
         assert_eq!(configured_frame_flags(None, Some("yes".into())), cursor);
         assert_eq!(configured_frame_flags(Some("true".into()), Some("1".into())), FrameFlags::empty());
+    }
+
+    #[test]
+    fn vrr_runs_only_for_requested_direct_scanout() {
+        assert!(runtime_vrr_enabled(true, true, true, false));
+        assert!(!runtime_vrr_enabled(false, true, true, false));
+        assert!(!runtime_vrr_enabled(true, false, true, false));
+        assert!(!runtime_vrr_enabled(true, true, false, false));
+        assert!(!runtime_vrr_enabled(true, true, true, true));
     }
 
     /// A direct buffer remains owned after the vblank that activates it

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -492,15 +492,22 @@ impl WindowRecord {
     }
 }
 
-/// Ledger entry for one decoration frame. `buffer` holds the imported
-/// decoration pixels (`None` until the first `paint_decoration`).
+pub(crate) struct FramePart {
+    pub offset: Point,
+    pub size: Size,
+    pub buffer: MemoryRenderBuffer,
+}
+
+/// Ledger entry for one decoration frame. `parts` holds only the imported
+/// chrome perimeter; the stable solid fill covers transient client gaps.
 /// No layout is cached here: chrome hit-testing happens in `wm-core`
 /// against the client's own theme-authoritative layout, so the
 /// backend only needs where the frame is, never what is drawn on it.
 pub(crate) struct FrameRecord {
     pub window: WlWindowId,
     pub geometry: Rect,
-    pub buffer: Option<MemoryRenderBuffer>,
+    pub parts: Vec<FramePart>,
+    pub fill_id: smithay::backend::renderer::element::Id,
     pub mapped: bool,
 }
 
@@ -647,6 +654,10 @@ pub struct WaylandBackend {
     /// drains it on the next pass — the same shape every other
     /// deferred backend request in this file takes.
     pub(crate) pending_keyboard: Option<wm_core::KeyboardConfig>,
+    pub(crate) pending_pointer: Option<wm_core::PointerConfig>,
+    pub(crate) pointer_config: wm_core::PointerConfig,
+    /// Post-libinput axis multiplier, also used by the nested backend.
+    pub(crate) scroll_factor: f64,
     /// The xkb layout actually installed on the seat.
     ///
     /// What IPC reports, rather than the config's own `kb_layout`: the
@@ -655,6 +666,10 @@ pub struct WaylandBackend {
     /// and the session never adopted. A bar that prints this should be
     /// printing the keymap in force.
     pub(crate) keyboard_layout: String,
+    /// Human-readable XKB group names and the active group selected on
+    /// the seat. Kept for immutable IPC snapshots.
+    pub(crate) keyboard_layouts: Vec<String>,
+    pub(crate) active_keyboard_layout: u32,
     /// Set when the workspace row moves, drained by
     /// `workspace::refresh`. On the ledger rather than on
     /// `WorkspaceState` because the verb that knows the row changed is
@@ -1006,7 +1021,12 @@ impl WaylandBackend {
             stacking_dirty: false,
             xwayland_keyboard_grab: None,
             pending_keyboard: None,
+            pending_pointer: None,
+            pointer_config: wm_core::PointerConfig::default(),
+            scroll_factor: 1.0,
             keyboard_layout: String::new(),
+            keyboard_layouts: Vec::new(),
+            active_keyboard_layout: 0,
             workspaces_dirty: true,
             input_devices: Vec::new(),
             ime_popups: Vec::new(),
@@ -1352,6 +1372,49 @@ pub struct ClientState {
     /// ever spoke this protocol. Atomic because the bind handler holds
     /// only `&ClientState`.
     pub kde_decoration_bound: std::sync::atomic::AtomicBool,
+    /// Present only for connections admitted by
+    /// `wp_security_context_v1`. Mutex-backed because Wayland global
+    /// filters receive only a shared client-data reference.
+    pub security_context: std::sync::Mutex<
+        Option<smithay::wayland::security_context::SecurityContext>,
+    >,
+}
+
+impl ClientState {
+    pub(crate) fn confined(
+        context: smithay::wayland::security_context::SecurityContext,
+    ) -> Self {
+        Self {
+            security_context: std::sync::Mutex::new(Some(context)),
+            ..Self::default()
+        }
+    }
+}
+
+pub(crate) fn client_is_confined(client: &smithay::reexports::wayland_server::Client) -> bool {
+    client
+        .get_data::<ClientState>()
+        .is_some_and(|data| data.security_context.lock().is_ok_and(|context| context.is_some()))
+}
+
+/// One gate for capabilities that affect other clients. The current
+/// policy remains permissive for both ordinary and confined clients;
+/// centralizing the decision makes confinement a policy choice instead
+/// of information the compositor cannot represent.
+pub(crate) fn privileged_global_visible(
+    client: &smithay::reexports::wayland_server::Client,
+) -> bool {
+    let _confined = client_is_confined(client);
+    true
+}
+
+/// The security-context protocol's own recursively-confined-listener guard.
+/// Smithay requires this global to be hidden from clients created through a
+/// context, independently of the policy for every other privileged global.
+pub(crate) fn security_context_global_visible(
+    client: &smithay::reexports::wayland_server::Client,
+) -> bool {
+    !client_is_confined(client)
 }
 
 impl ClientData for ClientState {
@@ -1439,6 +1502,13 @@ pub(crate) struct OutputSetup {
     /// alternatives instead of pretending the current mode is the only
     /// one.
     pub modes: Vec<Mode>,
+    pub powered: bool,
+    pub vrr_supported: bool,
+    /// Whether adaptive sync is allowed when the renderer proves this frame
+    /// is a direct-scanout fullscreen client.
+    pub vrr_requested: bool,
+    /// The DRM property's live value for the next commit.
+    pub vrr_enabled: bool,
 }
 
 /// The keyboard settings actually in force, from the config plus the
@@ -1494,6 +1564,9 @@ pub(crate) struct MonitorOutput {
     /// support), mirrored into the Hyprland compatibility snapshot.
     pub transform: i32,
     pub modes: Vec<MonitorMode>,
+    pub powered: bool,
+    pub vrr_supported: bool,
+    pub vrr_enabled: bool,
 }
 
 /// One output the compositor drives, everything the session needs to
@@ -1523,6 +1596,12 @@ pub(crate) struct OutputEntry {
     pub scale: f64,
     /// The modes this output can drive — see [`OutputSetup::modes`].
     pub modes: Vec<Mode>,
+    pub powered: bool,
+    pub vrr_supported: bool,
+    /// User/configuration policy; the renderer gates the live property further
+    /// to direct-scanout frames.
+    pub vrr_requested: bool,
+    pub vrr_enabled: bool,
     /// Only the nested backend renders through this: the session
     /// backend's `DrmCompositor` owns damage tracking per crtc itself.
     /// It is built from the `Output`, so a resize of that output
@@ -1555,6 +1634,10 @@ impl OutputEntry {
             transform: setup.transform,
             scale: 1.0,
             modes: setup.modes,
+            powered: setup.powered,
+            vrr_supported: setup.vrr_supported,
+            vrr_requested: setup.vrr_requested,
+            vrr_enabled: setup.vrr_enabled,
             damage_tracker,
             scene_scratch: Vec::new(),
             global,
@@ -1990,6 +2073,10 @@ pub(crate) fn apply_connector_hotplug(
             transform: entry.transform,
             requested_mode: None,
             modes: entry.modes.clone(),
+            powered: entry.powered,
+            vrr_supported: entry.vrr_supported,
+            vrr_requested: entry.vrr_requested,
+            vrr_enabled: entry.vrr_enabled,
         })
         .collect();
     let scales = apply_monitor_rules(&mut setups, &session.monitor_rules, comp.ui_scale as f64);
@@ -2155,7 +2242,7 @@ pub struct Compositor {
     /// represented by the Hyprland event stream. Kept separate from
     /// socket readiness: a desktop mutation must be published even
     /// when the subscriber itself has said nothing.
-    hyprland_state_dirty: bool,
+    pub(crate) hyprland_state_dirty: bool,
     /// Whether the wlr foreign-toplevel snapshot can differ from its
     /// last publication. Separate from Hyprland IPC because either
     /// protocol can be disabled or have no clients without preventing
@@ -2228,6 +2315,14 @@ pub struct Compositor {
     /// order binds together. Startup requires one, though DRM hot-unplug
     /// may leave this briefly empty until a connector returns.
     pub(crate) outputs: Vec<OutputEntry>,
+    /// Every live `wl_surface`, including role-less surfaces and hidden
+    /// subsurfaces. Commit-timing blockers can be installed before a role is
+    /// assigned, so the ordinary scene ledgers are not a complete registry.
+    pub(crate) pacing_surfaces: HashMap<ObjectId, WlSurface>,
+    /// Bounded escape for a FIFO barrier whose presentation never completes.
+    /// Retaining the barrier identity gives each replacement a fresh deadline.
+    pub(crate) pacing_fifo_deadlines:
+        HashMap<ObjectId, (smithay::wayland::compositor::Barrier, Instant)>,
 
     /// The X11 window-manager connection into XWayland, once
     /// `XWaylandEvent::Ready` has arrived (`None` before that, or if
@@ -2298,6 +2393,8 @@ pub struct Compositor {
     /// wlr-output-management: what `wlr-randr` and `kanshi` list and
     /// configure outputs through — see `output_mgmt.rs`.
     pub(crate) output_mgmt: crate::output_mgmt::OutputManagement,
+    /// Exclusive DPMS controls plus observers for each output.
+    pub(crate) output_power: crate::output_power::OutputPower,
     /// wlr-gamma-control: the per-output gamma ramps `wlsunset`,
     /// `gammastep` and `redshift` warm the screen through, with the
     /// exclusivity that stops two of them fighting and the captured
@@ -2446,6 +2543,7 @@ impl Compositor {
                 // layout that is now in force rather than the one the
                 // session started with.
                 self.hyprland_state_dirty = true;
+                crate::hyprland_ipc::refresh_keyboard_layout(self);
             }
             Err(error) => tracing::warn!(
                 %error,
@@ -2460,6 +2558,10 @@ impl Compositor {
         let _dispatch_guard = dispatch_span.enter();
         let dispatch_started = Instant::now();
         self.apply_pending_keyboard();
+        if let Some(config) = self.wm.backend_mut().pending_pointer.take() {
+            self.wm.backend_mut().scroll_factor = config.scroll_factor.unwrap_or(1.0);
+            crate::session::apply_pointer_config(&mut self.graphics, &config);
+        }
         tracing::debug_span!("dispatch_phase", phase = "connector_hotplug")
             .in_scope(|| crate::session::service_connector_hotplug(self));
         let phase_started = Instant::now();
@@ -2769,6 +2871,15 @@ impl Compositor {
         // output change, or surface death this returns immediately.
         crate::lock::refresh(self);
 
+        // Timed commits are independent of presentation, and an invisible
+        // surface cannot ever satisfy a FIFO presentation barrier. Visibility
+        // has settled at this point, so release both before the scene build.
+        self.service_surface_pacing();
+
+        // Chrome dirtied by a whole burst of pointer motion becomes pixels
+        // once, immediately before the scene is built.
+        self.wm.flush_decorations();
+
         // Everything above that changed a toplevel's size or state
         // staged it and booked a configure; this is where those go out,
         // one per toplevel, carrying the settled answer. It has to be
@@ -2791,12 +2902,19 @@ impl Compositor {
         // (a page flip was still in flight on one of them last pass).
         // The second condition only ever fires on the session backend
         // with more than one output — see `session::redraw_pending`.
+        let mut frame_presented = false;
         if self.wm.backend().damage || crate::session::redraw_pending(&self.graphics) {
             let render_started = Instant::now();
             if crate::renderer::render_frame(self) {
+                frame_presented = true;
                 self.frame_stats.record_render(render_started.elapsed());
             }
         }
+        crate::protocols::frame_presented(self, frame_presented);
+        // Visible FIFO barriers are signalled by the completed presentation
+        // path. Poll Smithay's client queues now so the next commit becomes
+        // current without waiting for another request from that client.
+        self.service_surface_pacing();
 
         // A locking client is owed its `locked` event only after a
         // frame built under the lock has been presented — which, if it
@@ -3458,6 +3576,9 @@ impl Compositor {
                             refresh_millihertz: u32::try_from(mode.refresh).unwrap_or(0),
                         })
                         .collect(),
+                    powered: entry.powered,
+                    vrr_supported: entry.vrr_supported,
+                    vrr_enabled: entry.vrr_enabled,
                 }
             })
             .collect();
@@ -3969,6 +4090,10 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
                 transform: Transform::Normal,
                 requested_mode: None,
                 modes: vec![mode],
+                powered: true,
+                vrr_supported: false,
+                vrr_requested: false,
+                vrr_enabled: false,
             }],
         )
     } else {
@@ -4027,6 +4152,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let image_capture = crate::image_capture::init(&display_handle);
     let toplevel_mapping = crate::toplevel_mapping::init(&display_handle);
     let output_mgmt = crate::output_mgmt::init(&display_handle);
+    let output_power = crate::output_power::init(&display_handle, &graphics);
     // Gamma control rides the same timing rule and additionally asks
     // the graphics stack what its hardware can do: an output with no
     // gamma LUT — every nested one, and some real crtcs — is refused
@@ -4042,17 +4168,19 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let global_shortcuts = crate::global_shortcuts::init(&display_handle);
     // The ecosystem protocols, under the same timing rule. Layer-shell
     // is what fuzzel/mako/waybar look for the moment they connect;
-    // session-lock is unfiltered (any client may lock — swaylock is
-    // just a client, and a filter would only be worth its complexity
-    // with a sandboxing story this desktop does not have); the idle
+    // layer-shell and session-lock both consult the shared
+    // security-context-aware policy (currently permissive); the idle
     // notifier's timers live on this very event loop.
-    let layer_shell = crate::layers::LayerShell::new(smithay::wayland::shell::wlr_layer::WlrLayerShellState::new::<
-        Compositor,
-    >(&display_handle));
+    let layer_shell = crate::layers::LayerShell::new(
+        smithay::wayland::shell::wlr_layer::WlrLayerShellState::new_with_filter::<Compositor, _>(
+            &display_handle,
+            crate::state::privileged_global_visible,
+        ),
+    );
     let session_lock = crate::lock::SessionLock::new(smithay::wayland::session_lock::SessionLockManagerState::new::<
         Compositor,
         _,
-    >(&display_handle, |_| true));
+    >(&display_handle, crate::state::privileged_global_visible));
     let mut idle = crate::idle::Idle::new(
         smithay::wayland::idle_notify::IdleNotifierState::<Compositor>::new(&display_handle, loop_handle.clone()),
         smithay::wayland::idle_inhibit::IdleInhibitManagerState::new::<Compositor>(&display_handle),
@@ -4170,7 +4298,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // the display server every client is waiting on. See
     // `wm_theme::FontState`.
     let fonts = FontState::new();
-    let engine = RasterThemeEngine::with_fonts(theme, fonts.clone());
+    let engine = RasterThemeEngine::with_fonts_at_scale(theme, fonts.clone(), state.scale);
 
     // The outputs advertise the session's scale from here on — the only
     // way a native Wayland client ever learns this desktop is scaled
@@ -4279,6 +4407,8 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         hyprland_source_scratch: HashSet::new(),
         seat,
         outputs,
+        pacing_surfaces: HashMap::new(),
+        pacing_fifo_deadlines: HashMap::new(),
         xwm: None,
         xdisplay: None,
         xwayland_restart_available: true,
@@ -4293,6 +4423,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         image_capture,
         _toplevel_mapping: toplevel_mapping,
         output_mgmt,
+        output_power,
         gamma,
         _ctm: ctm,
         layer_shell,
@@ -4309,6 +4440,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         running: true,
         restart: false,
     };
+    crate::hyprland_ipc::refresh_keyboard_layout(&mut comp);
 
     // Cross into the lock domain before the first dispatch. Clients
     // may already have been spawned during shell construction, but no
@@ -4418,6 +4550,9 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         }
         if let Some(deadline) = crate::session::next_hotplug_deadline(&comp.graphics) {
             wait = wait.min(deadline.saturating_duration_since(now));
+        }
+        if let Some(pacing) = comp.next_surface_pacing_in() {
+            wait = wait.min(pacing);
         }
         event_loop.dispatch(Some(wait), &mut comp)?;
         comp.dispatch_pending();
@@ -5001,6 +5136,10 @@ mod tests {
             transform: Transform::Normal,
             requested_mode: None,
             modes: vec![mode],
+            powered: true,
+            vrr_supported: false,
+            vrr_requested: false,
+            vrr_enabled: false,
         }
     }
 
@@ -5370,7 +5509,8 @@ mod tests {
                 FrameRecord {
                     window,
                     geometry: Rect::default(),
-                    buffer: None,
+                    parts: Vec::new(),
+                    fill_id: smithay::backend::renderer::element::Id::new(),
                     mapped: true,
                 },
             );

--- a/crates/wm-wayland/src/toplevel_mapping.rs
+++ b/crates/wm-wayland/src/toplevel_mapping.rs
@@ -46,6 +46,10 @@ impl GlobalDispatch<HyprlandToplevelMappingManagerV1, ()> for Compositor {
     ) {
         data_init.init(resource, ());
     }
+
+    fn can_view(client: Client, _global_data: &()) -> bool {
+        crate::state::privileged_global_visible(&client)
+    }
 }
 
 impl Dispatch<HyprlandToplevelMappingManagerV1, ()> for Compositor {

--- a/crates/wm-wayland/src/virtual_keyboard.rs
+++ b/crates/wm-wayland/src/virtual_keyboard.rs
@@ -118,13 +118,13 @@
 //! Made again, it lands in the same place, for a different reason:
 //! this session grants no client less than user privilege in the first
 //! place. Any client on this socket can already capture every pixel of
-//! every other client's window (`zwlr_screencopy_manager_v1`,
-//! unfiltered — see [`crate::protocols::init`]), enumerate every
+//! every other client's window (`zwlr_screencopy_manager_v1`, under
+//! the shared policy — see [`crate::protocols::init`]), enumerate every
 //! window and close or raise any of them
-//! (`zwlr_foreign_toplevel_manager_v1`, likewise unfiltered), and lock
-//! the session out from under the user (`ext_session_lock_v1`, whose
-//! filter `state::run` passes `|_| true`, with its own note as to
-//! why). Nearest of all: it can read every copy the user makes, at the
+//! (`zwlr_foreign_toplevel_manager_v1`, under the same shared policy),
+//! and lock the session out from under the user (`ext_session_lock_v1`,
+//! which consults that policy too). Nearest of all: it can read every
+//! copy the user makes, at the
 //! moment they make it and without ever holding focus, through
 //! data-control (see [`crate::data_control`], which grants that to
 //! every client for its own stated reasons). A protocol that hands out
@@ -139,17 +139,13 @@
 //! Omarchy features above — while moving nothing out of an attacker's
 //! reach.
 //!
-//! What would change the answer is a sandboxing story: a Flatpak-style
-//! client that is *not* fully the user, admitted through
-//! `wp_security_context_v1`, for which "can this client type into my
-//! bank tab" is a real question with a real answer. Smithay implements
-//! that protocol (`wayland::security_context`) and this compositor does
-//! not use it; nothing here tags a client as untrusted, so there is
-//! nothing for a filter to test. [`may_create_virtual_keyboard`] is
-//! deliberately a named function taking the `Client` rather than an
-//! inline `|_| true` so that the day a security context exists, the
-//! gate is a body to fill in and a test to extend rather than a design
-//! to invent.
+//! `wp_security_context_v1` now gives that future policy a real input:
+//! clients admitted through one are tagged in `ClientState`, cannot
+//! create nested security contexts, and every cross-client capability
+//! consults `state::privileged_global_visible`. The current single-user
+//! policy deliberately returns true for both tagged and ordinary
+//! clients, preserving the behavior above while making a later policy
+//! change one shared predicate instead of eleven unrelated filters.
 //!
 //! # Integration contract
 //!
@@ -233,13 +229,10 @@ fn seat_can_accept_virtual_keys(seat: &Seat<Compositor>) -> bool {
 /// denying it synthetic keystrokes breaks `wtype` without taking
 /// anything away from an attacker.
 ///
-/// This is a function and not `|_| true` on purpose: it is the exact
-/// place a `wp_security_context_v1` check belongs if this compositor
-/// ever admits clients that are less than the user, and having the
-/// `Client` already in hand makes that a body to write rather than a
-/// signature to thread.
-fn may_create_virtual_keyboard(_client: &Client) -> bool {
-    true
+/// This delegates to the shared security-context-aware policy rather than an
+/// inline allow-all closure, keeping every cross-client capability aligned.
+fn may_create_virtual_keyboard(client: &Client) -> bool {
+    crate::state::privileged_global_visible(client)
 }
 
 delegate_virtual_keyboard_manager!(Compositor);
@@ -278,10 +271,8 @@ mod tests {
         assert!(seat_can_accept_virtual_keys(&seat));
     }
 
-    /// The filter is unfiltered, deliberately. This test is here to
-    /// make that a decision with a paper trail: anyone narrowing it is
-    /// meant to arrive at the module's trust-model section by way of a
-    /// failing assertion.
+    /// The shared policy is currently permissive, deliberately. This test
+    /// preserves byte-for-byte behavior for an ordinary unconfined client.
     #[test]
     fn every_client_on_this_socket_may_create_a_virtual_keyboard() {
         let display = Display::<Compositor>::new().expect("wayland display");

--- a/crates/wm-wayland/src/virtual_pointer.rs
+++ b/crates/wm-wayland/src/virtual_pointer.rs
@@ -83,8 +83,8 @@ pub(crate) fn init(display_handle: &DisplayHandle) -> VirtualPointerState {
     VirtualPointerState { _global: global }
 }
 
-fn may_create_virtual_pointer(_client: &Client) -> bool {
-    true
+fn may_create_virtual_pointer(client: &Client) -> bool {
+    crate::state::privileged_global_visible(client)
 }
 
 fn map_absolute_axis(value: u32, extent: u32, size: u32) -> f64 {

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -37,6 +37,7 @@
 use std::collections::HashMap;
 use std::os::fd::OwnedFd;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::time::{Duration, Instant};
 
 use smithay::backend::renderer::utils::{on_commit_buffer_handler, with_renderer_surface_state};
 use smithay::desktop::{find_popup_root_surface, PopupKind};
@@ -587,6 +588,7 @@ impl CompositorHandler for Compositor {
     }
 
     fn new_surface(&mut self, surface: &WlSurface) {
+        self.pacing_surfaces.insert(surface.id(), surface.clone());
         // This compositor deliberately advertises every surface on
         // every output: all outputs share the session scale, and true
         // overlap tracking would add complexity without changing what
@@ -700,6 +702,8 @@ impl CompositorHandler for Compositor {
     }
 
     fn destroyed(&mut self, surface: &WlSurface) {
+        self.pacing_surfaces.remove(&surface.id());
+        self.pacing_fifo_deadlines.remove(&surface.id());
         // `Output` retains weak surface handles so it can replay
         // `enter` to wl_output objects a client binds later. The
         // destruction callback is the exact moment one can turn dead;
@@ -871,6 +875,142 @@ impl CompositorHandler for Compositor {
 }
 
 impl Compositor {
+    /// Release due commit-timing transactions and FIFO transactions that can
+    /// no longer wait for presentation. Called after visibility settles and
+    /// again after rendering, where it observes presentation-signalled FIFO
+    /// barriers and polls Smithay's per-client transaction queues.
+    pub(crate) fn service_surface_pacing(&mut self) {
+        const FIFO_DEADLINE: Duration = Duration::from_secs(1);
+
+        let now = Instant::now();
+        let clock_now = smithay::utils::Clock::<smithay::utils::Monotonic>::new().now();
+        let surfaces: Vec<_> = self.pacing_surfaces.values().cloned().collect();
+        for surface in &surfaces {
+            let visible = self.surface_affects_scene(surface);
+            let object = surface.id();
+            with_states(surface, |states| {
+                let fifo = states
+                    .cached_state
+                    .get::<smithay::wayland::fifo::FifoBarrierCachedState>()
+                    .current()
+                    .barrier
+                    .as_ref()
+                    .filter(|barrier| !barrier.is_signaled())
+                    .cloned();
+                match fifo {
+                    Some(barrier) if !visible => {
+                        barrier.signal();
+                        states
+                            .cached_state
+                            .get::<smithay::wayland::fifo::FifoBarrierCachedState>()
+                            .current()
+                            .barrier
+                            .take();
+                        self.pacing_fifo_deadlines.remove(&object);
+                    }
+                    Some(barrier) => {
+                        let deadline = self
+                            .pacing_fifo_deadlines
+                            .entry(object.clone())
+                            .and_modify(|(tracked, deadline)| {
+                                if *tracked != barrier {
+                                    *tracked = barrier.clone();
+                                    *deadline = now + FIFO_DEADLINE;
+                                }
+                            })
+                            .or_insert_with(|| (barrier.clone(), now + FIFO_DEADLINE))
+                            .1;
+                        if deadline <= now {
+                            tracing::warn!(surface = ?object, "FIFO presentation barrier expired; releasing the client commit");
+                            barrier.signal();
+                            states
+                                .cached_state
+                                .get::<smithay::wayland::fifo::FifoBarrierCachedState>()
+                                .current()
+                                .barrier
+                                .take();
+                            self.pacing_fifo_deadlines.remove(&object);
+                        }
+                    }
+                    None => {
+                        self.pacing_fifo_deadlines.remove(&object);
+                    }
+                }
+
+                if let Some(timers) = states
+                    .data_map
+                    .get::<smithay::wayland::commit_timing::CommitTimerBarrierStateUserData>()
+                {
+                    timers
+                        .lock()
+                        .expect("commit-timing mutex poisoned")
+                        .signal_until(clock_now);
+                }
+            });
+        }
+
+        // Signalling a Smithay barrier changes its state but deliberately does
+        // not poll the transaction queue. One no-op-safe call per client also
+        // covers FIFO barriers taken by the renderer at presentation.
+        let mut clients = std::collections::HashMap::new();
+        for surface in surfaces {
+            if let Some(client) = surface.client() {
+                clients.entry(client.id()).or_insert(client);
+            }
+        }
+        let display = self.display_handle.clone();
+        for client in clients.into_values() {
+            self.client_compositor_state(&client).blocker_cleared(self, &display);
+        }
+    }
+
+    /// Nearest wakeup required by a future commit timestamp or the bounded
+    /// FIFO fallback, suitable for capping calloop's blocking dispatch.
+    pub(crate) fn next_surface_pacing_in(&self) -> Option<Duration> {
+        let now = Instant::now();
+        let clock_now = smithay::utils::Clock::<smithay::utils::Monotonic>::new().now();
+        let mut next = self
+            .pacing_fifo_deadlines
+            .values()
+            .map(|(_, deadline)| deadline.saturating_duration_since(now))
+            .min();
+        for surface in self.pacing_surfaces.values() {
+            with_states(surface, |states| {
+                let Some(timers) = states
+                    .data_map
+                    .get::<smithay::wayland::commit_timing::CommitTimerBarrierStateUserData>()
+                else {
+                    return;
+                };
+                let Some(deadline) = timers
+                    .lock()
+                    .expect("commit-timing mutex poisoned")
+                    .next_deadline()
+                else {
+                    return;
+                };
+                let deadline: smithay::utils::Time<smithay::utils::Monotonic> = deadline.into();
+                let wait = smithay::utils::Time::elapsed(&clock_now, deadline);
+                next = Some(next.map_or(wait, |current| current.min(wait)));
+            });
+        }
+        next
+    }
+
+    fn surface_affects_scene(&self, surface: &WlSurface) -> bool {
+        let mut root = surface.clone();
+        while let Some(parent) = get_parent(&root) {
+            root = parent;
+        }
+        let popup = self.popups.find_popup(&root);
+        let scene_root = popup
+            .as_ref()
+            .and_then(|popup| find_popup_root_surface(popup).ok())
+            .unwrap_or(root);
+        let owner = self.wm.backend().window_for_surface(&scene_root);
+        self.resolved_surface_affects_scene(&scene_root, owner)
+    }
+
     /// Whether a commit whose popup-resolved root and indexed owner are
     /// supplied can change the scene being rendered right now.
     ///
@@ -2078,7 +2218,8 @@ mod tests {
                 FrameRecord {
                     window,
                     geometry: Rect::default(),
-                    buffer: None,
+                    parts: Vec::new(),
+                    fill_id: smithay::backend::renderer::element::Id::new(),
                     mapped: true,
                 },
             ),
@@ -2087,7 +2228,8 @@ mod tests {
                 FrameRecord {
                     window: other,
                     geometry: Rect::default(),
-                    buffer: None,
+                    parts: Vec::new(),
+                    fill_id: smithay::backend::renderer::element::Id::new(),
                     mapped: true,
                 },
             ),
@@ -2125,7 +2267,8 @@ mod tests {
             FrameRecord {
                 window,
                 geometry: Rect::default(),
-                buffer: None,
+                parts: Vec::new(),
+                fill_id: smithay::backend::renderer::element::Id::new(),
                 mapped: false,
             },
         )]);

--- a/crates/wm-x11/src/backend.rs
+++ b/crates/wm-x11/src/backend.rs
@@ -26,6 +26,15 @@ pub struct XWindow(pub Window);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct XFrame(pub Window);
 
+#[derive(Clone)]
+struct PaintedPart {
+    x: i16,
+    y: i16,
+    w: u16,
+    h: u16,
+    data: Vec<u8>,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum X11BackendError {
     #[error("failed to connect to the X server: {0}")]
@@ -124,7 +133,7 @@ pub struct X11Backend {
     /// Cached server-format pixels per painted window (frame or shell
     /// window), replayed on `Expose` without re-touching the theme
     /// engine or re-converting byte order.
-    painted: HashMap<Window, (u16, u16, Vec<u8>)>,
+    painted: HashMap<Window, Vec<PaintedPart>>,
     /// Button press/release events on windows we don't recognize as a
     /// client/frame (root, dock, menu popups...) — the desktop shell in
     /// `chonkstep` drains these separately from `poll_event`, since
@@ -809,7 +818,7 @@ impl X11Backend {
             tracing::warn!(?e, window = win, "put_image failed");
         }
         let _ = self.conn.flush();
-        self.painted.insert(win, (w, h, data));
+        self.painted.insert(win, vec![PaintedPart { x: 0, y: 0, w, h, data }]);
     }
 
     /// Sends `data` (a `w`x`h` `ZPixmap` buffer, top row first) to
@@ -823,6 +832,18 @@ impl X11Backend {
     /// silently truncating it, so without chunking the whole image simply
     /// never reaches the server.
     fn put_image_rows(&mut self, drawable: Drawable, w: u16, h: u16, data: &[u8]) -> Result<(), ConnectionError> {
+        self.put_image_rows_at(drawable, w, h, data, 0, 0)
+    }
+
+    fn put_image_rows_at(
+        &mut self,
+        drawable: Drawable,
+        w: u16,
+        h: u16,
+        data: &[u8],
+        x: i16,
+        y: i16,
+    ) -> Result<(), ConnectionError> {
         let stride = w as usize * 4;
         if stride == 0 || h == 0 {
             return Ok(());
@@ -841,9 +862,9 @@ impl X11Backend {
         let budget = self.conn.maximum_request_bytes().saturating_sub(REQUEST_OVERHEAD_BYTES);
         let rows_per_chunk = (budget / stride).max(1);
         for (chunk_index, chunk) in data.chunks(rows_per_chunk * stride).enumerate() {
-            let y = (chunk_index * rows_per_chunk) as i16;
+            let y = y.saturating_add((chunk_index * rows_per_chunk) as i16);
             let chunk_h = (chunk.len() / stride) as u16;
-            self.conn.put_image(ImageFormat::Z_PIXMAP, drawable, gc, w, chunk_h, 0, y, 0, depth, chunk)?;
+            self.conn.put_image(ImageFormat::Z_PIXMAP, drawable, gc, w, chunk_h, x, y, 0, depth, chunk)?;
         }
         Ok(())
     }
@@ -1192,8 +1213,10 @@ impl X11Backend {
             }
             Event::Expose(e) => {
                 if e.count == 0 {
-                    if let Some((w, h, data)) = self.painted.get(&e.window).cloned() {
-                        let _ = self.put_image_rows(e.window, w, h, &data);
+                    if let Some(parts) = self.painted.get(&e.window).cloned() {
+                        for part in parts {
+                            let _ = self.put_image_rows_at(e.window, part.w, part.h, &part.data, part.x, part.y);
+                        }
                         let _ = self.conn.flush();
                     }
                 }
@@ -2346,6 +2369,10 @@ impl Backend for X11Backend {
         &self.monitors
     }
 
+    fn decoration_scale(&self, _frame: Rect) -> f32 {
+        self.cursors.scale
+    }
+
     fn poll_event(&mut self) -> Option<BackendEvent<Self::WindowId, Self::FrameId>> {
         loop {
             let event = match self.conn.poll_for_event() {
@@ -2779,8 +2806,24 @@ impl Backend for X11Backend {
         let _ = self.conn.flush();
     }
 
-    fn paint_decoration(&mut self, frame: Self::FrameId, buffer: &DecorationBuffer) {
-        self.blit(frame.0, buffer);
+    fn paint_decoration(&mut self, frame: Self::FrameId, surface: &wm_theme_api::DecorationSurface) {
+        let mut painted = Vec::with_capacity(surface.parts.len());
+        for part in &surface.parts {
+            if part.buffer.width == 0 || part.buffer.height == 0 {
+                continue;
+            }
+            let w = part.buffer.width.min(u16::MAX as u32) as u16;
+            let h = part.buffer.height.min(u16::MAX as u32) as u16;
+            let x = part.offset.x.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+            let y = part.offset.y.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+            let data = to_server_bytes(&part.buffer, self.image_byte_order);
+            if let Err(error) = self.put_image_rows_at(frame.0, w, h, &data, x, y) {
+                tracing::warn!(?error, ?frame, "put_image decoration part failed");
+            }
+            painted.push(PaintedPart { x, y, w, h, data });
+        }
+        self.painted.insert(frame.0, painted);
+        let _ = self.conn.flush();
     }
 
     fn set_frame_cursor(&mut self, frame: Self::FrameId, edge: Option<ResizeEdge>) {

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -146,6 +146,26 @@
 # false for sloppy focus that leaves the stack alone.
 #autoraise = true
 
+# Pointer and touchpad hardware configuration. These values are applied to
+# each real libinput device when it appears and re-applied after a live config
+# reload. Unsupported settings are skipped per device instead of preventing
+# the remaining settings from taking effect.
+#
+# Sensitivity is -1.0 through 1.0. The acceleration profile is "adaptive" or
+# "flat". `scroll_factor` is a positive multiplier applied to both smooth and
+# wheel scrolling. `[input.touchpad]` is an optional nested spelling for the
+# touchpad-oriented controls; it overrides the corresponding flat key.
+#[input]
+#sensitivity = 0.0
+#accel_profile = "adaptive"
+#left_handed = false
+#
+#[input.touchpad]
+#natural_scroll = true
+#tap_to_click = false
+#clickfinger_behavior = true
+#scroll_factor = 0.4
+
 # UI scale factor for HiDPI displays: multiplies every pixel dimension
 # in the window chrome, dock, cursors, and terminal font as one system.
 # The CHONKSTEP_SCALE environment variable, when set to a valid value,

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -201,7 +201,7 @@ specific directive, not a count. Turn on `RUST_LOG=debug` to see them.
 | Anything commanding Hyprland — `hyprctl`, `omarchy-hyprland-*` | It talks to a compositor that is not running, so the binding could only fail. The same filter chonkstep's Omarchy menu already applies to menu rows. `hyprpicker`, `hyprlock` and `hypridle` are *not* caught by it: they are ordinary Wayland clients and work here. |
 | Gaps, borders, rounding, blur, shadows, animations, layouts (`hl.config`, `general { … }`, `decoration { … }`) | Hyprland's look. This desktop has its own — a theme, a titlebar, a decoration policy. Following them would mean drawing a NeXTSTEP frame in Hyprland's border colour. |
 | Layer rules (`layerrule`, `hl.layer_rule`) | They configure Hyprland's layer-shell implementation. This compositor has its own. |
-| Whole-desktop and device input policy (`follow_mouse`, touchpad policy, sensitivity, gestures) | The live read carries hardware-facing keyboard xkb/repeat values only. Chonkstep owns interaction policy: use its `focus_follows_mouse` key explicitly. Every declined value is logged. |
+| Whole-desktop interaction policy (`follow_mouse`, gestures) | Chonkstep owns focus and gesture policy: use its `focus_follows_mouse` key explicitly. Device properties listed below are applied; remaining declined values are logged. |
 | Unsupported window-rule properties | `opacity`, `no_blur`, `suppress_event`, `workspace`, `move`, `keep_aspect_ratio`, … are each logged with their matcher. Tags used to select another supported rule are resolved. |
 | Window rules carrying a matcher not implemented here (`match:xwayland 1`, `match:workspace 5`, `match:fullscreen 0`) | Refused **whole**. Applying a rule on the matchers that *were* understood turns "float this one XWayland window" into "float every window of this class". |
 | A `size` given as a Hyprland layout expression (`(monitor_h*4/25)`) | It needs a monitor to evaluate against, and a config reader has a file, not an output. |
@@ -260,6 +260,15 @@ front merely because the pointer crossed it; a click still raises. Environment `
 values remain more specific and win. If libxkbcommon rejects a
 configured map, the error is logged and the session falls back to the
 default usable keymap instead of aborting the login.
+
+Pointer configuration is also carried from both classic `input {}` /
+`touchpad {}` blocks and Omarchy's Lua tables. `sensitivity` and
+`accel_profile` configure libinput acceleration; `natural_scroll`,
+`tap_to_click`, `clickfinger_behavior`, and `left_handed` are applied
+where the device advertises them. `scroll_factor` multiplies continuous
+and wheel-axis motion after libinput so the configured speed also works
+on the nested backend. Unsupported capabilities are named per device
+without rejecting the rest of the configuration.
 
 Binding flags retain their behavior: `bindl`/`locked` actions may run
 on the lock screen, `binde`/`repeating` actions repeat after the
@@ -451,7 +460,7 @@ One `info` line per read, and one `debug` line per thing skipped:
 ```
 INFO  hyprland-config: read the desktop's live Hyprland configuration
       files=42 bindings=153 commands=113 env=8 autostart=4
-      float_rules=45 monitors=1 skipped=175
+      float_rules=45 monitors=1 skipped=173
 DEBUG hyprland-config: not carried over kind=bind what="SUPER + J (Toggle window split)"
       why="tiling-only: no meaning on a stacking desk"
 ```

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -83,14 +83,14 @@ start with `[[BATCH]]` and use `;` separators.
 | Request | Result |
 | --- | --- |
 | `status` | `configProvider="chonkstep"`; Quickshell uses classic dispatch while scripts may use the supported Lua forms |
-| `monitors` | Live output name, geometry, scale, focus, active workspace, transform and powered-on `dpmsStatus` |
+| `monitors` | Live output name, geometry, scale, focus, active workspace, transform, DPMS state, and measured VRR capability/runtime state. The optional `all` argument is accepted and ignored because connected outputs remain in the layout while powered down. |
 | `workspaces` | One-based ids; real per-workspace monitor assignment and fullscreen state |
 | `clients` / `activewindow` | Live pid, class/title, position, size, workspace, monitor, XWayland, floating, pinned, fullscreen, tags, focus history and idle inhibition |
 | `activeworkspace` | Exactly the active workspace, in JSON or one plain block |
 | `cursorpos` | The live pointer as plain `X, Y` |
 | `devices` | Seat keyboards and pointers; keyboards include `name`, `active_keymap`, `layout`, and `active_layout_index` |
 | `binds` | The live chonkstep keymap in Hyprland's plain bind-block format (or JSON) |
-| `getoption` | A complete, explicitly unset option shape; no fabricated Hyprland style value |
+| `getoption` | An explicitly unset `{ "option": ..., "set": false }` object. Value fields are absent so JavaScript keeps its own default instead of coercing `null` or zero. |
 | `version`, `splash` | Supported |
 | `configerrors` | Retained live-Hyprland refusals, one per line or as JSON `{"error": "…"}` objects |
 
@@ -99,9 +99,11 @@ logical keyboard and pointer. A hardware session reports its libinput
 devices. This prevents Omarchy's keyboard widget from polling forever
 without claiming nonexistent nested hardware.
 
-`dpmsStatus` is `true` because chonkstep currently keeps advertised
-outputs powered. `dispatch dpms` is refused; status and mutation cannot
-contradict one another.
+`dpmsStatus` follows the connector's live power state. `dispatch dpms
+on|off|toggle [OUTPUT]` uses the same hardware path as
+`zwlr_output_power_manager_v1`; real input wakes powered-down outputs.
+The nested backend refuses power control because its output is a host
+window, not a connector.
 
 Plain `clients` and `activewindow` use Hyprland's tab-indented field
 blocks. In particular, the real pid lets `omarchy-cmd-terminal-cwd`
@@ -121,6 +123,9 @@ actions. Supported families include:
   source, including `[[...]]` and `[=[...]=]` strings;
 - `eval hl.dispatch(hl.dsp....)`;
 - `eval hl.monitor({ output=..., scale=... })` for a live output;
+- `dispatch dpms on|off|toggle [OUTPUT]` for temporary connector power;
+- `switchxkblayout DEVICE next|prev|INDEX`, which changes the live XKB
+  group and emits `activelayout` with its human-readable name;
 - `eval hl.config({ cursor = { invisible = BOOL } })`, the live
   cursor-visibility property used by Omarchy's screensaver;
 - `reload`, which re-reads chonkstep/Hyprland configuration and emits
@@ -142,13 +147,13 @@ chonkstep re-reads `~/.config/hypr` within a second of an edit, and
 scale. The one shipped Omarchy caller is the monitor panel's row toggle
 (`hyprctl keyword monitor NAME,disable` / `NAME,preferred,auto,auto`),
 and that specific form is refused by name for a reason the user can act
-on: chonkstep drives every connected output and has no disable path, so
+on: chonkstep keeps every connected output in the layout and has no
+remove/disable path, so
 its `disabled` field is honestly `false` for every head and the panel's
-checkmark will not move. Growing an output-disable path—routing that
-form into the same validated apply `zwlr_output_management` already
-uses—is a real but separate piece of work; until it exists, saying so
-in the refusal is the honest answer, because `hyprctl` exits zero for a
-refusal and the string is the only diagnostic a user gets.
+checkmark will not move. The refusal names `dispatch dpms off OUTPUT`
+as the temporary blanking alternative. A powered-down head remains in
+`monitors` and in the workspace geometry by design; `monitors all`
+therefore returns the same set as `monitors`.
 
 The monitor object reports measured values, not conventional ones.
 `refreshRate` is the driven mode's rate, `availableModes` is the
@@ -157,8 +162,10 @@ first, and `make`/`model`/`serial` are read from the connector EDID. The
 same `make model serial` description backs `monitor = desc:…`,
 `wl_output`, IPC, and `zwlr_output_management`, so those interfaces
 cannot describe one panel two ways. `serial` stays empty only when the
-EDID itself supplies none; `vrr` remains covered by the adaptive-sync
-work. A backend driving no real mode reports 60 Hz rather than 0,
+EDID itself supplies none. `vrr` is true only while a capable output is
+actually using adaptive sync; wlr-output-management controls policy,
+and runtime activation is restricted to direct scanout. Set
+`CHONKSTEP_NO_VRR=1` to force it off. A backend driving no real mode reports 60 Hz rather than 0,
 because a bar divides this into a frame budget.
 
 Tiling vocabulary—`layoutmsg`, `togglesplit`, `swapwindow`, `pseudo`,
@@ -174,7 +181,7 @@ absent, so it cannot display a false “layout changed” notification.
 The event socket emits state diffs, plus the explicit post-reload
 event:
 
-`configreloaded`, `monitoraddedv2`, `monitorremoved`,
+`configreloaded`, `monitoradded`, `monitoraddedv2`, `monitorremoved`,
 `createworkspacev2`, `destroyworkspacev2`, `workspacev2`, `workspace`,
 `moveworkspacev2`, `focusedmon`, `fullscreen`, `openwindow`,
 `closewindow`, `movewindowv2`, `windowtitlev2`, `windowtitle`,
@@ -213,6 +220,9 @@ Ordinary applications also receive the Smithay-backed protocol set:
 | application activation | `xdg_activation_v1` v1 |
 | cursor shapes / solid-color buffers | `wp_cursor_shape_manager_v1` v2, `wp_single_pixel_buffer_manager_v1` v1 |
 | presentation timing | `wp_presentation` v2 |
+| explicit client pacing | `wp_fifo_manager_v1` v1, `wp_commit_timing_manager_v1` v1 |
+| sandbox context tagging | `wp_security_context_manager_v1` v1 |
+| physical output power | `zwlr_output_power_manager_v1` v1 (hardware sessions only) |
 | relative/locked/confined pointer | `zwp_relative_pointer_manager_v1` v1, `zwp_pointer_constraints_v1` v1 |
 | gestures / tablets | `zwp_pointer_gestures_v1` v3, `zwp_tablet_manager_v2` v1 |
 | foreign surface parenting | `zxdg_exporter_v2` and `zxdg_importer_v2` v1 |
@@ -223,6 +233,12 @@ Ordinary applications also receive the Smithay-backed protocol set:
 The IME popup participates in rendering and hit testing, activation
 focuses the target, pointer constraints follow focus and lifetime, and
 presentation feedback comes from winit presentation or DRM vblank.
+FIFO barriers release at that same presentation boundary; commit
+timestamps arm the event loop's monotonic-clock deadline, and invisible
+surfaces cannot remain wedged behind an unpresentable barrier. Security
+contexts tag admitted clients and every cross-client capability consults
+one shared policy predicate; the current single-user policy remains
+permissive, preserving ordinary and confined-client behavior.
 Tablet proximity, tip, buttons, pressure, distance, tilt, rotation,
 slider and wheel are forwarded from libinput.
 

--- a/docs/omarchy-integration.md
+++ b/docs/omarchy-integration.md
@@ -121,6 +121,32 @@ to terminate that session and the terminal running the command.
 | themes, pickers, OSD, notifications, and the Omarchy menu | Work without compositor-specific translation |
 | session lock and IME | Work through standard Wayland lock, text-input, and input-method protocols |
 
+## Quickshell protocol boundary
+
+Chonkstep serves the Quickshell-facing interfaces Omarchy itself uses:
+Hyprland request/event sockets, `hyprland_focus_grab_manager_v1`,
+`hyprland_toplevel_mapping_manager_v1`,
+`hyprland_ctm_control_manager_v1`, wlr foreign-toplevel management,
+wlr screencopy, and ext image-copy capture. Both `monitoradded` and
+`monitoraddedv2` are emitted so legacy and current monitor listeners
+refresh together.
+
+Three optional visual-effect interfaces are intentionally not served:
+
+- `hyprland_toplevel_export_manager_v1`: plugins that require this
+  Hyprland-only thumbnail path render no preview; use ext image-copy
+  capture for supported window capture.
+- `hyprland_surface_manager_v1`: Hyprland-specific per-surface effects
+  are unavailable, so plugins must retain their plain-surface fallback.
+- `ext_background_effect_manager_v1`: behind-window blur is unavailable;
+  translucent panels render without blur rather than receiving a fake
+  effect acknowledgement.
+
+`renameworkspace` is unreachable by construction: Chonkstep workspaces
+have persistent one-based numeric wire names derived from their internal
+indices, with no independent mutable-name field. It is therefore an
+intentional model boundary, not an omitted command handler.
+
 The screensaver launcher can open its terminal clients because long-bracket
 Lua commands and `openwindow` events are supported. Chonkstep does not have
 Hyprland's independent per-monitor workspace/focus model, so requests that


### PR DESCRIPTION
Completes the remaining compositor compatibility and performance batch in one change.

Highlights:
- make decorations sparse, retained, coalesced, and scale-aware
- cache screencopy render targets and coalesce per-output capture work
- add security-context client tagging and privileged-global policy
- add FIFO/commit timing release paths for invisible surfaces
- implement real DPMS and capability-backed VRR state
- expose libinput configuration through native and Hyprland config
- complete keyboard layout switching/events and exact IPC compatibility edges
- harden monitor disable handling and output event ordering

Validation:
- cargo test --workspace --no-fail-fast
- cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks
- RUSTDOCFLAGS="-D warnings -A rustdoc::private_intra_doc_links" cargo doc --workspace --no-deps --locked --document-private-items
- cargo build -p wm-wayland -p chonkstep-wayland --locked
- git diff --check

Closes #34
Closes #35
Closes #37
Closes #81
Closes #84
Closes #91
Closes #97
Closes #98
Closes #101
Closes #128
Closes #129
Closes #130
Closes #131