### PR TITLE
Fix CI profile gaps and make sampler checks deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run the Python SDK tests
         run: python3 -m unittest discover bindings/python/tests
 
+      - name: Run benchmark and preflight harness regression tests
+        run: scripts/check.sh harness
+
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version-file: bindings/go/chonkdock/go.mod
@@ -59,6 +62,8 @@ jobs:
           bash -n \
             packaging/arch/PKGBUILD \
             packaging/arch/PKGBUILD-release \
+            scripts/check.sh \
+            scripts/e2e.sh \
             scripts/install.sh \
             scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \
@@ -68,6 +73,8 @@ jobs:
             scripts/verify-install.sh \
             scripts/wayland-session.sh
           shellcheck \
+            scripts/check.sh \
+            scripts/e2e.sh \
             scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \
             scripts/omarchy-remove-desktop-chonkstep \
@@ -90,7 +97,7 @@ jobs:
         # untested but because they are the wayland job's whole purpose
         # (which installs their system libraries and builds+tests them);
         # compiling Smithay twice per push buys nothing.
-        run: cargo test --workspace --exclude wm-wayland --exclude chonkstep-wayland
+        run: scripts/check.sh unit
 
       - name: Install X11 smoke test dependencies
         # libx11-dev is here for the undecorated-client probe built in
@@ -389,7 +396,7 @@ jobs:
         run: cargo build -p wm-wayland -p chonkstep-wayland --locked
 
       - name: Run the wm-wayland test suite
-        run: cargo test -p wm-wayland
+        run: scripts/check.sh wayland-unit
 
       # Weston provides the host display a nested compositor needs,
       # with Mesa's software renderer on runners that expose no GPU.
@@ -405,7 +412,22 @@ jobs:
       # turns the day it stops coming into a red build instead of a
       # quietly smaller suite.
       - name: Run the nested compositor end-to-end suite
+        env:
+          # This is the software-renderer gate, not hardware coverage.
+          # Avoid probing Zink or an incidental runner GPU before falling back.
+          LIBGL_ALWAYS_SOFTWARE: '1'
+          GALLIUM_DRIVER: llvmpipe
+          TMPDIR: ${{ runner.temp }}
         run: scripts/e2e.sh --headless
+
+      - name: Preserve failed nested-session logs and screenshots
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: wayland-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/chonk-testkit/
+          if-no-files-found: ignore
+          retention-days: 7
 
   # Lint. This job exists because of one specific incident and one
   # specific class of bug.
@@ -476,9 +498,9 @@ jobs:
       # three bans verbatim; if you add a ban to the root file, add it
       # there too or that crate quietly loses it.
       - name: Deny clippy warnings workspace-wide
-        run: cargo clippy --workspace --all-targets --no-deps -- -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types -D clippy::undocumented_unsafe_blocks
+        # Shared with local preflight: do not replace this with a weaker
+        # `-D warnings` invocation that omits the opt-in safety/blocking lints.
+        run: scripts/check.sh lint
 
       - name: Deny broken links and warnings in public Rust documentation
-        env:
-          RUSTDOCFLAGS: -D warnings -A rustdoc::private_intra_doc_links
-        run: cargo doc --workspace --no-deps --locked --document-private-items
+        run: scripts/check.sh docs

--- a/README.md
+++ b/README.md
@@ -718,6 +718,12 @@ always available; it is not rebindable from the config file.
   is pure Rust (tiny-skia + cosmic-text, no X server needed), so most
   of the visual pipeline is unit-testable, including pixel-level
   regression tests for the relief recipes.
+- `scripts/check.sh` runs the same strict Clippy, documentation, debug-profile
+  unit, and benchmark-harness checks as CI. Individual gates are available as
+  `lint`, `docs`, `unit`, `wayland-unit`, and `harness`. Run this before pushing;
+  release-only tests miss debug assertions, and plain `clippy -D warnings`
+  does not enable the additional safety and blocking-call lints CI requires.
+  The Rust gates need the Wayland build dependencies installed locally.
 - `scripts/e2e.sh --headless` starts an isolated Weston host and runs the
   complete Wayland integration suite one compositor at a time. It exercises
   real clients and captured pixels without touching the logged-in desktop;

--- a/crates/chonk-shell/src/widgets/sampling.rs
+++ b/crates/chonk-shell/src/widgets/sampling.rs
@@ -789,6 +789,81 @@ fn sample_loop<T>(shared: Arc<Shared<T>>, mut sample: impl FnMut() -> Outcome<T>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    const TEST_DEADLINE: Duration = Duration::from_secs(10);
+
+    /// A real shell child announces entry, then blocks on a FIFO until
+    /// the test releases it. No scheduler-speed assumption or long-lived
+    /// sleep process is needed to prove that our caller remains runnable.
+    struct CommandGate {
+        root: PathBuf,
+        release: std::fs::File,
+    }
+
+    impl CommandGate {
+        fn new() -> Self {
+            use std::os::unix::{ffi::OsStrExt, fs::OpenOptionsExt};
+            use std::sync::atomic::{AtomicUsize, Ordering};
+            static NEXT: AtomicUsize = AtomicUsize::new(0);
+            let root = loop {
+                let root = std::env::temp_dir().join(format!("chonk-sampling-gate-{}-{}",
+                    std::process::id(), NEXT.fetch_add(1, Ordering::Relaxed)));
+                match std::fs::create_dir(&root) {
+                    Ok(()) => break root,
+                    Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => panic!("create command fixture: {error}"),
+                }
+            };
+            let fifo = root.join("release");
+            let path = std::ffi::CString::new(fifo.as_os_str().as_bytes()).unwrap();
+            // SAFETY: path is a live NUL-terminated string naming a new file
+            // in our exclusively created fixture directory; mkfifo retains no pointer.
+            assert_eq!(unsafe { libc::mkfifo(path.as_ptr(), 0o600) }, 0);
+            // O_RDWR opens a Linux FIFO without waiting for the child's reader.
+            // O_NONBLOCK also keeps failure-path cleanup from blocking on a write.
+            let release = std::fs::OpenOptions::new().read(true).write(true)
+                .custom_flags(libc::O_NONBLOCK).open(fifo).unwrap();
+            Self { root, release }
+        }
+
+        fn args(&self) -> Vec<String> {
+            vec!["-c".into(),
+                "printf started > \"$1\"; IFS= read -r reply < \"$2\"; printf finished > \"$3\"".into(),
+                "chonk-test-command".into(), self.root.join("started").to_string_lossy().into_owned(),
+                self.root.join("release").to_string_lossy().into_owned(),
+                self.root.join("finished").to_string_lossy().into_owned()]
+        }
+
+        fn wait_started(&self) {
+            let deadline = std::time::Instant::now() + TEST_DEADLINE;
+            while !self.root.join("started").exists() {
+                assert!(std::time::Instant::now() < deadline, "child did not enter its gated command");
+                std::thread::sleep(Duration::from_millis(1));
+            }
+        }
+
+        fn unblock(&mut self) {
+            writeln!(self.release, "release").unwrap();
+        }
+    }
+
+    impl Drop for CommandGate {
+        fn drop(&mut self) {
+            // Also release a child on assertion failure. If it has not opened
+            // the FIFO yet, removing the path makes its open fail instead of hang.
+            let _ = writeln!(self.release, "release");
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    struct NotifyWake(std::sync::mpsc::Sender<()>);
+
+    impl Wake for NotifyWake {
+        fn resample_soon(&self) {
+            let _ = self.0.send(());
+        }
+    }
 
     fn wait_for_generation<T>(worker: &Worker<T>, generation: u64) {
         let deadline = std::time::Instant::now() + Duration::from_secs(2);
@@ -817,7 +892,7 @@ mod tests {
             let mut worker = Worker::spawn("test-resume-counter".into(), Duration::from_secs(3600), true, move || {
                 count += 1;
                 let _ = started.send(count);
-                let _ = proceed.recv_timeout(Duration::from_secs(2));
+                let _ = proceed.recv(); // Release or sender drop, never a scheduler-driven sample.
                 Outcome::Sampled(Some(count))
             });
             assert_eq!(starts.recv_timeout(Duration::from_secs(2)).unwrap(), 1);
@@ -872,7 +947,7 @@ mod tests {
         let mut worker = Worker::spawn("test-visibility".into(), Duration::from_millis(1), false, move || {
             let _ = &lifetime;
             let _ = sampled.send(());
-            let _ = proceed.recv_timeout(Duration::from_secs(2));
+            let _ = proceed.recv();
             Outcome::Sampled(Some("reading".to_string()))
         });
         // The same effect handle must work before and after first show.
@@ -922,7 +997,7 @@ mod tests {
         let (release, proceed) = mpsc::channel();
         let worker = Worker::spawn("test-resample".into(), Duration::from_secs(3600), true, move || {
             let _ = sampled.send(());
-            let _ = proceed.recv_timeout(Duration::from_secs(2));
+            let _ = proceed.recv();
             Outcome::Sampled(Some(1_u32))
         });
         samples.recv_timeout(Duration::from_secs(2)).expect("first read starts");
@@ -1035,6 +1110,7 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(1));
         }
+        assert!(registry.samples().fresh(id), "the missing-file worker must publish an actual reading attempt");
         assert_eq!(registry.samples().text(id), None);
         assert!(!registry.samples().unusable(id), "a file that is not there yet may be there later");
     }
@@ -1094,39 +1170,41 @@ mod tests {
     /// property rather than the symptom.
     ///
     /// `refresh` is what runs on the compositor's repaint thread. A
-    /// sampler parked in a child process that will not return for two
-    /// seconds must not cost that thread anything at all — which is the
+    /// sampler parked in a child process must not wait on that child — the
     /// exact opposite of what `nmcli dev wifi` did from `tick()` on
     /// 2026-08-29, when a ~3.6s scan became a ~3.6s freeze.
     ///
-    /// The bound is one 60 Hz display frame (16 ms) for
-    /// a *thousand* refreshes taken while the child is parked — chosen
-    /// loose enough that a debug build on a loaded runner cannot fail
-    /// it by accident, and still tighter than the failure it guards
-    /// against by more than two orders of magnitude.
+    /// Prove ordering, not a 16 ms microbenchmark: the child cannot exit
+    /// until all refreshes have returned. The timeout is only a deadlock
+    /// watchdog, so a descheduled test thread is not mistaken for blocking I/O.
     #[test]
-    fn a_sampler_blocked_in_a_child_process_costs_the_caller_nothing() {
+    fn a_sampler_blocked_in_a_child_process_does_not_block_refresh() {
+        let mut gate = CommandGate::new();
         let mut registry = SamplerRegistry::new();
         registry.register(vec![Source::Command {
-            program: "sleep",
-            args: vec!["2".to_string()],
-            interval: Duration::from_millis(1),
+            program: "sh", args: gate.args(), interval: Duration::from_secs(3600),
         }]);
-        // Let the worker actually reach the child before measuring, so
-        // this times refreshes taken *while* it is blocked.
-        std::thread::sleep(Duration::from_millis(50));
-
-        let start = std::time::Instant::now();
-        for _ in 0..1_000 {
-            registry.refresh();
-            let _ = registry.samples();
-        }
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed < Duration::from_millis(16),
-            "1000 refreshes took {elapsed:?} while a sampler was parked in a 2s child; the whole point of \
-             this module is that the repaint thread never waits for one"
-        );
+        gate.wait_started();
+        let (done, returned) = std::sync::mpsc::channel();
+        let caller = std::thread::spawn(move || {
+            for _ in 0..1_000 {
+                registry.refresh();
+                let _ = registry.samples();
+            }
+            registry.set_active(false);
+            let Sampler::Text(worker) = &registry.samplers[0] else { unreachable!() };
+            let generation = worker.shared.state.lock().unwrap().generation;
+            let _ = done.send(generation);
+            registry
+        });
+        let result = returned.recv_timeout(TEST_DEADLINE);
+        assert!(!gate.root.join("finished").exists(), "the child must still be gated");
+        gate.unblock();
+        let registry = caller.join().unwrap();
+        assert_eq!(result.expect("refresh must return before the child is released"), 0,
+            "refresh must finish while sampling is still blocked, not after the command deadline kills it");
+        let Sampler::Text(worker) = &registry.samplers[0] else { unreachable!() };
+        wait_for_generation(worker, 1); // The child has exited and has been reaped.
     }
 
     /// The same claim for the click path: `Effect::Run` hands the
@@ -1138,14 +1216,34 @@ mod tests {
     /// the desktop waits for none of them.
     #[test]
     fn running_effects_returns_before_the_commands_do() {
-        let start = std::time::Instant::now();
-        run_detached(vec![("sleep", vec!["2".to_string()], None)], Vec::new());
-        assert!(start.elapsed() < Duration::from_millis(50), "run_detached must not wait on the child");
-
-        let start = std::time::Instant::now();
-        run_detached(vec![("sleep", vec!["2".to_string()], None), ("sleep", vec!["2".to_string()], None)], Vec::new());
-        assert!(start.elapsed() < Duration::from_millis(50), "a sequence must not wait on its children either");
-
+        for count in [1, 2] {
+            let mut gates: Vec<_> = (0..count).map(|_| CommandGate::new()).collect();
+            let (completed, completions) = std::sync::mpsc::channel();
+            let commands = gates.iter().map(|gate| {
+                ("sh", gate.args(), Some(Resampler { shared: Arc::new(NotifyWake(completed.clone())) }))
+            }).collect();
+            let (done, returned) = std::sync::mpsc::channel();
+            let caller = std::thread::spawn(move || {
+                run_detached(commands, Vec::new());
+                let _ = done.send(());
+            });
+            gates[0].wait_started();
+            let result = returned.recv_timeout(TEST_DEADLINE);
+            assert!(gates.iter().all(|gate| !gate.root.join("finished").exists()));
+            if count == 2 {
+                assert!(!gates[1].root.join("started").exists(), "commands must run in sequence");
+            }
+            // Always release/reap every command before asserting the result,
+            // including when a synchronous-execution regression is detected.
+            for gate in &mut gates {
+                gate.wait_started();
+                gate.unblock();
+                completions.recv_timeout(TEST_DEADLINE).expect("released effect is reaped and requests resampling");
+                assert!(gate.root.join("finished").exists());
+            }
+            caller.join().unwrap();
+            result.expect("run_detached must return before any child is released");
+        }
         run_detached(Vec::new(), Vec::new());
     }
 

--- a/crates/wm-theme/examples/performance.rs
+++ b/crates/wm-theme/examples/performance.rs
@@ -31,6 +31,8 @@ fn allocated(bytes: usize) {
 // and layout. Accounting only touches atomics and cannot allocate recursively.
 unsafe impl GlobalAlloc for CountingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: GlobalAlloc's caller supplies a valid, nonzero layout;
+        // it is forwarded unchanged to the backing System allocator.
         let pointer = unsafe { System.alloc(layout) };
         if !pointer.is_null() {
             allocated(layout.size());
@@ -39,6 +41,8 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: the caller's valid, nonzero layout is forwarded unchanged.
+        // System supplies the zero initialization required by this operation.
         let pointer = unsafe { System.alloc_zeroed(layout) };
         if !pointer.is_null() {
             allocated(layout.size());
@@ -47,11 +51,16 @@ unsafe impl GlobalAlloc for CountingAllocator {
     }
 
     unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: every allocation comes from System, and the caller must
+        // supply a still-live pointer and the same layout used to allocate it.
         unsafe { System.dealloc(pointer, layout) };
         LIVE_BYTES.fetch_sub(layout.size(), Relaxed);
     }
 
     unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: the caller supplies a live System allocation, its original
+        // layout, and a nonzero new size satisfying GlobalAlloc's size bound.
+        // Forward all three unchanged; a null result leaves the old allocation live.
         let result = unsafe { System.realloc(pointer, layout, new_size) };
         if !result.is_null() {
             LIVE_BYTES.fetch_sub(layout.size(), Relaxed);

--- a/crates/wm-wayland/src/readback.rs
+++ b/crates/wm-wayland/src/readback.rs
@@ -19,7 +19,7 @@ pub(crate) fn with_rgba_pixels<R>(
     size: Size<i32, Buffer>,
     consume: impl FnOnce(&[u8]) -> R,
 ) -> Result<R, String> {
-    let length = rgba_length(size).ok_or("invalid RGBA readback extent")?;
+    let length = rgba_length(size.w, size.h).ok_or("invalid RGBA readback extent")?;
     // In Smithay 0.7, Blit is a core-GLES-3-only capability. Unlike
     // re-querying GL_VERSION on every capture this is already cached.
     if renderer.capabilities().contains(&Capability::Blit) {
@@ -63,11 +63,14 @@ pub(crate) fn with_rgba_pixels<R>(
     Ok(consume(&pixels))
 }
 
-fn rgba_length(size: Size<i32, Buffer>) -> Option<usize> {
-    if size.w <= 0 || size.h <= 0 {
+// Validate raw dimensions: Smithay's Size constructor debug-asserts on
+// negative inputs before our allocation guard could inspect them. Keeping
+// this arithmetic independent of Size tests the same rejection in every profile.
+fn rgba_length(width: i32, height: i32) -> Option<usize> {
+    if width <= 0 || height <= 0 {
         return None;
     }
-    (size.w as usize).checked_mul(size.h as usize)?.checked_mul(4)
+    (width as usize).checked_mul(height as usize)?.checked_mul(4)
         .filter(|length| *length <= isize::MAX as usize)
 }
 
@@ -76,10 +79,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn readback_extents_are_checked_before_allocating_or_calling_gl() {
-        assert_eq!(rgba_length((1280, 800).into()), Some(4_096_000));
-        for size in [(0, 1), (1, 0), (-1, 1), (1, -1), (i32::MAX, i32::MAX)] {
-            assert_eq!(rgba_length(size.into()), None);
+    fn valid_readback_extents_count_four_bytes_per_pixel() {
+        assert_eq!(rgba_length(1, 1), Some(4));
+        assert_eq!(rgba_length(1280, 800), Some(4_096_000));
+    }
+
+    #[test]
+    fn empty_and_negative_readback_extents_are_rejected_without_constructing_geometry() {
+        for (width, height) in [(0, 0), (0, 1), (1, 0), (-1, 1), (1, -1), (-1, -1),
+            (i32::MIN, 1), (1, i32::MIN)] {
+            assert_eq!(rgba_length(width, height), None, "extent {width}x{height}");
         }
+    }
+
+    #[test]
+    fn oversized_readback_extents_are_rejected_before_allocating_or_calling_gl() {
+        // Exceeds isize::MAX on 64-bit targets and overflows usize on 32-bit targets.
+        assert_eq!(rgba_length(i32::MAX, i32::MAX), None);
     }
 }

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -898,7 +898,10 @@ fn make_winit_surface_current(
     // GL state, framebuffer contents, or resource ownership is changed.
     let result = unsafe { egl::MakeCurrent(**display, surface, surface, handle) };
     if result == egl::FALSE {
-        return Err(format!("make current: EGL error {:#x}", unsafe { egl::GetError() }));
+        // SAFETY: EGL's entry points are loaded for this live backend.
+        // GetError only reads/clears this thread's EGL error and needs no current context.
+        let error = unsafe { egl::GetError() };
+        return Err(format!("make current: EGL error {error:#x}"));
     }
     Ok(())
 }

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# The display-free Rust/harness checks shared by local preflight and CI.
+# E2E still runs separately with scripts/e2e.sh --headless.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+usage() {
+    echo "Usage: scripts/check.sh [all|lint|docs|unit|wayland-unit|harness]" >&2
+}
+
+check_lint() {
+    cargo clippy --locked --workspace --all-targets --no-deps -- \
+        -D warnings -D clippy::disallowed_methods -D clippy::disallowed_types \
+        -D clippy::undocumented_unsafe_blocks
+}
+
+check_docs() {
+    RUSTDOCFLAGS="${RUSTDOCFLAGS:+$RUSTDOCFLAGS }-D warnings -A rustdoc::private_intra_doc_links" \
+        cargo doc --workspace --no-deps --locked --document-private-items
+}
+
+check_unit() {
+    # CI's display-free job has no Wayland system libraries. The next gate
+    # owns those crates, and `all` runs both gates locally, in debug profile.
+    cargo test --locked --workspace --exclude wm-wayland --exclude chonkstep-wayland
+}
+
+check_wayland_unit() {
+    cargo test --locked -p wm-wayland
+}
+
+check_harness() {
+    python3 -B -m unittest discover -s scripts/tests -v
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 2
+fi
+case "${1:-all}" in
+    all)
+        check_lint
+        check_docs
+        check_unit
+        check_wayland_unit
+        check_harness
+        ;;
+    lint) check_lint ;;
+    docs) check_docs ;;
+    unit) check_unit ;;
+    wayland-unit) check_wayland_unit ;;
+    harness) check_harness ;;
+    -h|--help) usage ;;
+    *) usage; exit 2 ;;
+esac

--- a/scripts/tests/test_check.py
+++ b/scripts/tests/test_check.py
@@ -1,0 +1,106 @@
+"""Exercise the real preflight dispatcher without compiling or starting a desktop."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+CHECK = Path(__file__).resolve().parents[1] / "check.sh"
+
+
+class PreflightTests(unittest.TestCase):
+    def run_check(self, *arguments, fail=""):
+        with tempfile.TemporaryDirectory(prefix="chonk-check-test-") as temporary:
+            root = Path(temporary)
+            log = root / "commands.jsonl"
+            stub = root / "stub"
+            stub.write_text(f"#!{sys.executable}\n" + '''
+import json
+import os
+from pathlib import Path
+import sys
+
+name = Path(sys.argv[0]).name
+with open(os.environ["CHONK_CHECK_TEST_LOG"], "a") as log:
+    log.write(json.dumps({"tool": name, "args": sys.argv[1:],
+                          "rustdocflags": os.environ.get("RUSTDOCFLAGS", ""),
+                          "cwd": os.getcwd()}) + "\\n")
+if name + ":" + sys.argv[1] == os.environ.get("CHONK_CHECK_TEST_FAIL"):
+    sys.exit(42)
+''')
+            stub.chmod(0o755)
+            for name in ("cargo", "python3"):
+                (root / name).symlink_to(stub)
+            env = {**os.environ, "PATH": f"{root}{os.pathsep}{os.environ['PATH']}",
+                   "CHONK_CHECK_TEST_LOG": str(log), "CHONK_CHECK_TEST_FAIL": fail,
+                   "RUSTDOCFLAGS": "--cfg preflight_test"}
+            result = subprocess.run([str(CHECK), *arguments], cwd=root, env=env,
+                                    capture_output=True, text=True, timeout=10)
+            commands = [json.loads(line) for line in log.read_text().splitlines()] if log.exists() else []
+            return result, commands
+
+    def test_default_runs_every_gate_including_debug_wayland_tests(self):
+        result, commands = self.run_check()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual([(item["tool"], item["args"][0]) for item in commands],
+                         [("cargo", "clippy"), ("cargo", "doc"), ("cargo", "test"),
+                          ("cargo", "test"), ("python3", "-B")])
+        for item in commands:
+            self.assertEqual(item["cwd"], str(CHECK.parent.parent))
+            if item["tool"] == "cargo":
+                self.assertIn("--locked", item["args"])
+                self.assertNotIn("--release", item["args"])
+        self.assertEqual(commands[3]["args"], ["test", "--locked", "-p", "wm-wayland"])
+
+    def test_lint_keeps_every_ci_safety_gate_enabled(self):
+        result, commands = self.run_check("lint")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0]["args"], [
+            "clippy", "--locked", "--workspace", "--all-targets", "--no-deps", "--",
+            "-D", "warnings", "-D", "clippy::disallowed_methods", "-D", "clippy::disallowed_types",
+            "-D", "clippy::undocumented_unsafe_blocks",
+        ])
+
+    def test_documentation_keeps_strict_flags_and_private_items(self):
+        result, commands = self.run_check("docs")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0]["rustdocflags"],
+                         "--cfg preflight_test -D warnings -A rustdoc::private_intra_doc_links")
+        self.assertIn("--document-private-items", commands[0]["args"])
+
+    def test_individual_test_gates_do_not_invoke_unrelated_tools(self):
+        for mode, tool, expected in [
+            ("unit", "cargo", ["test", "--locked", "--workspace", "--exclude", "wm-wayland",
+                               "--exclude", "chonkstep-wayland"]),
+            ("wayland-unit", "cargo", ["test", "--locked", "-p", "wm-wayland"]),
+            ("harness", "python3", ["-B", "-m", "unittest", "discover", "-s", "scripts/tests", "-v"]),
+        ]:
+            with self.subTest(mode=mode):
+                result, commands = self.run_check(mode)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual([(item["tool"], item["args"]) for item in commands], [(tool, expected)])
+
+    def test_all_fails_immediately_without_retrying_or_masking_errors(self):
+        for stage, count in [("clippy", 1), ("doc", 2), ("test", 3)]:
+            with self.subTest(stage=stage):
+                result, commands = self.run_check("all", fail=f"cargo:{stage}")
+                self.assertEqual(result.returncode, 42, result.stderr)
+                self.assertEqual(len(commands), count)
+
+    def test_invalid_arguments_do_not_start_any_check(self):
+        for arguments in [("typo",), ("lint", "--release")]:
+            with self.subTest(arguments=arguments):
+                result, commands = self.run_check(*arguments)
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("Usage:", result.stderr)
+                self.assertEqual(commands, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the deterministic failures in CI run 33992240927 and removes scheduler-sensitive sampler assertions.

- Document the allocator and EGL unsafe contracts without disabling any lint.
- Validate raw readback dimensions so negative-input tests exercise our guard in both debug and release, not a Smithay debug assertion.
- Share locked, strict Clippy, documentation, debug unit and harness commands between local preflight and CI; regression-test the dispatcher and fail-fast behavior.
- Replace 16–50 ms sampler/effect timing assertions with real FIFO-gated children and ordering checks. Verify completion/reaping, preserve sequential commands, and release gates on failure.
- Remove timed auto-release from controlled worker tests; require a missing-file source to actually publish before passing.
- Explicitly select software rendering in the nested CI gate and preserve failure logs/screenshots as artifacts.

Validation completed locally: strict Clippy and documentation gates, debug workspace/Wayland tests, 21 Python harness tests, ShellCheck, and 100 single-core rounds with 16 test threads (1600 sampler test executions, zero failures). Full debug nested E2E and the release readback check are also being run. Required GitHub checks must pass before merge; no admin bypass or retry-to-green policy.