### PR TITLE
Native Wayland screenshots and screen recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,7 +387,8 @@ jobs:
           sudo apt-get install -y \
             libxkbcommon-dev libegl-dev libgles-dev libwayland-dev \
             libdrm-dev libgbm-dev libinput-dev libudev-dev libseat-dev \
-            weston xwayland foot alacritty zenity grim wayland-utils wlr-randr wtype
+            weston xwayland foot alacritty zenity grim wayland-utils wlr-randr wtype \
+            wl-clipboard wf-recorder ffmpeg libnotify-bin xdg-user-dirs
 
       # --locked: the compositor pins Smithay 0.7.0, and a silent
       # re-resolution here would test a different dependency tree than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ crate and both session binaries carry the same number.
 
 ## [Unreleased]
 
+- Native Wayland capture: lossless screen, area and unobscured-window PNGs,
+  automatic saving and PNG clipboard ownership, a keyboard/pointer selector,
+  and region/display recording with a stop indicator and recoverable MP4 export.
+  Omarchy workspace/group shortcuts are preserved; see [Capture](docs/capture.md).
+
 - Overview's desktop thumbnails now have an × control. Removing a desktop
   preserves its windows on a neighboring desktop, compacts the row, keeps
   minimized state and focus, and leaves at least one desktop.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3458,6 +3458,7 @@ dependencies = [
  "chonk-hyprland-ipc",
  "chonk-shell",
  "chonk-xsettings",
+ "cosmic-text",
  "libc",
  "profiling",
  "smithay",

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -45,6 +45,8 @@ use chonk_dock_proto::wire::PanelCloseReason;
 /// act for the binary to carry out.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShellOutcome {
+    /// The native backend owns the capture pixels and modal interaction.
+    Capture(wm_config::CaptureMode),
     /// Nothing process-level to do; keep looping.
     Continue,
     /// The user asked to end the session (the root menu's Exit item).
@@ -1815,6 +1817,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
     /// of silently binding to nothing.
     pub fn run_action(&mut self, wm: &mut WindowManager<B>, action: &Action) -> ShellOutcome {
         match action {
+            Action::Capture(mode) => return ShellOutcome::Capture(*mode),
             Action::SpawnTerminal => {
                 let terminal = spawn_terminal(
                     self.state.terminal.as_deref(),
@@ -1968,7 +1971,15 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             // desktop stays up either way; that is the whole contract
             // this crate's config layer is written to.
             Action::Run(name) => match self.state.commands.get(name) {
-                Some(argv) => run_named_command(name, argv, self.state.scale),
+                Some(argv) => {
+                    // The unmodified Omarchy Print binding reaches our selector
+                    // on Wayland. Custom argv and the X11 session keep their
+                    // normal command behavior; this is not a name-only override.
+                    if wm.backend().supports_native_capture() && argv.as_slice() == ["omarchy-capture-screenshot"] {
+                        return ShellOutcome::Capture(wm_config::CaptureMode::Area);
+                    }
+                    run_named_command(name, argv, self.state.scale);
+                }
                 None => tracing::warn!(
                     command = %name,
                     "no such command in [commands]; nothing to run"

--- a/crates/chonk-testkit/tests/browser_selection.rs
+++ b/crates/chonk-testkit/tests/browser_selection.rs
@@ -92,22 +92,38 @@ fn wait_for_presented_extent(session: &mut Session, phase: &str) {
 }
 
 fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str) {
-    let start = browser
-        .evaluate(&format!("window.chonkProbe.point('{id}', 8)"))
-        .unwrap();
-    let end = browser
-        .evaluate(&format!("window.chonkProbe.point('{id}', 24)"))
-        .unwrap();
-    for (point, expected) in [(&start, 8), (&end, 24)] {
+    // Read points and viewport in one renderer turn. A fullscreen resize can
+    // otherwise land between separate CDP reads and combine a new compositor
+    // rectangle with old DOM coordinates (particularly under SwiftShader).
+    let (geometry, client) = poll_until(EVENT, "coherent selection geometry", || {
+        let geometry = browser.evaluate(&format!(
+            "new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve({{\
+             viewport:window.chonkProbe.snapshot(), start:window.chonkProbe.point('{id}',8), \
+             end:window.chonkProbe.point('{id}',24)}}))))"
+        )).ok()?;
+        let viewport = &geometry["viewport"];
+        let world = session.world().ok()?;
+        let client = world.window_matching("ChonkStep Selection Probe")?;
+        let dpr = coordinate(viewport, "dpr");
+        if phase == "fullscreen" && (viewport["fullscreen"] != true
+            || client.w != world.output_w || client.h != world.output_h
+            || (coordinate(viewport, "width") * dpr - f64::from(client.w)).abs() > dpr
+            || (coordinate(viewport, "height") * dpr - f64::from(client.h)).abs() > dpr) {
+            return None;
+        }
+        Some((geometry, client.clone()))
+    }).unwrap();
+    let start = &geometry["start"];
+    let end = &geometry["end"];
+    for (point, expected) in [(start, 8), (end, 24)] {
         assert_eq!(
             point["offset"], expected,
             "DOM geometry must name the intended caret"
         );
         assert_eq!(point["sameNode"], true);
     }
-    let viewport = value(browser);
+    let viewport = geometry["viewport"].clone();
     let dpr = coordinate(&viewport, "dpr");
-    let client = window(session);
     // The page viewport is bottom/right aligned inside this app window. This
     // accounts for the browser's own titlebar without confusing it with the
     // compositor's server-side frame, which is outside `client` already.
@@ -121,8 +137,8 @@ fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str
             (origin.1 + coordinate(point, "y") * dpr).ceil(),
         )
     };
-    let from = global(&start);
-    let to = global(&end);
+    let from = global(start);
+    let to = global(end);
     browser.evaluate("window.chonkProbe.reset()").unwrap();
     // Edge shows a native mini menu after selecting plain text. Like a user,
     // dismiss it with an outside click before beginning a new selection. DOM
@@ -141,7 +157,7 @@ fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str
             .find(|event| event["type"] == "mousemove")?;
         ["x", "y"]
             .into_iter()
-            .all(|axis| (coordinate(motion, axis) - coordinate(&start, axis)).abs() < 0.75)
+            .all(|axis| (coordinate(motion, axis) - coordinate(start, axis)).abs() < 0.75)
             .then_some(observed)
     })
     .unwrap_or_else(|error| {
@@ -159,7 +175,7 @@ fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str
         .find(|event| event["type"] == "mousemove")
         .unwrap();
     for axis in ["x", "y"] {
-        assert!((coordinate(motion, axis) - coordinate(&start, axis)).abs() < 0.75,
+        assert!((coordinate(motion, axis) - coordinate(start, axis)).abs() < 0.75,
             "viewport calibration failed before pressing: {phase}, {id}, {client:?}, {start}, {hover}");
     }
     // Do not confuse the popup-dismissal click with the drag's release.
@@ -192,22 +208,22 @@ fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str
         serde_json::to_vec_pretty(&report).unwrap(),
     )
     .unwrap();
-    let screenshot = session
-        .screenshot(&format!("selection-{phase}-{id}"))
-        .unwrap();
-    let background = screenshot.mean_rgb(
-        (origin.0 + 32.0 * dpr) as u32,
-        // Keep clear of the browser's temporary fullscreen-exit banner.
-        (origin.1 + (coordinate(&viewport, "height") - 24.0) * dpr) as u32,
-        12,
-        12,
-    );
-    for (actual, expected) in background.into_iter().zip([246.0, 244.0, 232.0]) {
-        assert!(
-            (actual - expected).abs() < 3.0,
-            "DOM selection is insufficient if the browser did not render: {background:?}"
+    // SwiftShader can commit an initially black buffer at the correct extent
+    // before the page's first painted frame. DOM input and buffer size alone
+    // cannot fence that asynchronous paint; require the real pixels as well.
+    let mut background = [0.0; 3];
+    poll_until(EVENT, "the browser to paint the selected page", || {
+        let screenshot = session.screenshot(&format!("selection-{phase}-{id}")).ok()?;
+        background = screenshot.mean_rgb(
+            (origin.0 + 32.0 * dpr) as u32,
+            // Keep clear of the browser's temporary fullscreen-exit banner.
+            (origin.1 + (coordinate(&viewport, "height") - 24.0) * dpr) as u32,
+            12,
+            12,
         );
-    }
+        background.into_iter().zip([246.0, 244.0, 232.0])
+            .all(|(actual, expected)| (actual - expected).abs() < 3.0).then_some(())
+    }).unwrap_or_else(|error| panic!("{error}: DOM selection is insufficient if the browser did not render: {background:?}"));
     let release = observed["events"]
         .as_array()
         .unwrap()
@@ -217,7 +233,7 @@ fn selection(session: &mut Session, browser: &mut Browser, phase: &str, id: &str
         .unwrap();
     for axis in ["x", "y"] {
         assert!(
-            (coordinate(release, axis) - coordinate(&end, axis)).abs() < 0.75,
+            (coordinate(release, axis) - coordinate(end, axis)).abs() < 0.75,
             "held-button {axis} is not the same coordinate space as hover: {report}"
         );
     }
@@ -467,7 +483,11 @@ fn run(name: &str, scale: f32, platform: Platform) {
     if std::env::var_os("CI").is_some() {
         // Same private-page software-renderer policy as the existing Chromium
         // regressions on hosted runners that disable unprivileged namespaces.
-        args.extend(["--no-sandbox", "--use-gl=angle", "--use-angle=swiftshader"]);
+        // Chromium's no-sandbox warning infobar remains visible in DOM
+        // fullscreen and reduces innerHeight. Its official test switch
+        // suppresses startup infobars, keeping the strict viewport/surface
+        // agreement below meaningful. Only this isolated CI browser uses it.
+        args.extend(["--no-sandbox", "--test-type", "--use-gl=angle", "--use-angle=swiftshader"]);
     }
     match platform {
         Platform::Wayland => session.launch_isolated(&program, &args),
@@ -548,7 +568,10 @@ fn run(name: &str, scale: f32, platform: Platform) {
                         .then_some(())
                 },
             )
-            .unwrap();
+            .unwrap_or_else(|error| {
+                let _ = session.screenshot("fullscreen-timeout");
+                panic!("{error}: page={}, world={:?}", value(&mut browser), session.world());
+            });
         }
         // A configure updates compositor and DOM geometry before Chromium's
         // newly sized Wayland buffer necessarily reaches the scene. Fence the

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -1,0 +1,453 @@
+//! Real keyboard/pointer entry, GPU pixels, clipboard and ffmpeg lifecycle.
+//! Isolated directories and Wayland sockets; never touches the user's clipboard.
+#![allow(clippy::disallowed_methods)] // Test process, not the compositor loop.
+use chonk_testkit::{poll_until, profile_binary, session_dir, Screenshot, Session, SessionOptions};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+fn shortcut(session: &mut Session, number: u32) {
+    session.door().key(125, true).unwrap();
+    session.door().key(29, true).unwrap();
+    session.door().key(42, true).unwrap();
+    session.door().tap_key(number + 1).unwrap();
+    session.door().key(42, false).unwrap();
+    session.door().key(29, false).unwrap();
+    session.door().key(125, false).unwrap();
+    session.door().barrier().unwrap();
+}
+
+fn files(directory: &Path, extension: &str) -> Vec<PathBuf> {
+    let mut paths: Vec<_> = std::fs::read_dir(directory)
+        .into_iter()
+        .flatten()
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| {
+            !p.file_name().unwrap().to_string_lossy().starts_with('.')
+                && p.extension().is_some_and(|e| e == extension)
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn saved(directory: &Path, count: usize, extension: &str) -> PathBuf {
+    poll_until(Duration::from_secs(30), "capture saved", || {
+        let found = files(directory, extension);
+        (found.len() == count).then(|| found.last().unwrap().clone())
+    })
+    .unwrap()
+}
+
+fn boot(name: &str, scale: f32) -> Session {
+    let dir = session_dir(name).join("exports");
+    Session::boot(
+        name,
+        SessionOptions {
+            scale: Some(scale),
+            config_extra: "desktop = \"omarchy\"\nomarchy_bar = false\nshow_dock = false\n".into(),
+            config_root_files: vec![(
+                "hypr/hyprland.conf".into(),
+                "bind = SUPER, F12, workspace, 1\nbind = , PRINT, exec, omarchy-capture-screenshot\n".into(),
+            )],
+            env: vec![
+                ("OMARCHY_SCREENSHOT_DIR".into(), dir.display().to_string()),
+                ("OMARCHY_SCREENRECORD_DIR".into(), dir.display().to_string()),
+            ],
+            ..SessionOptions::default()
+        },
+    )
+    .unwrap()
+}
+
+fn diagnostic(session: &mut Session, name: &str) -> Screenshot {
+    let path = session.dir.join(format!("{name}.png"));
+    std::fs::write(
+        session.dir.join("state/chonkstep/screenshot"),
+        path.display().to_string(),
+    )
+    .unwrap();
+    poll_until(Duration::from_secs(10), "visible capture chrome", || {
+        Screenshot::load(&path).ok()
+    })
+    .unwrap()
+}
+
+fn screenshot_workflow(scale: f32, name: &str) {
+    let mut session = boot(name, scale);
+    let exports = session.dir.join("exports");
+    let probe = profile_binary("chonk-input-probe").unwrap();
+    session.launch(probe.to_str().unwrap(), &["1"]).unwrap();
+    let window = session.wait_for_window("input-probe").unwrap();
+    session
+        .door()
+        .click((window.x + 50) as f64, (window.y + 50) as f64)
+        .unwrap();
+    let before = session.screenshot("before").unwrap();
+    shortcut(&mut session, 3);
+    let path = saved(&exports, 1, "png");
+    let full = Screenshot::load(&path).unwrap();
+    assert_eq!((full.width, full.height), (before.width, before.height));
+    assert_eq!(full.pixel(0, 0), before.pixel(0, 0));
+    // Clipboard's MIME offer must serve byte-for-byte the published PNG.
+    poll_until(Duration::from_secs(10), "PNG clipboard", || {
+        let output = Command::new("wl-paste")
+            .args(["--no-newline", "--type", "image/png"])
+            .env("WAYLAND_DISPLAY", &session.wayland_display)
+            .output()
+            .ok()?;
+        (output.status.success() && output.stdout == std::fs::read(&path).ok()?).then_some(())
+    })
+    .unwrap();
+    if scale == 1.0 {
+        session.door().tap_key(99).unwrap();
+    } else {
+        shortcut(&mut session, 4);
+    }
+    session
+        .door()
+        .drag_to((30.0, 40.0), (231.0, 153.0))
+        .unwrap();
+    let visible = diagnostic(&mut session, "area-overlay");
+    assert!(
+        visible.diff_fraction(&before, 0) > 0.01,
+        "visible capture chrome"
+    );
+    let exported = session.screenshot("overlay-excluded").unwrap();
+    assert_eq!(
+        exported.pixel(2, 2),
+        before.pixel(2, 2),
+        "screencopy excludes dimming"
+    );
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    let area = Screenshot::load(&saved(&exports, 2, "png")).unwrap();
+    assert_eq!(
+        (area.width, area.height),
+        (201, 113),
+        "device pixels, no scale multiplier"
+    );
+    for y in 0..area.height {
+        for x in 0..area.width {
+            assert_eq!(
+                area.pixel(x, y),
+                exported.pixel(x + 30, y + 40),
+                "pixel {x},{y}"
+            );
+        }
+    }
+    // A window screenshot includes its titlebar and has no surrounding desktop.
+    shortcut(&mut session, 4);
+    session.door().tap_key(57).unwrap(); // Space -> window
+    session
+        .door()
+        .motion((window.x + 20) as f64, (window.y + 20) as f64)
+        .unwrap();
+    session.door().barrier().unwrap();
+    diagnostic(&mut session, "window-overlay");
+    let world = session.world().unwrap();
+    let frame = world.frame_of(window.id).unwrap();
+    let expected = (frame.w, frame.h);
+    session
+        .door()
+        .click((window.x + 20) as f64, (window.y + 20) as f64)
+        .unwrap();
+    let shot = Screenshot::load(&saved(&exports, 3, "png")).unwrap();
+    assert_eq!((shot.width, shot.height), expected);
+    // Escape during a held drag must consume its release and restore typing.
+    shortcut(&mut session, 4);
+    session
+        .door()
+        .drag_to((50.0, 50.0), (200.0, 150.0))
+        .unwrap();
+    session.door().tap_key(1).unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    session.door().tap_key(30).unwrap();
+    poll_until(
+        Duration::from_secs(5),
+        "typing restored after capture cancellation",
+        || {
+            session
+                .client_log("chonk-input-probe")
+                .contains("keyboard key 30 down")
+                .then_some(())
+        },
+    )
+    .unwrap();
+    assert_eq!(files(&exports, "png").len(), 3, "cancel creates no file");
+    // Toolbar entry, numbered mode and cancellation exercise the other shortcut.
+    shortcut(&mut session, 5);
+    diagnostic(&mut session, "capture-toolbar");
+    session.door().tap_key(1).unwrap();
+}
+
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn screenshots_1x() {
+    screenshot_workflow(1.0, "capture-1x");
+}
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn screenshots_fractional() {
+    screenshot_workflow(1.5, "capture-15x");
+}
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn screenshots_2x() {
+    screenshot_workflow(2.0, "capture-2x");
+}
+
+#[test]
+#[ignore = "needs nested Wayland, wf-recorder and ffmpeg"]
+fn recording_odd_area_is_playable_and_controls_are_excluded() {
+    let mut session = boot("capture-record", 1.5);
+    let exports = session.dir.join("exports");
+    let before = session.screenshot("before-recording").unwrap();
+    shortcut(&mut session, 5);
+    session.door().tap_key(6).unwrap(); // 5 -> record area
+    session
+        .door()
+        .drag_to((430.0, 10.0), (731.0, 211.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().tap_key(28).unwrap(); // Enter starts recording
+    diagnostic(&mut session, "recording-indicator");
+    let deadline = std::time::Instant::now() + Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        session.door().motion(100.0, 100.0).unwrap();
+        session.door().barrier().unwrap();
+        std::thread::sleep(Duration::from_millis(40));
+    }
+    shortcut(&mut session, 5); // Stop / finish
+    let path = saved(&exports, 1, "mp4");
+    let probe = Command::new("ffprobe")
+        .args([
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=codec_name,width,height,pix_fmt:format=duration",
+            "-of",
+            "json",
+        ])
+        .arg(&path)
+        .output()
+        .unwrap();
+    assert!(probe.status.success());
+    let info: serde_json::Value = serde_json::from_slice(&probe.stdout).unwrap();
+    assert_eq!(info["streams"][0]["codec_name"], "h264");
+    // Full-range 4:2:0 is reported as yuvj420p by some ffmpeg versions.
+    assert!(["yuv420p", "yuvj420p"].contains(&info["streams"][0]["pix_fmt"].as_str().unwrap()));
+    assert_eq!(info["streams"][0]["width"], 302);
+    assert_eq!(info["streams"][0]["height"], 202);
+    assert!(
+        info["format"]["duration"]
+            .as_str()
+            .unwrap()
+            .parse::<f64>()
+            .unwrap()
+            > 1.0
+    );
+    let frame_path = session.dir.join("recording-first-frame.png");
+    assert!(Command::new("ffmpeg")
+        .args(["-nostdin", "-v", "error", "-i"])
+        .arg(&path)
+        .args(["-frames:v", "1"])
+        .arg(&frame_path)
+        .status()
+        .unwrap()
+        .success());
+    let frame = Screenshot::load(&frame_path).unwrap();
+    // This point is underneath the visible recording badge, not merely outside
+    // the selected region. Its original desktop pixels must survive in video.
+    let expected = before.pixel(500, 25);
+    let actual = frame.pixel(70, 15);
+    for channel in 0..3 {
+        assert!(
+            actual[channel].abs_diff(expected[channel]) < 12,
+            "no dim overlay encoded: {actual:?} vs {expected:?}"
+        );
+    }
+    shortcut(&mut session, 4);
+    session.door().tap_key(1).unwrap(); // Tool can be reopened after finalization.
+}
+
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn window_capture_excludes_occluding_windows() {
+    let mut session = boot("capture-occluded", 1.5);
+    let exports = session.dir.join("exports");
+    let probe = profile_binary("chonk-input-probe").unwrap();
+    session.launch(probe.to_str().unwrap(), &["1"]).unwrap();
+    let target = session.wait_for_window("input-probe").unwrap();
+    let baseline = session.screenshot("unoccluded").unwrap();
+    // Select the target, then map an occluder: a window screenshot must render
+    // the selected window itself, not simply crop the composite desktop.
+    shortcut(&mut session, 4);
+    session.door().tap_key(57).unwrap();
+    session
+        .door()
+        .motion((target.x + 20) as f64, (target.y + 20) as f64)
+        .unwrap();
+    session.door().barrier().unwrap();
+    session
+        .launch(
+            "foot",
+            &[
+                "--title=capture-occluder",
+                "--window-size-pixels=800x600",
+                "--override",
+                "locked-title=yes",
+            ],
+        )
+        .unwrap();
+    let occluder = session.wait_for_window("capture-occluder").unwrap();
+    let composite = session.screenshot("occluded").unwrap();
+    let world = session.world().unwrap();
+    let frame = world.frame_of(target.id).unwrap();
+    let x = (target.x + 10).max(occluder.x + 10) as u32;
+    let y = (target.y + 10).max(occluder.y + 10) as u32;
+    assert!(
+        x < (target.x + target.w as i32) as u32 && y < (target.y + target.h as i32) as u32,
+        "fixture windows overlap"
+    );
+    assert_ne!(
+        composite.pixel(x, y),
+        baseline.pixel(x, y),
+        "occluder really covers the target"
+    );
+    let source = (frame.x, frame.y, frame.w, frame.h);
+    session.door().tap_key(28).unwrap();
+    let image = Screenshot::load(&saved(&exports, 1, "png")).unwrap();
+    assert_eq!((image.width, image.height), (source.2, source.3));
+    assert_eq!(
+        image.pixel((x as i32 - source.0) as u32, (y as i32 - source.1) as u32),
+        baseline.pixel(x, y)
+    );
+}
+
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn saving_failure_does_not_leave_input_grabbed() {
+    let mut session = boot("capture-save-failure", 1.0);
+    // A file where a directory is expected deterministically fails even under
+    // root-run CI; chmod-based permission tests do not.
+    std::fs::write(session.dir.join("exports"), "not a directory").unwrap();
+    shortcut(&mut session, 4);
+    session
+        .door()
+        .drag_to((30.0, 40.0), (231.0, 153.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    poll_until(Duration::from_secs(10), "failure surfaced", || {
+        session.log().contains("Screenshot failed").then_some(())
+    })
+    .unwrap();
+    shortcut(&mut session, 5);
+    diagnostic(&mut session, "toolbar-after-failure");
+    session.door().tap_key(1).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(session.dir.join("exports")).unwrap(),
+        "not a directory"
+    );
+}
+
+#[test]
+#[ignore = "needs nested Wayland; scripts/e2e.sh --headless --test capture_tool"]
+fn retained_area_moves_resizes_and_blocks_desktop_gestures() {
+    let mut session = boot("capture-adjust", 1.0);
+    shortcut(&mut session, 5);
+    session
+        .door()
+        .drag_to((30.0, 40.0), (231.0, 153.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    session
+        .door()
+        .drag_to((100.0, 100.0), (110.0, 120.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    session
+        .door()
+        .drag_to((241.0, 173.0), (261.0, 193.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    session.door().tap_key(106).unwrap(); // Right: one physical pixel
+    session.door().tap_key(108).unwrap(); // Down
+    let workspace = session.world().unwrap().current_workspace;
+    session.door().swipe_begin(3).unwrap();
+    for _ in 0..8 {
+        session.door().swipe_update(-100.0, 0.0).unwrap();
+    }
+    session.door().swipe_end(false).unwrap();
+    session.door().touch_down(0, 400.0, 300.0).unwrap();
+    session.door().touch_up(0).unwrap();
+    session.door().touch_frame().unwrap();
+    session.door().barrier().unwrap();
+    let world = session.world().unwrap();
+    assert_eq!(world.current_workspace, workspace);
+    diagnostic(&mut session, "adjusted-selection");
+    let baseline = session.screenshot("without-chrome").unwrap();
+    let width = 720.min(world.output_w - 16);
+    let x = (world.output_w - width) / 2 + width * 13 / 14;
+    session
+        .door()
+        .click(x as f64, (world.output_h - 83) as f64)
+        .unwrap();
+    let image = Screenshot::load(&saved(&session.dir.join("exports"), 1, "png")).unwrap();
+    assert_eq!((image.width, image.height), (221, 133));
+    assert_eq!(image.pixel(0, 0), baseline.pixel(41, 61));
+    assert_eq!(image.pixel(220, 132), baseline.pixel(261, 193));
+}
+
+#[test]
+#[ignore = "needs nested Wayland, wf-recorder and ffmpeg"]
+fn toolbar_screen_modes_work_without_moving_off_the_toolbar_and_badge_stops() {
+    let mut session = boot("capture-display", 1.0);
+    let world = session.world().unwrap();
+    let exports = session.dir.join("exports");
+    shortcut(&mut session, 5);
+    session
+        .door()
+        .motion((world.output_w / 2) as f64, (world.output_h - 83) as f64)
+        .unwrap();
+    session.door().tap_key(2).unwrap(); // 1 -> screenshot display
+    session.door().tap_key(28).unwrap();
+    let image = Screenshot::load(&saved(&exports, 1, "png")).unwrap();
+    assert_eq!(
+        (image.width, image.height),
+        (world.output_w, world.output_h)
+    );
+    shortcut(&mut session, 5);
+    session.door().tap_key(5).unwrap(); // 4 -> record display
+    session.door().tap_key(28).unwrap();
+    poll_until(Duration::from_secs(10), "recorder creates data", || {
+        std::fs::read_dir(&exports)
+            .ok()?
+            .flatten()
+            .any(|e| {
+                e.path().extension().is_some_and(|x| x == "mkv")
+                    && e.metadata().is_ok_and(|m| m.len() > 1000)
+            })
+            .then_some(())
+    })
+    .unwrap();
+    session
+        .door()
+        .click((world.output_w / 2) as f64, 30.0)
+        .unwrap();
+    let path = saved(&exports, 1, "mp4");
+    assert!(Command::new("ffprobe")
+        .args(["-v", "error"])
+        .arg(path)
+        .status()
+        .unwrap()
+        .success());
+}

--- a/crates/chonkstep/src/main.rs
+++ b/crates/chonkstep/src/main.rs
@@ -541,6 +541,10 @@ fn dispatch_motion(
 /// it) that must not drift on what each variant means.
 fn exit_requested(shell: &mut Shell<X11Backend>, outcome: ShellOutcome) -> bool {
     match outcome {
+        ShellOutcome::Capture(_) => {
+            tracing::warn!("native capture requires the Chonkstep Wayland session");
+            false
+        }
         ShellOutcome::Continue => false,
         ShellOutcome::Exit => true,
         // The exact path `scripts/restart.sh` takes: re-exec the

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -257,6 +257,9 @@ pub struct Reading {
     /// later entries winning — Hyprland's own rule for a chord bound
     /// twice.
     pub keybindings: Vec<(KeyCombo, Action)>,
+    /// Explicit bind/unbind choices suppress native capture defaults, even when
+    /// a dispatcher is not supported. Never reclaim a user's chosen chord.
+    pub explicit_keys: Vec<KeyCombo>,
     /// Every accepted binding including release/locked/repeat behavior
     /// and its human description.
     pub bindings: Vec<crate::Binding>,
@@ -317,10 +320,11 @@ impl Reading {
         // replaced the built-in keybindings. Destructure exhaustively so a
         // future category cannot silently disappear at this loading boundary.
         let Self {
-            keybindings, bindings, layer_bindings, commands, env, autostart,
+            keybindings, explicit_keys, bindings, layer_bindings, commands, env, autostart,
             float_rules, monitors, input, files: _, skipped: _,
         } = self;
         keybindings.is_empty()
+            && explicit_keys.is_empty()
             && bindings.is_empty()
             && layer_bindings.is_empty()
             && commands.is_empty()
@@ -481,8 +485,17 @@ pub fn apply(config: &mut crate::Config, reading: Option<&Reading>) {
             "hyprland-config: no bindings came out of the read; keeping the built-in keymap"
         );
     } else {
+        let captures: Vec<_> = config.keybindings.iter()
+            .filter(|(key, action)| matches!(action, Action::Capture(_))
+                && !reading.explicit_keys.contains(key)
+                && !reading.keybindings.iter().any(|(other, _)| other == key))
+            .cloned().collect();
         config.keybindings = reading.keybindings.clone();
+        config.keybindings.extend(captures);
     }
+    config.keybindings.retain(|(key, action)| !matches!(action, Action::Capture(_))
+        || !reading.explicit_keys.contains(key)
+        || reading.keybindings.iter().any(|(other, _)| other == key));
     config.bindings = reading.bindings.clone();
     config.layer_bindings = reading.layer_bindings.clone();
     // Commands are *inserted*, so a `[commands]` entry of the same name
@@ -787,13 +800,12 @@ fn lower(stream: Vec<Directive>, report: LoadReport) -> Reading {
                 description,
                 flags,
                 dispatcher,
-            } => bind(
-                &mut reading,
-                &keys,
-                description.as_deref(),
-                flags,
-                &dispatcher,
-            ),
+            } => {
+                if let Ok(spec) = keys::spec_for(&keys) {
+                    if let Some(combo) = crate::parse_key(&spec) { reading.explicit_keys.push(combo); }
+                }
+                bind(&mut reading, &keys, description.as_deref(), flags, &dispatcher)
+            },
             Directive::LayerBind {
                 namespace,
                 keys,
@@ -811,6 +823,7 @@ fn lower(stream: Vec<Directive>, report: LoadReport) -> Reading {
             Directive::Unbind { keys } => match keys::spec_for(&keys) {
                 Ok(spec) => {
                     if let Some(combo) = crate::parse_key(&spec) {
+                        reading.explicit_keys.push(combo);
                         reading
                             .keybindings
                             .retain(|(existing, _)| *existing != combo);

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -1124,9 +1124,8 @@ fn the_posture_decides_whether_anybody_elses_config_is_read() {
     );
 }
 
-/// The read replaces the baked preset rather than merging with it —
-/// the same replace-don't-merge rule, and the same reason: a chord
-/// with two answers has no documented winner.
+/// Live bindings replace the preset, with native capture defaults filling only
+/// unclaimed chords. No chord may have two answers.
 #[test]
 fn the_live_read_replaces_the_baked_preset() {
     let mut config = crate::Config::default_config();
@@ -1137,11 +1136,25 @@ fn the_live_read_replaces_the_baked_preset() {
     apply(&mut config, Some(&reading));
     assert_eq!(
         config.keybindings.len(),
-        reading.keybindings.len(),
-        "replaced, not merged with, the {baked} baked entries"
+        reading.keybindings.len() + 4,
+        "only four native capture shortcuts augment the live read, not all {baked} entries"
     );
     assert!(config.float_policy.is_some());
     assert!(!config.session_env.is_empty());
+}
+
+#[test]
+fn capture_defaults_honor_live_bind_and_unbind_even_without_other_bindings() {
+    let capture = crate::parse_key("super+ctrl+shift+4").unwrap();
+    for replacement in [None, Some(Action::Close)] {
+        let mut config = crate::Config::default_config();
+        crate::preset::apply_keymap(&mut config, crate::preset::Keymap::Omarchy);
+        let mut reading = Reading { explicit_keys: vec![capture], ..Reading::default() };
+        if let Some(action) = &replacement { reading.keybindings.push((capture, action.clone())); }
+        assert!(!reading.is_empty(), "unbind is an explicit user choice");
+        apply(&mut config, Some(&reading));
+        assert_eq!(config.keybindings.iter().find(|(key, _)| *key == capture).map(|(_, a)| a.clone()), replacement);
+    }
 }
 
 /// Nothing to read means the preset stands. That is what it is for.

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -104,6 +104,8 @@ use wm_core::{KeyCombo, Modifiers, PlacementPolicy};
 /// do-nothing case that should have been filtered out at parse time.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Action {
+    /// Native Wayland screenshot / recording workflow.
+    Capture(CaptureMode),
     SpawnTerminal,
     Close,
     ToggleMaximize,
@@ -217,6 +219,16 @@ pub enum Action {
     Run(String),
 }
 
+/// Entry points to the native Wayland capture tool.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureMode {
+    Screen,
+    Area,
+    Window,
+    Toolbar,
+    Stop,
+}
+
 /// A configured binding with the behavioral facts Hyprland attaches
 /// to it. The legacy `Config::keybindings` projection remains the
 /// press-action map used by both window-manager backends.
@@ -285,6 +297,11 @@ fn action_from_name(name: &str) -> Option<Action> {
         "workspace-prev" => Some(Action::WorkspacePrev),
         "workspace-carry-next" => Some(Action::WorkspaceCarryNext),
         "workspace-carry-prev" => Some(Action::WorkspaceCarryPrev),
+        "capture-screen" => Some(Action::Capture(CaptureMode::Screen)),
+        "capture-area" => Some(Action::Capture(CaptureMode::Area)),
+        "capture-window" => Some(Action::Capture(CaptureMode::Window)),
+        "capture" => Some(Action::Capture(CaptureMode::Toolbar)),
+        "capture-stop" => Some(Action::Capture(CaptureMode::Stop)),
         "overview" => Some(Action::Overview),
         "root-menu" => Some(Action::RootMenu),
         "window-menu" => Some(Action::WindowMenu),
@@ -676,6 +693,10 @@ impl Config {
                 // the arrow pairs with the arrows that then drive the
                 // selection inside it.
                 bind("super+up", Action::Overview),
+                bind("super+shift+3", Action::Capture(CaptureMode::Screen)),
+                bind("super+shift+4", Action::Capture(CaptureMode::Area)),
+                bind("super+shift+5", Action::Capture(CaptureMode::Toolbar)),
+                bind("super+ctrl+escape", Action::Capture(CaptureMode::Stop)),
                 // The window commands menu, reachable without a
                 // titlebar to right-click. Window Maker binds exactly
                 // this, on exactly this key, and documents it as the
@@ -1999,6 +2020,10 @@ mod tests {
             (combo(0xff53, alt_shift), Action::WorkspaceCarryNext),
             (combo(0xff51, alt_shift), Action::WorkspaceCarryPrev),
             (combo(0xff52, Modifiers::SUPER), Action::Overview),
+            (combo(0x33, Modifiers::SUPER | Modifiers::SHIFT), Action::Capture(CaptureMode::Screen)),
+            (combo(0x34, Modifiers::SUPER | Modifiers::SHIFT), Action::Capture(CaptureMode::Area)),
+            (combo(0x35, Modifiers::SUPER | Modifiers::SHIFT), Action::Capture(CaptureMode::Toolbar)),
+            (combo(0xff1b, Modifiers::SUPER | Modifiers::CONTROL), Action::Capture(CaptureMode::Stop)),
             (combo(0xff1b, Modifiers::CONTROL), Action::WindowMenu),
         ];
         let config = Config::default_config();
@@ -2242,8 +2267,7 @@ scroll_factor = 0.4
             action_for(&config, "alt+shift+left"),
             Some(Action::WorkspaceCarryPrev)
         );
-        // 12 defaults - 1 unbound + 2 new = 13.
-        assert_eq!(config.keybindings.len(), 13);
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len() + 1);
     }
 
     /// The one conversion between the two workspace vocabularies, in
@@ -2458,7 +2482,7 @@ scroll_factor = 0.4
         assert_eq!(config.diagnostics, vec!["bind: SUPER J — tiling-only"]);
         let report = effective_config_report(&config);
         assert!(report.contains("focus_follows_mouse = true\t# config file"));
-        assert!(report.contains("keybindings = 12\t# live Hyprland config"));
+        assert!(report.contains("keybindings = 16\t# live Hyprland config"));
     }
 
     #[test]
@@ -2482,14 +2506,14 @@ scroll_factor = 0.4
         assert_eq!(action_for(&config, "alt+shift+x"), Some(Action::Close));
         // Every other default is untouched, and no entry was duplicated.
         assert_eq!(action_for(&config, "alt+shift+q"), Some(Action::Close));
-        assert_eq!(config.keybindings.len(), 12);
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len());
     }
 
     #[test]
     fn none_unbinds_a_default() {
         let config = parse("[keybindings]\n\"alt+shift+q\" = \"none\"\n").unwrap();
         assert_eq!(action_for(&config, "alt+shift+q"), None);
-        assert_eq!(config.keybindings.len(), 11);
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len() - 1);
         assert!(!config.keybindings.iter().any(|(_, a)| *a == Action::Close));
     }
 
@@ -2499,7 +2523,7 @@ scroll_factor = 0.4
         // through an alias/case variant of the default's spelling works.
         let config = parse("[keybindings]\n\"ALT+CONTROL+RIGHT\" = \"None\"\n").unwrap();
         assert_eq!(action_for(&config, "alt+ctrl+right"), None);
-        assert_eq!(config.keybindings.len(), 11);
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len() - 1);
     }
 
     #[test]
@@ -2560,8 +2584,8 @@ scroll_factor = 0.4
         // ...the bad ones were skipped without binding anything...
         assert_eq!(action_for(&config, "super+u"), None);
         assert_eq!(action_for(&config, "super+v"), None);
-        // ...and the untouched defaults survived: 12 - 1 + 1 = 12.
-        assert_eq!(config.keybindings.len(), 12);
+        // ...and the untouched defaults survived: one removed, one added.
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len());
         assert_eq!(
             action_for(&config, "alt+shift+x"),
             Some(Action::ToggleMaximize)
@@ -2590,7 +2614,7 @@ scroll_factor = 0.4
         assert_eq!(config.theme, None);
         assert_eq!(config.placement, PlacementPolicy::Smart);
         assert_eq!(config.edge_resistance, 10);
-        assert_eq!(config.keybindings.len(), 12);
+        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len());
     }
 
     #[test]

--- a/crates/wm-config/src/preset.rs
+++ b/crates/wm-config/src/preset.rs
@@ -362,6 +362,11 @@ pub fn omarchy_keybindings() -> Vec<(wm_core::KeyCombo, Action)> {
 /// a future Omarchy release is a file-by-file read rather than a hunt.
 /// A `run <name>` action names an entry in [`OMARCHY_COMMANDS`].
 pub const OMARCHY_BINDINGS: &[(&str, &str)] = &[
+    // Shift+digits carry windows; Alt+digits select groups. Keep both intact.
+    ("super+ctrl+shift+3", "capture-screen"),
+    ("super+ctrl+shift+4", "capture-area"),
+    ("super+ctrl+shift+5", "capture"),
+    ("super+ctrl+escape", "capture-stop"),
     // -- applications.lua: the ungated essentials ---------------------
     //
     // Omarchy's own gate (`o.preinstalled_bindings_enabled()`) is what

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -130,6 +130,8 @@ pub trait Backend {
     fn supports_live_overview(&self) -> bool {
         false
     }
+    /// The backend has the native screenshot and recording selector.
+    fn supports_native_capture(&self) -> bool { false }
     fn show_live_overview(
         &mut self,
         surface: Self::ShellId,

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -64,6 +64,7 @@ calloop = { version = "0.14", features = ["signals"] }
 # Screenshot encoding (see `capture.rs`) - the same rasterizer the
 # theme engine draws with, so no second image stack enters the graph.
 tiny-skia = "0.11"
+cosmic-text = "0.19"
 # Protocol code generation for the one interface no published crate
 # carries: `hyprland-focus-grab-v1` (see `focus_grab.rs` and the XML
 # vendored beside it in `protocols/`). Omarchy's Quickshell desktop

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -506,6 +506,7 @@ impl Backend for WaylandBackend {
     fn supports_live_overview(&self) -> bool {
         true
     }
+    fn supports_native_capture(&self) -> bool { true }
 
     fn show_live_overview(
         &mut self,

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -246,7 +246,7 @@ pub(crate) fn capture_output_png(comp: &mut Compositor, path: &Path) -> Result<(
     // The same scene the frame about to be drawn will submit - cursor
     // included, because "what is the session showing" includes where
     // the pointer is.
-    let (elements, clear_color) = build_scene(
+    let (mut elements, clear_color) = build_scene(
         wm.backend(),
         renderer,
         *pointer_location,
@@ -256,6 +256,9 @@ pub(crate) fn capture_output_png(comp: &mut Compositor, path: &Path) -> Result<(
         // every element stays at the coordinate the ledger holds it at.
         Rect::new(Point::new(0, 0), size),
     );
+    // Diagnostic marker captures what the user sees, including capture chrome.
+    // User exports and protocol screencopy deliberately do not add this layer.
+    crate::capture_tool::render(&mut elements, renderer, wm.backend(), Rect::new(Point::new(0, 0), size));
     let buffer = render_offscreen(renderer, &elements, size, 1.0, clear_color)
         .ok_or_else(|| "offscreen render of the desktop failed".to_string())?;
     write_png(buffer, path)
@@ -272,6 +275,36 @@ fn graphics_renderer(graphics: &mut Graphics) -> &mut GlesRenderer {
         Graphics::Winit(backend) => backend.renderer(),
         Graphics::Session(session) => session.renderer(),
     }
+}
+
+/// A user screenshot is lossless device pixels, without the pointer or capture
+/// controls. Window capture renders that surface and its own chrome in isolation
+/// so overlapping applications cannot appear in the saved window image.
+pub(crate) fn capture_user_pixels(comp: &mut Compositor, viewport: Rect, window: Option<WlWindowId>) -> Option<DecorationBuffer> {
+    if comp.wm.backend().locked || viewport.size.w == 0 || viewport.size.h == 0 { return None; }
+    let Compositor { wm, graphics, pointer_location, cursors, .. } = comp;
+    let renderer = graphics_renderer(graphics);
+    let (elements, clear_color) = if let Some(window) = window {
+        let backend = wm.backend();
+        let record = backend.windows.get(&window).filter(|r| r.mapped)?;
+        let surface = record.surface.wl_surface()?;
+        let mut elements = Vec::new();
+        crate::renderer::push_surface_tree(&mut elements, renderer, &surface,
+            (record.content.pos.x - viewport.pos.x, record.content.pos.y - viewport.pos.y).into(),
+            backend.window_surface_scale(record), 1.0, Kind::Unspecified);
+        for frame in backend.frames.values().filter(|f| f.window == window && f.mapped) {
+            for part in &frame.parts {
+                if let Ok(element) = smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement::from_buffer(
+                    renderer, ((frame.geometry.pos.x + part.offset.x - viewport.pos.x) as f64,
+                        (frame.geometry.pos.y + part.offset.y - viewport.pos.y) as f64),
+                    &part.buffer, None, None, None, Kind::Unspecified) { elements.push(element.into()); }
+            }
+        }
+        (elements, Color32F::new(0.0, 0.0, 0.0, 0.0))
+    } else {
+        build_scene(wm.backend(), renderer, *pointer_location, &smithay::input::pointer::CursorImageStatus::Hidden, cursors, viewport)
+    };
+    render_offscreen(renderer, &elements, viewport.size, 1.0, clear_color)
 }
 
 /// The windows whose snapshot is stale - at most

--- a/crates/wm-wayland/src/capture_tool.rs
+++ b/crates/wm-wayland/src/capture_tool.rs
@@ -1,0 +1,1073 @@
+//! User-facing capture. Selection is compositor-owned; PNG, clipboard and
+//! recorder I/O run on one bounded worker. The overlay is added only to scanout,
+//! never to the scenes exported through screencopy / image-copy-capture.
+
+mod worker;
+
+use std::collections::HashSet;
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::time::Instant;
+
+use smithay::backend::renderer::element::memory::{
+    MemoryRenderBuffer, MemoryRenderBufferRenderElement,
+};
+use smithay::backend::renderer::element::solid::SolidColorRenderElement;
+use smithay::backend::renderer::element::{Id, Kind};
+use smithay::backend::renderer::gles::GlesRenderer;
+use smithay::backend::renderer::utils::CommitCounter;
+use smithay::backend::renderer::Color32F;
+use smithay::input::pointer::CursorImageStatus;
+use smithay::utils::{Physical, Rectangle as SRect};
+use wm_config::CaptureMode;
+use wm_core::{Backend, KeyCombo, Modifiers};
+use wm_theme::model::{Color, FontSpec, FontStyle, FontWeight, TextAlign};
+use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
+
+use crate::renderer::SceneElement;
+use crate::state::{Compositor, StackEntry, WaylandBackend, WlWindowId};
+use worker::{Job, Update};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Mode {
+    Screen,
+    Window,
+    Area,
+    RecordScreen,
+    RecordArea,
+}
+
+impl Mode {
+    fn recording(self) -> bool {
+        matches!(self, Self::RecordScreen | Self::RecordArea)
+    }
+    fn area(self) -> bool {
+        matches!(self, Self::Area | Self::RecordArea)
+    }
+}
+
+pub(crate) struct Overlay {
+    mode: Mode,
+    quick: bool,
+    /// A recording indicator is clickable but must never grab client input.
+    badge: bool,
+    monitor: Rect,
+    selection: Option<Rect>,
+    window: Option<WlWindowId>,
+    drag: Option<(Point, Option<Rect>)>,
+    move_selection: bool,
+    toolbar: Rect,
+    label: Option<MemoryRenderBuffer>,
+    ids: [Id; 16],
+    armed: Option<usize>,
+}
+
+pub(crate) struct Service {
+    jobs: SyncSender<Job>,
+    updates: Receiver<Update>,
+    worker: Option<std::thread::JoinHandle<()>>,
+    fonts: Option<(cosmic_text::FontSystem, cosmic_text::SwashCache)>,
+    buttons: HashSet<u32>,
+    recording: bool,
+    finishing: bool,
+    started: Instant,
+    last_second: u64,
+    screenshots: usize,
+    label_dirty: bool,
+    label_deadline: Instant,
+}
+
+impl Service {
+    pub fn new() -> Self {
+        let (jobs, updates, worker) = worker::start();
+        Self {
+            jobs,
+            updates,
+            worker: Some(worker),
+            fonts: None,
+            buttons: HashSet::new(),
+            recording: false,
+            finishing: false,
+            started: Instant::now(),
+            last_second: 0,
+            screenshots: 0,
+            label_dirty: false,
+            label_deadline: Instant::now(),
+        }
+    }
+
+    fn submit(&self, job: Job) -> bool {
+        if let Err(error) = self.jobs.try_send(job) {
+            tracing::warn!(%error, "capture worker busy; request not queued");
+            return false;
+        }
+        true
+    }
+}
+
+impl Drop for Service {
+    fn drop(&mut self) {
+        // Only at orderly logout, never in the input/render loop. The worker
+        // signals and reaps its own children, preserving unfinished recordings.
+        let _ = self.jobs.send(Job::Shutdown);
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
+        }
+    }
+}
+
+pub(crate) fn modal(backend: &WaylandBackend) -> bool {
+    backend.capture_ui.as_ref().is_some_and(|ui| !ui.badge)
+}
+
+pub(crate) fn crosshair(backend: &WaylandBackend) -> Option<Point> {
+    let ui = backend.capture_ui.as_ref().filter(|ui| !ui.badge)?;
+    backend.pointer.filter(|p| !ui.toolbar.contains(*p))
+}
+
+pub(crate) fn begin(comp: &mut Compositor, mode: CaptureMode) {
+    if mode == CaptureMode::Stop {
+        stop(comp);
+        return;
+    }
+    if comp.wm.backend().locked {
+        return;
+    }
+    if comp.capture_tool.recording || comp.capture_tool.finishing {
+        if mode == CaptureMode::Toolbar {
+            stop(comp);
+        }
+        return;
+    }
+    if modal(comp.wm.backend()) {
+        dismiss(comp);
+        return;
+    }
+    // Never steal an existing modal session or a drag's held buttons.
+    if comp.wm.backend().keyboard_grabbed
+        || comp.wm.backend().pointer_grab.is_some()
+        || comp.wm.interactive_drag_active()
+        || crate::input::capture_pointer_busy(&comp.seat)
+        || comp.focus_grab.is_active()
+        || comp.layer_shell.exclusive_focus.is_some()
+        || comp.seat.get_pointer().is_some_and(|p| p.is_grabbed())
+    {
+        return;
+    }
+    if mode == CaptureMode::Screen {
+        let rect = Rect::new(Point::new(0, 0), comp.wm.backend().output_size);
+        photograph(comp, rect, None);
+        return;
+    }
+    let at = pointer(comp);
+    let Some(monitor) = comp
+        .wm
+        .backend()
+        .monitors
+        .iter()
+        .find(|m| m.geometry.contains(at))
+        .or_else(|| comp.wm.backend().monitors.first())
+        .map(|m| m.geometry)
+    else {
+        return;
+    };
+    let scale = comp.wm.backend().scale_at(monitor).clamp(1.0, 3.0) as f32;
+    let width = (720.0 * scale).min(monitor.size.w.saturating_sub(16) as f32) as u32;
+    let height = (86.0 * scale) as u32;
+    let toolbar = Rect::new(
+        Point::new(
+            monitor.pos.x + (monitor.size.w - width) as i32 / 2,
+            monitor.pos.y + monitor.size.h as i32 - height as i32 - (24.0 * scale) as i32,
+        ),
+        Size::new(width, height),
+    );
+    let selected_mode = if mode == CaptureMode::Window {
+        Mode::Window
+    } else {
+        Mode::Area
+    };
+    comp.wm.backend_mut().capture_ui = Some(Overlay {
+        mode: selected_mode,
+        quick: mode != CaptureMode::Toolbar,
+        badge: false,
+        monitor,
+        selection: None,
+        window: None,
+        drag: None,
+        move_selection: false,
+        toolbar,
+        label: None,
+        ids: std::array::from_fn(|_| Id::new()),
+        armed: None,
+    });
+    crate::input::release_pointer_constraint(comp);
+    comp.wm.backend_mut().grab_keyboard();
+    crate::input::reset_client_input_focus(comp);
+    comp.cursor_status = CursorImageStatus::default_named();
+    motion(comp, at);
+    repaint(comp);
+}
+
+fn pointer(comp: &Compositor) -> Point {
+    Point::new(
+        comp.pointer_location.x.floor() as i32,
+        comp.pointer_location.y.floor() as i32,
+    )
+}
+
+fn dismiss(comp: &mut Compositor) {
+    let was_modal = modal(comp.wm.backend());
+    comp.wm.backend_mut().capture_ui = None;
+    if was_modal {
+        comp.wm.backend_mut().ungrab_keyboard();
+    }
+    comp.wm.backend_mut().mark_damaged();
+    crate::input::sync_pointer_focus(comp);
+}
+
+fn photograph(comp: &mut Compositor, rect: Rect, window: Option<WlWindowId>) -> bool {
+    // Bound readback memory as well as worker queue length, including the image
+    // currently being encoded. Repeated shortcuts cannot accumulate 4K buffers.
+    if comp.capture_tool.screenshots >= 2 {
+        comp.capture_tool.submit(Job::Error(
+            "Finishing previous screenshots; please try again shortly".into(),
+        ));
+        return false;
+    }
+    match crate::capture::capture_user_pixels(comp, rect, window) {
+        Some(pixels) => {
+            if comp.capture_tool.submit(Job::Screenshot(pixels)) {
+                comp.capture_tool.screenshots += 1;
+                return true;
+            }
+        }
+        None => {
+            comp.capture_tool
+                .submit(Job::Error("Could not capture the selected pixels".into()));
+        }
+    }
+    false
+}
+
+fn commit(comp: &mut Compositor) {
+    let Some(ui) = comp.wm.backend().capture_ui.as_ref() else {
+        return;
+    };
+    let mode = ui.mode;
+    let Some(rect) = ui.selection.filter(|r| r.size.w > 0 && r.size.h > 0) else {
+        return;
+    };
+    let window = ui.window;
+    if mode.recording() {
+        // wf-recorder owns one output. Refuse a cross-output selection rather
+        // than silently cutting off the part on the other monitor.
+        let output = comp
+            .wm
+            .backend()
+            .monitors
+            .iter()
+            .find(|m| contains_rect(m.geometry, rect))
+            .map(|m| (m.name.clone(), m.geometry));
+        let Some((output, monitor)) = output else {
+            comp.capture_tool.submit(Job::Error(
+                "Keep a recording area inside one display".into(),
+            ));
+            return;
+        };
+        let Some(entry) = comp
+            .outputs
+            .iter()
+            .find(|entry| entry.position == monitor.pos)
+        else {
+            return;
+        };
+        let Some((geometry, filter)) = recording_region(
+            rect,
+            monitor,
+            entry.output.current_scale().integer_scale(),
+            entry.transform,
+        ) else {
+            comp.capture_tool.submit(Job::Error(
+                "This recording region cannot be represented by the output's capture grid".into(),
+            ));
+            return;
+        };
+        if comp.capture_tool.submit(Job::Record {
+            output,
+            geometry,
+            filter,
+        }) {
+            dismiss(comp);
+            comp.capture_tool.recording = true;
+            comp.capture_tool.started = Instant::now();
+            comp.capture_tool.last_second = 0;
+            let scale = comp.wm.backend().scale_at(monitor).clamp(1.0, 3.0);
+            let width = ((280.0 * scale) as u32).min(monitor.size.w);
+            comp.wm.backend_mut().capture_ui = Some(Overlay {
+                mode,
+                quick: false,
+                badge: true,
+                monitor,
+                selection: None,
+                window: None,
+                drag: None,
+                move_selection: false,
+                toolbar: Rect::new(
+                    Point::new(
+                        monitor.pos.x + (monitor.size.w - width) as i32 / 2,
+                        monitor.pos.y + (12.0 * scale) as i32,
+                    ),
+                    Size::new(width, (42.0 * scale) as u32),
+                ),
+                label: None,
+                ids: std::array::from_fn(|_| Id::new()),
+                armed: None,
+            });
+            repaint(comp);
+        }
+    } else if photograph(comp, rect, window) {
+        dismiss(comp);
+    }
+}
+
+fn stop(comp: &mut Compositor) {
+    if comp.capture_tool.recording
+        && !comp.capture_tool.finishing
+        && comp.capture_tool.submit(Job::Stop)
+    {
+        comp.capture_tool.finishing = true;
+        repaint(comp);
+    }
+}
+
+pub(crate) fn key(comp: &mut Compositor, combo: &KeyCombo) -> bool {
+    if !modal(comp.wm.backend()) {
+        return false;
+    }
+    if combo.modifiers.contains(Modifiers::SUPER) {
+        if let Some(chonk_shell::shell::KeyResolution::Action(wm_config::Action::Capture(mode))) =
+            comp.shell.keymap_action(combo)
+        {
+            begin(comp, mode);
+            return true;
+        }
+    }
+    match combo.keysym {
+        0xff1b => dismiss(comp), // Escape, including during a held drag.
+        0xff0d | 0xff8d => commit(comp),
+        0x20 => {
+            let at = pointer(comp);
+            let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
+            if ui.drag.is_some() {
+                ui.move_selection = !ui.move_selection;
+                ui.drag = Some((at, ui.selection));
+            } else {
+                set_mode(
+                    comp,
+                    if comp.wm.backend().capture_ui.as_ref().unwrap().mode == Mode::Window {
+                        Mode::Area
+                    } else {
+                        Mode::Window
+                    },
+                );
+            }
+        }
+        0x31..=0x35 => set_mode(
+            comp,
+            [
+                Mode::Screen,
+                Mode::Window,
+                Mode::Area,
+                Mode::RecordScreen,
+                Mode::RecordArea,
+            ][(combo.keysym - 0x31) as usize],
+        ),
+        0xff51..=0xff54 => {
+            if let Some(ui) = comp
+                .wm
+                .backend_mut()
+                .capture_ui
+                .as_mut()
+                .filter(|ui| ui.mode.area())
+            {
+                let step = if combo.modifiers.contains(Modifiers::SHIFT) {
+                    10
+                } else {
+                    1
+                };
+                let (dx, dy) = match combo.keysym {
+                    0xff51 => (-step, 0),
+                    0xff52 => (0, -step),
+                    0xff53 => (step, 0),
+                    _ => (0, step),
+                };
+                ui.selection = ui.selection.map(|r| moved_rect(r, dx, dy, ui.monitor));
+            }
+            repaint(comp);
+        }
+        _ => {}
+    }
+    true
+}
+
+fn set_mode(comp: &mut Compositor, mode: Mode) {
+    if let Some(ui) = comp.wm.backend_mut().capture_ui.as_mut() {
+        ui.mode = mode;
+        ui.selection = matches!(mode, Mode::Screen | Mode::RecordScreen).then_some(ui.monitor);
+        ui.window = None;
+        ui.drag = None;
+    }
+    motion(comp, pointer(comp));
+    repaint(comp);
+}
+
+/// Returns true only when the capture UI owns this motion.
+pub(crate) fn motion(comp: &mut Compositor, at: Point) -> bool {
+    if !modal(comp.wm.backend()) {
+        return false;
+    }
+    if comp
+        .wm
+        .backend()
+        .capture_ui
+        .as_ref()
+        .is_some_and(|ui| ui.toolbar.contains(at) && ui.drag.is_none())
+    {
+        return true;
+    }
+    let window = hovered_window(comp.wm.backend(), at);
+    let monitor = comp
+        .wm
+        .backend()
+        .monitors
+        .iter()
+        .find(|m| m.geometry.contains(at))
+        .map(|m| m.geometry);
+    let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
+    let previous = ui.selection;
+    match ui.mode {
+        Mode::Window => {
+            ui.window = window.map(|(id, _)| id);
+            ui.selection = window.map(|(_, r)| r);
+        }
+        Mode::Screen | Mode::RecordScreen => {
+            ui.selection = monitor;
+        }
+        Mode::Area | Mode::RecordArea => {
+            if let Some((anchor, original)) = ui.drag {
+                ui.selection = if ui.move_selection {
+                    original.map(|r| moved_rect(r, at.x - anchor.x, at.y - anchor.y, ui.monitor))
+                } else {
+                    Some(drag_rect(anchor, at))
+                };
+            }
+        }
+    }
+    if previous != ui.selection {
+        comp.capture_tool.label_dirty = true;
+    }
+    comp.wm.backend_mut().mark_damaged();
+    true
+}
+
+pub(crate) fn button(comp: &mut Compositor, code: u32, pressed: bool) -> bool {
+    let at = pointer(comp);
+    let capture_hit = comp
+        .wm
+        .backend()
+        .capture_ui
+        .as_ref()
+        .is_some_and(|ui| !ui.badge || ui.toolbar.contains(at));
+    let held = comp.capture_tool.buttons.contains(&code);
+    if !capture_hit && !held {
+        return false;
+    }
+    if pressed {
+        comp.capture_tool.buttons.insert(code);
+    } else {
+        comp.capture_tool.buttons.remove(&code);
+    }
+    let Some(ui) = comp.wm.backend().capture_ui.as_ref() else {
+        return true;
+    };
+    if ui.badge {
+        if code == 0x110 && !pressed && held && capture_hit {
+            stop(comp);
+        }
+        return true;
+    }
+    if code == 0x111 && pressed {
+        dismiss(comp);
+        return true;
+    }
+    if code != 0x110 {
+        return true;
+    }
+    let hit = toolbar_hit(ui, at);
+    if pressed {
+        let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
+        ui.armed = hit;
+        if hit.is_none() && ui.mode.area() {
+            let corner = ui
+                .selection
+                .and_then(|r| resize_anchor(r, at, (ui.toolbar.size.h / 10).max(6) as i32));
+            let original = ui.selection.filter(|r| r.contains(at) && corner.is_none());
+            ui.move_selection = original.is_some();
+            ui.drag = Some((corner.unwrap_or(at), original));
+            if original.is_none() && corner.is_none() {
+                ui.selection = None;
+            }
+        }
+    } else {
+        let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
+        let armed = ui.armed.take();
+        ui.drag = None;
+        if let Some(index) = hit.filter(|h| Some(*h) == armed) {
+            match index {
+                0 => dismiss(comp),
+                1..=5 => set_mode(
+                    comp,
+                    [
+                        Mode::Screen,
+                        Mode::Window,
+                        Mode::Area,
+                        Mode::RecordScreen,
+                        Mode::RecordArea,
+                    ][index - 1],
+                ),
+                _ => commit(comp),
+            }
+        } else if armed.is_none() && ui.quick {
+            commit(comp);
+        }
+    }
+    repaint(comp);
+    true
+}
+
+fn toolbar_hit(ui: &Overlay, at: Point) -> Option<usize> {
+    ui.toolbar
+        .contains(at)
+        .then(|| (((at.x - ui.toolbar.pos.x) as u32 * 7 / ui.toolbar.size.w) as usize).min(6))
+}
+
+fn hovered_window(backend: &WaylandBackend, at: Point) -> Option<(WlWindowId, Rect)> {
+    backend.stacking.iter().rev().find_map(|entry| {
+        let (window, rect) = match entry {
+            StackEntry::Window(id) => (*id, backend.windows.get(id)?.content),
+            StackEntry::Frame(id) => {
+                let frame = backend.frames.get(id)?;
+                if !frame.mapped {
+                    return None;
+                }
+                (frame.window, frame.geometry)
+            }
+        };
+        backend
+            .windows
+            .get(&window)
+            .filter(|r| r.mapped && rect.contains(at))
+            .map(|_| (window, rect))
+    })
+}
+
+fn contains_rect(outer: Rect, inner: Rect) -> bool {
+    inner.pos.x >= outer.pos.x
+        && inner.pos.y >= outer.pos.y
+        && inner.pos.x as i64 + inner.size.w as i64 <= outer.pos.x as i64 + outer.size.w as i64
+        && inner.pos.y as i64 + inner.size.h as i64 <= outer.pos.y as i64 + outer.size.h as i64
+}
+
+/// Request an even, output-logical enclosure, then crop in physical pixels.
+/// wf-recorder truncates odd SHM buffers before filtering. Expanding the request
+/// first preserves the last selected row/column; padding then makes H.264 happy.
+fn recording_region(
+    rect: Rect,
+    output: Rect,
+    scale: i32,
+    transform: smithay::utils::Transform,
+) -> Option<(String, String)> {
+    use smithay::utils::Transform;
+    if !contains_rect(output, rect) || scale < 1 {
+        return None;
+    }
+    let axis = |start: i32, size: u32, limit: u32| {
+        let quantum = if scale % 2 == 0 { scale } else { scale * 2 };
+        let mut first = start / quantum * quantum;
+        let mut end = ((start + size as i32 + quantum - 1) / quantum) * quantum;
+        if end > limit as i32 {
+            end = limit as i32 / quantum * quantum;
+            if end < start + size as i32 {
+                return None;
+            }
+        }
+        if end <= first {
+            first = end - quantum;
+        }
+        Some((first / scale, (end - first) / scale, start - first))
+    };
+    let (x, w, crop_x) = axis(rect.pos.x - output.pos.x, rect.size.w, output.size.w)?;
+    let (y, h, crop_y) = axis(rect.pos.y - output.pos.y, rect.size.h, output.size.h)?;
+    let orientation = match transform {
+        Transform::Normal => "",
+        Transform::_90 => "transpose=1,",
+        Transform::_180 => "hflip,vflip,",
+        Transform::_270 => "transpose=2,",
+        Transform::Flipped => "hflip,",
+        Transform::Flipped90 => "transpose=1,hflip,",
+        Transform::Flipped180 => "vflip,",
+        Transform::Flipped270 => "transpose=2,hflip,",
+    };
+    // An explicit transform in -F disables wf-recorder's automatic transform;
+    // normalizing BEFORE crop keeps the same coordinates on rotated displays.
+    Some((
+        format!("{},{} {w}x{h}", output.pos.x + x, output.pos.y + y),
+        format!(
+            "{orientation}crop={}:{}:{crop_x}:{crop_y}:exact=1,pad=ceil(iw/2)*2:ceil(ih/2)*2",
+            rect.size.w, rect.size.h
+        ),
+    ))
+}
+
+fn drag_rect(a: Point, b: Point) -> Rect {
+    Rect::new(
+        Point::new(a.x.min(b.x), a.y.min(b.y)),
+        Size::new(a.x.abs_diff(b.x), a.y.abs_diff(b.y)),
+    )
+}
+
+fn resize_anchor(rect: Rect, at: Point, radius: i32) -> Option<Point> {
+    let right = rect.pos.x + rect.size.w as i32;
+    let bottom = rect.pos.y + rect.size.h as i32;
+    [
+        (rect.pos, Point::new(right, bottom)),
+        (
+            Point::new(right, rect.pos.y),
+            Point::new(rect.pos.x, bottom),
+        ),
+        (
+            Point::new(rect.pos.x, bottom),
+            Point::new(right, rect.pos.y),
+        ),
+        (Point::new(right, bottom), rect.pos),
+    ]
+    .into_iter()
+    .find(|(p, _)| p.x.abs_diff(at.x) <= radius as u32 && p.y.abs_diff(at.y) <= radius as u32)
+    .map(|(_, anchor)| anchor)
+}
+
+fn moved_rect(mut rect: Rect, dx: i32, dy: i32, bounds: Rect) -> Rect {
+    rect.pos.x = (rect.pos.x + dx).clamp(
+        bounds.pos.x,
+        bounds.pos.x + bounds.size.w.saturating_sub(rect.size.w) as i32,
+    );
+    rect.pos.y = (rect.pos.y + dy).clamp(
+        bounds.pos.y,
+        bounds.pos.y + bounds.size.h.saturating_sub(rect.size.h) as i32,
+    );
+    rect
+}
+
+pub(crate) fn tick(comp: &mut Compositor) {
+    if comp.capture_tool.label_dirty && Instant::now() >= comp.capture_tool.label_deadline {
+        repaint(comp);
+    }
+    if modal(comp.wm.backend())
+        && (comp.layer_shell.exclusive_focus.is_some() || comp.focus_grab.is_active())
+    {
+        dismiss(comp);
+    }
+    if comp.wm.backend().locked {
+        if modal(comp.wm.backend()) {
+            dismiss(comp);
+        }
+        stop(comp);
+    }
+    while let Ok(update) = comp.capture_tool.updates.try_recv() {
+        match update {
+            Update::ScreenshotDone => {
+                comp.capture_tool.screenshots = comp.capture_tool.screenshots.saturating_sub(1);
+            }
+            Update::RecordingEnded => {
+                comp.capture_tool.recording = false;
+                comp.capture_tool.finishing = false;
+                dismiss(comp);
+            }
+        }
+    }
+    if comp.capture_tool.recording {
+        let second = comp.capture_tool.started.elapsed().as_secs();
+        if second != comp.capture_tool.last_second {
+            comp.capture_tool.last_second = second;
+            repaint(comp);
+        }
+    }
+    // Output removal/resize cancels stale selection coordinates immediately.
+    if comp.wm.backend().capture_ui.as_ref().is_some_and(|ui| {
+        !ui.badge
+            && !comp
+                .wm
+                .backend()
+                .monitors
+                .iter()
+                .any(|m| m.geometry == ui.monitor)
+    }) {
+        dismiss(comp);
+    }
+}
+
+fn repaint(comp: &mut Compositor) {
+    comp.capture_tool.label_dirty = false;
+    comp.capture_tool.label_deadline = Instant::now() + std::time::Duration::from_millis(33);
+    let Some(ui) = comp.wm.backend_mut().capture_ui.as_mut() else {
+        return;
+    };
+    let (fonts, cache) = comp.capture_tool.fonts.get_or_insert_with(|| {
+        (
+            cosmic_text::FontSystem::new(),
+            cosmic_text::SwashCache::new(),
+        )
+    });
+    let Some(mut pixmap) = tiny_skia::Pixmap::new(ui.toolbar.size.w, ui.toolbar.size.h) else {
+        return;
+    };
+    let scale = ui.toolbar.size.h as f32 / if ui.badge { 42.0 } else { 86.0 };
+    let font = FontSpec {
+        family: "sans-serif".into(),
+        size: 12.0 * scale,
+        weight: FontWeight::Normal,
+        style: FontStyle::Normal,
+    };
+    let mut paint = tiny_skia::Paint::default();
+    paint.set_color_rgba8(24, 27, 33, 246);
+    if let Some(path) = rounded_rect(
+        ui.toolbar.size.w as f32,
+        ui.toolbar.size.h as f32,
+        12.0 * scale,
+    ) {
+        pixmap.fill_path(
+            &path,
+            &paint,
+            tiny_skia::FillRule::Winding,
+            tiny_skia::Transform::identity(),
+            None,
+        );
+    }
+    if ui.badge {
+        let secs = comp.capture_tool.started.elapsed().as_secs();
+        let text = if comp.capture_tool.finishing {
+            "Finishing recording…".into()
+        } else {
+            format!("●  {:02}:{:02}     ■  Stop recording", secs / 60, secs % 60)
+        };
+        wm_theme::paint::draw_text(
+            &mut pixmap,
+            fonts,
+            cache,
+            &text,
+            &font,
+            Color::rgb(255, 170, 170),
+            4,
+            0,
+            ui.toolbar.size.w - 8,
+            ui.toolbar.size.h,
+            TextAlign::Center,
+        );
+    } else {
+        let labels = [
+            "×  Close",
+            "1  Screen",
+            "2  Window",
+            "3  Area",
+            "4  Record",
+            "5  Rec area",
+            if ui.mode.recording() {
+                "Record"
+            } else {
+                "Capture"
+            },
+        ];
+        let selected = match ui.mode {
+            Mode::Screen => 1,
+            Mode::Window => 2,
+            Mode::Area => 3,
+            Mode::RecordScreen => 4,
+            Mode::RecordArea => 5,
+        };
+        let width = ui.toolbar.size.w / 7;
+        for (i, label) in labels.iter().enumerate() {
+            let x = i as i32 * width as i32;
+            if i == selected || i == 6 {
+                wm_theme::paint::fill_rect(
+                    &mut pixmap,
+                    x + 4,
+                    (10.0 * scale) as i32,
+                    width.saturating_sub(8),
+                    (34.0 * scale) as u32,
+                    if i == 6 && ui.selection.is_some_and(|r| r.size.w > 0 && r.size.h > 0) {
+                        Color::rgb(50, 107, 188)
+                    } else {
+                        Color::rgb(61, 66, 77)
+                    },
+                );
+            }
+            wm_theme::paint::draw_text(
+                &mut pixmap,
+                fonts,
+                cache,
+                label,
+                &font,
+                Color::rgb(246, 247, 249),
+                x,
+                (8.0 * scale) as i32,
+                width,
+                (38.0 * scale) as u32,
+                TextAlign::Center,
+            );
+        }
+        let dimensions = ui
+            .selection
+            .map(|r| format!("{} × {} px  ·  ", r.size.w, r.size.h))
+            .unwrap_or_default();
+        let hint = format!(
+            "{dimensions}Drag to select · Space: window / area · Enter: capture · Esc: cancel"
+        );
+        let font = FontSpec {
+            size: 11.0 * scale,
+            ..font
+        };
+        wm_theme::paint::draw_text(
+            &mut pixmap,
+            fonts,
+            cache,
+            &hint,
+            &font,
+            Color::rgb(176, 183, 196),
+            8,
+            (48.0 * scale) as i32,
+            ui.toolbar.size.w.saturating_sub(16),
+            (30.0 * scale) as u32,
+            TextAlign::Center,
+        );
+    }
+    ui.label = crate::backend_impl::import_buffer(
+        &DecorationBuffer {
+            width: pixmap.width(),
+            height: pixmap.height(),
+            pixels: pixmap.take(),
+        },
+        false,
+    );
+    comp.wm.backend_mut().mark_damaged();
+}
+
+fn rounded_rect(w: f32, h: f32, r: f32) -> Option<tiny_skia::Path> {
+    let mut p = tiny_skia::PathBuilder::new();
+    p.move_to(r, 0.0);
+    p.line_to(w - r, 0.0);
+    p.quad_to(w, 0.0, w, r);
+    p.line_to(w, h - r);
+    p.quad_to(w, h, w - r, h);
+    p.line_to(r, h);
+    p.quad_to(0.0, h, 0.0, h - r);
+    p.line_to(0.0, r);
+    p.quad_to(0.0, 0.0, r, 0.0);
+    p.close();
+    p.finish()
+}
+
+/// Scanout-only overlay. Stable solid IDs keep selection damage sparse; no
+/// monitor-sized CPU images are allocated while the pointer moves.
+pub(crate) fn render(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    viewport: Rect,
+) {
+    if backend.locked {
+        return;
+    }
+    let Some(ui) = backend.capture_ui.as_ref() else {
+        return;
+    };
+    let mut overlay = Vec::with_capacity(10);
+    if let Some(at) = crosshair(backend) {
+        for (i, (x, y, w, h)) in [
+            (at.x - 10, at.y - 1, 21, 3),
+            (at.x - 1, at.y - 10, 3, 21),
+            (at.x - 10, at.y, 21, 1),
+            (at.x, at.y - 10, 1, 21),
+        ]
+        .into_iter()
+        .enumerate()
+        .rev()
+        {
+            overlay.push(
+                SolidColorRenderElement::new(
+                    ui.ids[8 + i].clone(),
+                    SRect::<i32, Physical>::new(
+                        (x - viewport.pos.x, y - viewport.pos.y).into(),
+                        (w, h).into(),
+                    ),
+                    CommitCounter::default(),
+                    if i < 2 {
+                        Color32F::new(0.0, 0.0, 0.0, 1.0)
+                    } else {
+                        Color32F::new(1.0, 1.0, 1.0, 1.0)
+                    },
+                    Kind::Cursor,
+                )
+                .into(),
+            );
+        }
+    }
+    if let Some(buffer) = &ui.label {
+        if let Ok(element) = MemoryRenderBufferRenderElement::from_buffer(
+            renderer,
+            (
+                (ui.toolbar.pos.x - viewport.pos.x) as f64,
+                (ui.toolbar.pos.y - viewport.pos.y) as f64,
+            ),
+            buffer,
+            None,
+            None,
+            None,
+            Kind::Unspecified,
+        ) {
+            overlay.push(element.into());
+        }
+    }
+    if !ui.badge {
+        let selection = ui
+            .selection
+            .unwrap_or(Rect::new(viewport.pos, Size::new(0, 0)));
+        let x1 = selection
+            .pos
+            .x
+            .clamp(viewport.pos.x, viewport.pos.x + viewport.size.w as i32);
+        let y1 = selection
+            .pos
+            .y
+            .clamp(viewport.pos.y, viewport.pos.y + viewport.size.h as i32);
+        let x2 = (selection.pos.x + selection.size.w as i32)
+            .clamp(x1, viewport.pos.x + viewport.size.w as i32);
+        let y2 = (selection.pos.y + selection.size.h as i32)
+            .clamp(y1, viewport.pos.y + viewport.size.h as i32);
+        let right = viewport.pos.x + viewport.size.w as i32;
+        let bottom = viewport.pos.y + viewport.size.h as i32;
+        let rects = [
+            (
+                viewport.pos.x,
+                viewport.pos.y,
+                viewport.size.w,
+                (y1 - viewport.pos.y) as u32,
+            ),
+            (viewport.pos.x, y2, viewport.size.w, (bottom - y2) as u32),
+            (
+                viewport.pos.x,
+                y1,
+                (x1 - viewport.pos.x) as u32,
+                (y2 - y1) as u32,
+            ),
+            (x2, y1, (right - x2) as u32, (y2 - y1) as u32),
+            (x1, y1, (x2 - x1) as u32, 1),
+            (x1, y2, (x2 - x1) as u32, 1),
+            (x1, y1, 1, (y2 - y1) as u32),
+            (x2, y1, 1, (y2 - y1) as u32),
+        ];
+        for (i, (x, y, w, h)) in rects.into_iter().enumerate() {
+            if w == 0 || h == 0 {
+                continue;
+            }
+            overlay.push(
+                SolidColorRenderElement::new(
+                    ui.ids[i].clone(),
+                    SRect::<i32, Physical>::new(
+                        (x - viewport.pos.x, y - viewport.pos.y).into(),
+                        (w as i32, h as i32).into(),
+                    ),
+                    CommitCounter::default(),
+                    if i < 4 {
+                        Color32F::new(0.0, 0.0, 0.0, 0.42)
+                    } else {
+                        Color32F::new(1.0, 1.0, 1.0, 0.95)
+                    },
+                    Kind::Unspecified,
+                )
+                .into(),
+            );
+        }
+        if ui.mode.area() && ui.selection.is_some() && !ui.quick {
+            for (i, (x, y)) in [(x1, y1), (x2, y1), (x1, y2), (x2, y2)]
+                .into_iter()
+                .enumerate()
+            {
+                overlay.push(
+                    SolidColorRenderElement::new(
+                        ui.ids[12 + i].clone(),
+                        SRect::<i32, Physical>::new(
+                            (x - viewport.pos.x - 3, y - viewport.pos.y - 3).into(),
+                            (7, 7).into(),
+                        ),
+                        CommitCounter::default(),
+                        Color32F::new(1.0, 1.0, 1.0, 1.0),
+                        Kind::Unspecified,
+                    )
+                    .into(),
+                );
+            }
+        }
+    }
+    elements.splice(0..0, overlay);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn area_is_direction_independent_and_half_open() {
+        let expected = Rect::new(Point::new(5, 8), Size::new(101, 53));
+        assert_eq!(drag_rect(Point::new(106, 8), Point::new(5, 61)), expected);
+        assert_eq!(drag_rect(Point::new(5, 61), Point::new(106, 8)), expected);
+        assert_eq!(
+            drag_rect(Point::new(5, 8), Point::new(5, 8)).size,
+            Size::new(0, 0)
+        );
+    }
+    #[test]
+    fn recording_cannot_silently_cross_outputs() {
+        let output = Rect::new(Point::new(1920, 0), Size::new(2560, 1440));
+        assert!(contains_rect(output, output));
+        assert!(!contains_rect(
+            output,
+            Rect::new(Point::new(1919, 0), Size::new(100, 100))
+        ));
+        assert!(!contains_rect(
+            output,
+            Rect::new(Point::new(4400, 0), Size::new(100, 100))
+        ));
+    }
+    #[test]
+    fn moving_selection_preserves_pixels_and_stays_visible() {
+        let bounds = Rect::new(Point::new(1920, 0), Size::new(1280, 720));
+        let rect = Rect::new(Point::new(2100, 50), Size::new(101, 53));
+        let moved = moved_rect(rect, 4000, -1000, bounds);
+        assert_eq!(moved.size, rect.size);
+        assert!(contains_rect(bounds, moved));
+    }
+
+    #[test]
+    fn recorder_region_encloses_device_pixels_before_crop_and_padding() {
+        let output = Rect::new(Point::new(1920, 0), Size::new(2560, 1440));
+        let selected = Rect::new(Point::new(1971, 41), Size::new(301, 201));
+        let (geometry, filter) =
+            recording_region(selected, output, 2, smithay::utils::Transform::Flipped180).unwrap();
+        assert_eq!(geometry, "1945,20 151x101");
+        assert_eq!(
+            filter,
+            "vflip,crop=301:201:1:1:exact=1,pad=ceil(iw/2)*2:ceil(ih/2)*2"
+        );
+        let (geometry, _) =
+            recording_region(selected, output, 1, smithay::utils::Transform::Normal).unwrap();
+        assert_eq!(geometry, "1970,40 302x202");
+    }
+}

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -1,0 +1,390 @@
+//! All filesystem and child-process work stays away from the compositor loop.
+// Every blocking method in this module runs on its single dedicated I/O worker;
+// no renderer, input callback or shell tick waits for these children.
+#![allow(clippy::disallowed_methods)]
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use wm_theme_api::DecorationBuffer;
+
+pub(super) enum Job {
+    Screenshot(DecorationBuffer),
+    Record {
+        output: String,
+        geometry: String,
+        filter: String,
+    },
+    Stop,
+    Error(String),
+    Shutdown,
+}
+
+pub(super) enum Update {
+    RecordingEnded,
+    ScreenshotDone,
+}
+
+struct Recording {
+    child: Child,
+    partial: PathBuf,
+    destination: PathBuf,
+    log: PathBuf,
+}
+
+pub(super) fn start() -> (
+    SyncSender<Job>,
+    Receiver<Update>,
+    std::thread::JoinHandle<()>,
+) {
+    let (sender, jobs) = mpsc::sync_channel(2);
+    let (updates, receiver) = mpsc::sync_channel(8);
+    let worker = std::thread::spawn(move || {
+        let mut recording: Option<Recording> = None;
+        let mut clipboard: Option<Child> = None;
+        loop {
+            match jobs.recv_timeout(Duration::from_millis(100)) {
+                Ok(Job::Screenshot(pixels)) => {
+                    match screenshot(pixels, &mut clipboard) {
+                        Ok((path, copied)) => notify(
+                            if copied {
+                                "Screenshot saved and copied"
+                            } else {
+                                "Screenshot saved (clipboard unavailable)"
+                            },
+                            &path.display().to_string(),
+                        ),
+                        Err(error) => notify("Screenshot failed", &error),
+                    }
+                    let _ = updates.try_send(Update::ScreenshotDone);
+                }
+                Ok(Job::Record {
+                    output,
+                    geometry,
+                    filter,
+                }) => {
+                    if recording.is_none() {
+                        match record(&output, &geometry, &filter) {
+                            Ok(child) => recording = Some(child),
+                            Err(error) => {
+                                notify("Recording could not start", &error);
+                                let _ = updates.try_send(Update::RecordingEnded);
+                            }
+                        }
+                    }
+                }
+                Ok(Job::Stop) => {
+                    if let Some(active) = recording.take() {
+                        finish(active);
+                    }
+                    let _ = updates.try_send(Update::RecordingEnded);
+                }
+                Ok(Job::Error(error)) => notify("Capture", &error),
+                Ok(Job::Shutdown) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    if let Some(active) = recording.take() {
+                        finish(active);
+                    }
+                    if let Some(mut child) = clipboard.take() {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                    }
+                    break;
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {}
+            }
+            let exited = recording
+                .as_mut()
+                .is_some_and(|r| !matches!(r.child.try_wait(), Ok(None)));
+            if exited {
+                if let Some(mut active) = recording.take() {
+                    let _ = active.child.wait();
+                    notify(
+                        "Recording stopped unexpectedly",
+                        &format!(
+                            "Recoverable file: {}\nDetails: {}",
+                            active.partial.display(),
+                            active.log.display()
+                        ),
+                    );
+                }
+                let _ = updates.try_send(Update::RecordingEnded);
+            }
+            if clipboard
+                .as_mut()
+                .is_some_and(|c| !matches!(c.try_wait(), Ok(None)))
+            {
+                clipboard = None;
+            }
+        }
+    });
+    (sender, receiver, worker)
+}
+
+fn notify(title: &str, message: &str) {
+    tracing::info!(title, message, "capture result");
+    if let Ok(mut child) = Command::new("notify-send")
+        .args([
+            "--app-name=Chonkstep Capture",
+            "--icon=camera-photo",
+            title,
+            message,
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        let _ = wait_child(&mut child, Duration::from_secs(2));
+    }
+}
+
+fn directory(recording: bool) -> Result<PathBuf, String> {
+    let override_key = if recording {
+        "OMARCHY_SCREENRECORD_DIR"
+    } else {
+        "OMARCHY_SCREENSHOT_DIR"
+    };
+    if let Some(path) = std::env::var_os(override_key).filter(|s| !s.is_empty()) {
+        let path = PathBuf::from(path);
+        return path
+            .is_absolute()
+            .then_some(path)
+            .ok_or_else(|| format!("{override_key} must be an absolute directory path"));
+    }
+    let kind = if recording { "VIDEOS" } else { "PICTURES" };
+    let base = Command::new("xdg-user-dir")
+        .arg(kind)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| PathBuf::from(s.trim()))
+        .filter(|p| p.is_absolute());
+    let base = base
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(|home| PathBuf::from(home).join(if recording { "Videos" } else { "Pictures" }))
+        })
+        .ok_or_else(|| "No home or capture directory is configured".to_string())?;
+    Ok(base.join(if recording {
+        "Recordings"
+    } else {
+        "Screenshots"
+    }))
+}
+
+/// Reserve a unique, private temporary file on the destination filesystem.
+/// Publishing uses a hard link (no replacement), so concurrent captures cannot
+/// overwrite an existing screenshot even if clocks move backwards.
+fn paths(recording: bool, extension: &str) -> Result<(PathBuf, PathBuf, File), String> {
+    let directory = directory(recording)?;
+    std::fs::create_dir_all(&directory).map_err(|e| e.to_string())?;
+    let stamp = Command::new("date")
+        .arg("+%Y-%m-%d at %H.%M.%S")
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_owned())
+        .unwrap_or_else(|| "capture".into());
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let name = format!(
+        "{} {stamp}-{unique}",
+        if recording { "Recording" } else { "Screenshot" }
+    );
+    let destination = directory.join(format!("{name}.{extension}"));
+    let partial = directory.join(format!(
+        ".{name}.partial.{}",
+        if recording { "mkv" } else { "png" }
+    ));
+    let file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&partial)
+        .map_err(|e| e.to_string())?;
+    Ok((partial, destination, file))
+}
+
+fn screenshot(
+    pixels: DecorationBuffer,
+    clipboard: &mut Option<Child>,
+) -> Result<(PathBuf, bool), String> {
+    let size =
+        tiny_skia::IntSize::from_wh(pixels.width, pixels.height).ok_or("Empty screenshot")?;
+    let image = tiny_skia::Pixmap::from_vec(pixels.pixels, size)
+        .ok_or("Invalid screenshot pixel length")?;
+    // tiny-skia's PNG encoder unpremultiplies alpha; transparent window edges
+    // must not be saved as dark halos.
+    let png = image.encode_png().map_err(|e| e.to_string())?;
+    let (partial, destination, mut file) = paths(false, "png")?;
+    let result = (|| {
+        file.write_all(&png)?;
+        file.sync_all()?;
+        std::fs::hard_link(&partial, &destination)
+    })();
+    let _ = std::fs::remove_file(&partial);
+    result.map_err(|e| e.to_string())?;
+    let input = File::open(&destination).map_err(|e| e.to_string())?;
+    // Foreground lets us own and reap the clipboard provider, instead of
+    // accumulating detached children. It serves the exact saved PNG bytes.
+    let child = Command::new("wl-copy")
+        .args(["--foreground", "--type", "image/png"])
+        .stdin(input)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
+    let copied = match child {
+        Ok(mut child) => {
+            std::thread::sleep(Duration::from_millis(100));
+            let status = child.try_wait();
+            if matches!(status, Ok(None)) {
+                if let Some(mut old) = clipboard.take() {
+                    let _ = old.kill();
+                    let _ = old.wait();
+                }
+                *clipboard = Some(child);
+                true
+            } else {
+                // A clipboard manager can take ownership immediately and let
+                // wl-copy exit successfully; that is still a successful copy.
+                if status.is_err() {
+                    let _ = child.kill();
+                }
+                child.wait().is_ok_and(|status| status.success())
+            }
+        }
+        Err(_) => false,
+    };
+    Ok((destination, copied))
+}
+
+fn record(output: &str, geometry: &str, filter: &str) -> Result<Recording, String> {
+    let (partial, destination, file) = paths(true, "mp4")?;
+    drop(file);
+    let log = partial.with_extension("log");
+    let stderr = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&log)
+        .map_err(|e| e.to_string())?;
+    // Software H.264 is intentional: no VAAPI/NVIDIA assumption on Apple
+    // Silicon / Asahi. Pad odd selections instead of dropping their last row.
+    // calloop uses signalfd, so children inherit blocked INT/TERM/HUP. GNU env
+    // resets their disposition AND mask before exec; otherwise Stop would hang
+    // until the hard timeout despite delivering SIGINT to the correct process.
+    let child = Command::new("env")
+        .args(["--default-signal=INT,TERM,HUP", "wf-recorder"])
+        .args([
+            "--no-dmabuf",
+            "--no-damage",
+            "-y",
+            "-o",
+            output,
+            "-g",
+            geometry,
+            "-c",
+            "libx264",
+            "-p",
+            "preset=veryfast",
+            "-p",
+            "crf=18",
+            "-r",
+            "60",
+            "-x",
+            "yuv420p",
+            "-F",
+            filter,
+            "-f",
+        ])
+        .arg(&partial)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(stderr)
+        .spawn();
+    match child {
+        Ok(child) => Ok(Recording {
+            child,
+            partial,
+            destination,
+            log,
+        }),
+        Err(error) => {
+            let _ = std::fs::remove_file(&partial);
+            let _ = std::fs::remove_file(&log);
+            Err(format!("Install wf-recorder to record the screen: {error}"))
+        }
+    }
+}
+
+fn finish(mut active: Recording) {
+    // Signal only the child we own, never pkill/killall. SIGINT gives the muxer
+    // time to flush its trailer. A crashed encoder still leaves a recoverable MKV.
+    let _ = Command::new("kill")
+        .args(["-INT", "--", &active.child.id().to_string()])
+        .status();
+    if !wait_child(&mut active.child, Duration::from_secs(8)) {
+        notify(
+            "Recording needs recovery",
+            &active.partial.display().to_string(),
+        );
+        return;
+    }
+    let temporary = active.partial.with_extension("mp4");
+    let reserved = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&temporary)
+        .is_ok();
+    let converted = reserved
+        && Command::new("ffmpeg")
+            .args(["-nostdin", "-v", "error", "-y", "-i"])
+            .arg(&active.partial)
+            .args(["-c", "copy", "-movflags", "+faststart"])
+            .arg(&temporary)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .is_ok_and(|mut child| wait_child(&mut child, Duration::from_secs(30)));
+    if converted && std::fs::hard_link(&temporary, &active.destination).is_ok() {
+        let _ = std::fs::remove_file(&temporary);
+        let _ = std::fs::remove_file(&active.partial);
+        let _ = std::fs::remove_file(&active.log);
+        notify("Recording saved", &active.destination.display().to_string());
+    } else {
+        if reserved {
+            let _ = std::fs::remove_file(&temporary);
+        }
+        notify(
+            "Recording preserved as MKV",
+            &format!(
+                "{}\nInstall ffmpeg for MP4 export.",
+                active.partial.display()
+            ),
+        );
+    }
+}
+
+fn wait_child(child: &mut Child, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.success(),
+            Ok(None) if Instant::now() < deadline => std::thread::sleep(Duration::from_millis(20)),
+            _ => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return false;
+            }
+        }
+    }
+}

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -342,6 +342,11 @@ pub(crate) fn clear_implicit_grab(seat: &Seat<Compositor>) {
     });
 }
 
+/// Capture must not interrupt a shell/client press or a touch-owned gesture.
+pub(crate) fn capture_pointer_busy(seat: &Seat<Compositor>) -> bool {
+    with_input(seat, |input| input.implicit_grab.is_some() || !input.active_touches.is_empty())
+}
+
 /// Reconciles every held-input state after the real session regains its
 /// seat.
 ///
@@ -752,6 +757,12 @@ pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event
     if family.resets_idle() {
         crate::output_power::wake_all(state);
         crate::idle::note_activity(state);
+    }
+    // The capture selector is pointer/keyboard driven. Other interaction
+    // families must not operate the desktop behind its modal selection.
+    if !state.wm.backend().locked && crate::capture_tool::modal(state.wm.backend())
+        && matches!(family, InputFamily::Touch | InputFamily::TabletTool | InputFamily::Gesture) {
+        return;
     }
     // Buttons, scroll and gestures are delivered against the seat's
     // existing pointer focus. Re-assert the locked domain before any
@@ -1721,6 +1732,11 @@ fn pointer_moved(
     // answer without reaching the `Compositor` — see that verb for the
     // stale-anchor bug the mirror exists to prevent.
     state.wm.backend_mut().pointer = Some(at);
+    if !state.wm.backend().locked && crate::capture_tool::motion(state, at) {
+        pointer.motion(state, None, &MotionEvent { location: position, serial, time });
+        pointer.frame(state);
+        return;
+    }
     // A locked session's pointer exists only for the lock surfaces:
     // one seat motion against whichever covers the position, and none
     // of the routing below — no hover bookkeeping, no shell queues, no
@@ -1938,6 +1954,9 @@ fn pointer_button(
 ) {
     let serial = SERIAL_COUNTER.next_serial();
     let pressed = button_state == ButtonState::Pressed;
+    if !state.wm.backend().locked && crate::capture_tool::button(state, button_code, pressed) {
+        return;
+    }
     // L/M/R map onto the WM's vocabulary; anything else (side buttons,
     // wheel tilt) is client-only — `wm-x11` swallowed those outright,
     // here they at least still reach a client under the pointer.
@@ -2539,6 +2558,7 @@ fn route_shell_scroll_values(
     vertical_v120: Option<f64>,
     source: AxisSource,
 ) -> bool {
+    if !state.wm.backend().locked && crate::capture_tool::modal(state.wm.backend()) { return true; }
     // Locked: nothing here is the shell's — the axis flows to the seat
     // and lands on the lock surface like every other locked input.
     if state.wm.backend().locked {
@@ -2687,6 +2707,7 @@ pub(crate) fn inject_pointer_axis(
 /// and the renderer's makes clicks land on things the user cannot see,
 /// so both sides cite `backend_impl.rs`'s stacking-band contract.
 fn hit_at(backend: &WaylandBackend, at: Point, position: LogicalPoint<f64, Logical>) -> Hit {
+    if !backend.locked && crate::capture_tool::modal(backend) { return Hit::Root; }
     // The lock is a scene domain, not one more band in the desktop's
     // z-order. Put its boundary on the shared hit-test itself so a new
     // input caller cannot accidentally see a window, layer, shell or

--- a/crates/wm-wayland/src/input/gestures.rs
+++ b/crates/wm-wayland/src/input/gestures.rs
@@ -8,6 +8,7 @@ use crate::state::Compositor;
 
 fn available(state: &Compositor) -> bool {
     !state.wm.backend().locked
+        && !crate::capture_tool::modal(state.wm.backend())
         && state.layer_shell.exclusive_focus.is_none()
         && !state.focus_grab.is_active()
         && state.wm.backend().pointer_grab.is_none()

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -25,6 +25,7 @@
 
 mod backend_impl;
 mod capture;
+mod capture_tool;
 mod core_protocols;
 mod ctm;
 mod data_control;

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -852,6 +852,7 @@ fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> boo
             Rect::new(Point::new(0, 0), entry.size),
         );
 
+        crate::capture_tool::render(scene_scratch, renderer, wm.backend(), Rect::new(Point::new(0, 0), entry.size));
         match damage_tracker.render_output(renderer, &mut framebuffer, age, scene_scratch, clear_color) {
             Ok(result) => {
                 log_damage(age, result.damage.map(Vec::as_slice));
@@ -1474,6 +1475,7 @@ pub(crate) fn push_cursor_elements(
     if matches!(status, CursorImageStatus::Hidden) {
         return;
     }
+    if crate::capture_tool::crosshair(backend).is_some() { return; }
     let subject = crate::input::pointer_subject(backend, global);
     let sprite = match subject {
         crate::input::PointerSubject::Client => None,

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -2622,6 +2622,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
             viewport,
         );
 
+        crate::capture_tool::render(&mut output.scene_scratch, renderer, wm.backend(), viewport);
         let (rendered, direct_scanout, render_states) =
             match output.drm_compositor.render_frame(renderer, &output.scene_scratch, clear_color, frame_flags()) {
             Ok(result) => {

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -621,6 +621,7 @@ pub struct WaylandBackend {
     pub(crate) frames: HashMap<WlFrameId, FrameRecord>,
     pub(crate) shells: HashMap<WlShellId, ShellRecord>,
     pub(crate) overview: Option<crate::overview::Overview>,
+    pub(crate) capture_ui: Option<crate::capture_tool::Overlay>,
     /// Bottom-to-top managed application order — see [`StackEntry`].
     pub(crate) stacking: Vec<StackEntry>,
     /// Whether [`Self::stacking`] has actually moved since the X server
@@ -1009,6 +1010,7 @@ impl WaylandBackend {
             next_id: 1,
             windows: HashMap::new(),
             overview: None,
+            capture_ui: None,
             scene_index: SceneIndex::default(),
             surface_windows: HashMap::new(),
             popup_roots: HashMap::new(),
@@ -2371,6 +2373,7 @@ pub struct Compositor {
     /// requests. Kept beside the renderer because servicing one needs
     /// the live graphics context even when the scene is otherwise idle.
     pub(crate) screenshot_poller: crate::capture::ScreenshotRequestPoller,
+    pub(crate) capture_tool: crate::capture_tool::Service,
     /// linux-dmabuf: the format set we advertise and the protocol
     /// state behind it. Always present; "this renderer cannot do
     /// dmabuf" is represented inside, not by an `Option`, so protocol
@@ -2501,6 +2504,7 @@ impl Compositor {
     /// ever needs to move.
     #[cfg_attr(feature = "profile", profiling::function)]
     pub(crate) fn dispatch_pending(&mut self) {
+        crate::capture_tool::tick(self);
         let dispatch_span = tracing::info_span!("dispatch_pass");
         let _dispatch_guard = dispatch_span.enter();
         let dispatch_started = Instant::now();
@@ -2538,6 +2542,9 @@ impl Compositor {
             // switcher open (see the X11 loop's longer commentary;
             // `KeyRelease` is never intercepted at all).
             if let BackendEvent::KeyPress(combo) = &event {
+                if crate::capture_tool::key(self, combo) {
+                    continue;
+                }
                 if let Some(resolution) = self.shell.keymap_action(combo) {
                     if let Some(motion) = pending_motion.take() {
                         self.dispatch_motion(motion);
@@ -3218,6 +3225,7 @@ impl Compositor {
     fn note_outcome(&mut self, outcome: ShellOutcome) {
         match outcome {
             ShellOutcome::Continue => {}
+            ShellOutcome::Capture(mode) => crate::capture_tool::begin(self, mode),
             ShellOutcome::Exit => self.running = false,
             ShellOutcome::Restart => {
                 self.restart = true;
@@ -4078,6 +4086,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         ui_scale: scale,
         graphics,
         screenshot_poller: crate::capture::ScreenshotRequestPoller::new(Instant::now()),
+        capture_tool: crate::capture_tool::Service::new(),
         dmabuf,
         syncobj,
         protocols,

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -1,0 +1,109 @@
+# Capture
+
+Chonkstep's Wayland session has a native, Mac-inspired screenshot and recording
+tool. Selection stays inside the compositor: no external region picker, editor
+launch, or X11 round trip. Saving, PNG encoding, clipboard serving and video
+finalization run on a bounded background worker.
+
+## Shortcuts
+
+| Capture | Omarchy keymap | Chonkstep keymap |
+| --- | --- | --- |
+| Entire desktop → PNG + clipboard | Super+Ctrl+Shift+3 | Super+Shift+3 |
+| Select an area | Super+Ctrl+Shift+4 or Print¹ | Super+Shift+4 |
+| Screenshot / recording toolbar | Super+Ctrl+Shift+5 | Super+Shift+5 |
+| Stop recording | Super+Ctrl+Escape | Super+Ctrl+Escape |
+
+¹ The standard Omarchy `omarchy-capture-screenshot` binding is routed to the
+native selector on Wayland. A customized command is left alone.
+
+Omarchy already assigns Super+Shift+digits to desktop carrying and
+Super+Alt+digits to group selection. The additional Ctrl preserves those
+choices. Capture defaults fill otherwise-unclaimed chords in a live Hyprland
+import; an explicit bind or unbind wins. To choose the literal Mac-style chords
+instead, knowingly replacing those three workspace bindings:
+
+```toml
+[keybindings]
+"super+shift+3" = "capture-screen"
+"super+shift+4" = "capture-area"
+"super+shift+5" = "capture"
+```
+
+`capture-window` is also bindable for direct window selection. Native capture
+actions require the Wayland session; X11's existing command-based tools remain
+unchanged.
+
+## Selecting
+
+Drag an area and release for an immediate screenshot. Space switches between
+area and window selection; click a highlighted window to capture it, including
+its Chonkstep titlebar, without overlapping applications. Escape or right-click
+cancels without saving or changing the clipboard.
+
+The toolbar offers screen, window, area, record-screen and record-area modes.
+Keys 1–5 select the modes; Enter captures or starts recording. In toolbar area
+mode, releasing the pointer keeps the selection so it can be adjusted: drag
+inside to move, drag a corner to resize, or drag outside to replace it. Arrow
+keys move by one device pixel, Shift+arrow by ten. Space during a drag toggles
+moving the selection. Dimensions are shown in actual output pixels.
+
+Screenshots preserve the compositor's device-pixel resolution at integer and
+fractional UI scales. The immediate whole-desktop shortcut covers all outputs;
+the toolbar's screen mode selects the display under the pointer. Area captures
+may cross displays. The pointer and capture controls are excluded from PNGs.
+Selection is keyboard/pointer driven; touch, tablet and desktop gestures are
+suppressed while the selector owns input.
+
+## Files and clipboard
+
+PNG screenshots go to `Pictures/Screenshots` and recordings to
+`Videos/Recordings`, using the user's localized XDG Pictures/Videos directories.
+`OMARCHY_SCREENSHOT_DIR` and `OMARCHY_SCREENRECORD_DIR`, when set, override those
+destinations directly. Filenames contain the date, time and a unique suffix.
+Overrides must be absolute paths.
+Existing files are never replaced; published captures have owner-only access.
+
+Every successful screenshot also offers the exact saved PNG as `image/png` on
+the Wayland clipboard. Saving does not depend on clipboard availability; the
+completion notification distinguishes those outcomes. Failed writes are
+reported and do not leave the input grab active. No review application opens
+automatically. Open/review and annotation UI are intentionally deferred.
+
+## Recording
+
+Select a display or an area within one display, then press Record or Enter.
+The elapsed-time indicator can be clicked to stop. The toolbar shortcut also
+stops an active recording; Super+Ctrl+Escape is the direct stop shortcut.
+The indicator never appears in the video or exported screencopy frames.
+Locking the session stops recording. Another recording cannot start until the
+current file has finished finalizing.
+
+Recordings are silent, 60 fps H.264 at CRF 18, using a portable software encoder
+that does not assume NVIDIA or VAAPI support. Odd selections retain their last
+row/column and are padded to even encoder dimensions. High-resolution 60 fps
+software encoding can be CPU-intensive; physical M1/Asahi performance has not
+been measured. Hardware acceleration, audio controls and window-following
+recording are not part of this first version.
+
+An in-progress hidden `.partial.mkv` lives beside the eventual file. Stopping
+flushes the recorder, then remuxes to a fast-start MP4 without re-encoding.
+On an encoder/finalization failure the MKV and diagnostic log remain available;
+the notification identifies their paths. An abrupt process or machine failure
+can lose the latest buffered frames; an unfinished recording is not promised
+to be perfectly recoverable. A recording region must fit one output and its
+capture grid; an unrepresentable edge on an odd-sized output is refused rather
+than silently cropped.
+
+Dependencies are included in the Arch package and source installer:
+`wl-clipboard`, `wf-recorder`, `ffmpeg`, `libnotify`, and `xdg-user-dirs`.
+
+## Verification
+
+Run `scripts/e2e.sh --headless --test capture_tool` for real keyboard/pointer,
+GPU readback, PNG clipboard, scale, occlusion, recording and failure tests.
+Use the screenshot marker when inspecting the visible selector: ordinary
+screencopy intentionally omits capture chrome. See
+[the engineering report](engineering/2026-09-06-capture.md) for validation and
+known limits. This is a tested native workflow, not a claim that every macOS
+capture feature or every GPU has been reproduced.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -558,6 +558,12 @@
 "alt+shift+right" = "workspace-carry-next"  # carry the focused window along
 "alt+shift+left" = "workspace-carry-prev"   # carry the focused window back
 "super+up" = "overview"                     # the modal Overview (see below)
+"super+shift+3" = "capture-screen"          # Wayland: screen PNG + clipboard
+"super+shift+4" = "capture-area"            # drag an area; Space selects a window
+"super+shift+5" = "capture"                 # screenshot / recording toolbar
+"super+ctrl+escape" = "capture-stop"        # finish the active screen recording
+# Omarchy defaults add Ctrl to Shift+3/4/5, preserving desktop-carry bindings.
+# Omit the three numbered lines above to retain Omarchy's choices.
 
 # Workspaces by number are unbound in this keymap -- the defaults above
 # reach them by stepping -- but the verbs are there for the taking, and

--- a/docs/engineering/2026-09-06-browser-input.md
+++ b/docs/engineering/2026-09-06-browser-input.md
@@ -74,6 +74,24 @@ to the client rectangle. Finally, fullscreen qualification waits for the DOM
 viewport, compositor extent and presented buffer, since their updates are
 asynchronous. Exact selection and coordinate assertions remain in place.
 
+PR #137's CI run exposed a test-environment difference: the hosted runner uses
+`--no-sandbox`, whose Chromium warning infobar stays visible even in DOM
+fullscreen. Reproducing with `CI=1` locally showed the same full-size client
+with a shorter page viewport. The isolated CI browser now uses Chromium's
+`--test-type` startup-infobar suppression (see the
+[Chromium implementation](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/chrome/browser/ui/startup/infobar_utils.cc)).
+This leaves all extent, rendering, selection and repeat assertions intact and
+does not change browser launch options in the user's desktop session.
+Fullscreen timeouts now retain a screenshot and both DOM/compositor geometry.
+The CI-mode rerun also caught SwiftShader presenting an initial black buffer
+at the correct extent before painting the page. The screenshot color assertion
+now polls for that asynchronous paint for at most ten seconds; a permanently
+blank page still fails, and all exact input assertions are unchanged.
+Selection points and viewport size are read atomically after renderer frames,
+and requalified against fullscreen geometry immediately before input. Separate
+CDP reads had occasionally combined an old DOM viewport with the new client
+extent during an XWayland configure sequence.
+
 ## Results
 
 The tested compositor is the installed optimized 0.3.2 executable from

--- a/docs/engineering/2026-09-06-capture.md
+++ b/docs/engineering/2026-09-06-capture.md
@@ -1,0 +1,107 @@
+# Native Wayland capture — 2026-09-06
+
+## Scope
+
+The compositor now owns the screenshot/recording selection experience. This
+implements the requested screen, region and window screenshots, automatic PNG
+saving and clipboard, plus display/area recording with explicit start/stop.
+It does not claim complete macOS feature parity or physical M1 certification.
+See [the user guide](../capture.md) for shortcuts and current limits.
+
+## Architecture and invariants
+
+Capture keybindings resolve to a backend-specific shell outcome. The selector
+takes the existing modal keyboard ownership path, clears client pointer focus,
+and consumes both edges of its pointer presses—even a release after Escape.
+It declines to interrupt another modal owner, a held pointer gesture or a WM
+drag. Touch/tablet/desktop gestures cannot act behind the selection overlay.
+Locking or losing the selected output cancels selection; locking stops recording.
+
+Scanout adds the overlay after normal scene construction. Protocol screencopy
+and image-copy-capture never add it. The diagnostic screenshot marker does,
+so visual QA can inspect exactly what is on screen. Solid element IDs remain
+stable, and only the small toolbar owns raster pixels. Dimension-label work
+is limited to roughly 30 Hz while the outline follows pointer reports.
+
+User PNGs render device pixels directly from the GPU, without the pointer.
+A window is composed separately with its own server-side frame, not cropped
+from an occluded desktop or enlarged from an Overview thumbnail. tiny-skia
+unpremultiplies alpha when encoding the PNG. At most two screenshot buffers
+may be in flight; encoding and filesystem I/O do not run on the input loop.
+
+The worker reserves private, unique files using `create_new` and publishes
+with a no-replace hard link. Clipboard serving uses the exact saved PNG via
+an owned foreground `wl-copy` child. Clipboard failure does not undo saving.
+The recorder child is owned/reaped, never found through `pkill` or a PID file.
+It writes MKV during recording, receives SIGINT to flush, then ffmpeg remuxes
+to a private fast-start MP4. Failed finalization preserves the source MKV/log.
+
+## Integration bugs found during development
+
+- **Shortcut collisions.** Super+Shift+digits carries windows to Omarchy
+  desktops, while Super+Alt+digits is reserved for group focus. The Omarchy
+  capture defaults therefore use Super+Ctrl+Shift+3/4/5, plus its normal Print
+  command for area selection. Explicit live bindings/unbinds still win.
+- **Recorder stop signals.** calloop's signalfd setup blocks INT/TERM/HUP.
+  Subprocesses inherited that mask, so sending SIGINT alone left a recording
+  running until its hard timeout. GNU `env --default-signal=INT,TERM,HUP`
+  restores both disposition and mask before executing wf-recorder.
+- **Fractional-scale geometry.** The compositor stores physical coordinates
+  but screencopy regions are output-logical. At UI scale 1.5, the advertised
+  integer scale is 2; passing a physical 301×201 region directly recorded
+  602×402 pixels. Capture now requests a logical enclosure and crops exact
+  device pixels after normalizing the output transform.
+- **Odd dimensions.** wf-recorder's SHM path truncates odd buffer dimensions
+  before filters. The enclosure must therefore be even before the recorder
+  receives it. Cropping followed by padding preserves the selected edge pixels
+  and provides even H.264 dimensions. An unrepresentable output edge is refused.
+- **Toolbar screen mode.** Choosing Screen while the pointer was still on the
+  toolbar originally left no selected display. It now immediately selects the
+  toolbar's display, without requiring an extra pointer movement.
+
+The coordinate/odd-buffer/filter behavior was checked against the recorder's
+[capture implementation](https://github.com/ammen99/wf-recorder/blob/master/src/main.cpp)
+and [filter implementation](https://github.com/ammen99/wf-recorder/blob/master/src/frame-writer.cpp),
+then verified against the installed recorder with decoded output frames.
+
+## Validation
+
+`scripts/check.sh all` passed: workspace-wide strict Clippy, documentation with
+warnings denied, Rust tests, Wayland unit tests and the Python harness checks.
+The final run passed 1,941 Rust tests/doctests and 26 Python harness tests;
+239 display-dependent/diagnostic tests remained ignored in that display-free
+gate. The eight capture E2E cases passed against both debug and optimized
+binaries. Chromium's six Wayland/XWayland/scale cases also passed, along with
+13 keyboard-repeat and seven keyboard-focus cases on the optimized compositor.
+The three installed-Omarchy menu/theme checks passed alongside these runs.
+
+Recorder dependencies on the validation machine were wf-recorder 0.6.0-2,
+ffmpeg 9.0.1 and wl-clipboard 2.3.0. Capture artifacts were kept under
+`/tmp/ccap.RXAP3ZEt/chonk-testkit/` for local inspection.
+
+The real nested-Wayland capture suite exercises:
+
+- Screenshot shortcuts and the imported Omarchy Print command.
+- 1×, 1.5× and 2× device-pixel dimensions; every area pixel compared with the
+  corresponding live scene pixel; clipboard PNG bytes equal to the saved file.
+- Window dimensions including the frame, and a separate overlapping-window
+  test proving that the saved image contains the selected window underneath.
+- Escape while dragging, swallowing the subsequent release, and restored
+  physical keyboard delivery to a native client.
+- Retained-area moving, corner resizing, one-pixel keyboard adjustment,
+  pointer activation of Capture, and blocked touch/desktop gestures.
+- A deterministic failed save, with a readable failure and reusable selector.
+- Odd-area recording, H.264 metadata/dimensions/duration, decoded video pixels
+  underneath the visible recording badge, and successful stop/finalization.
+- Display screenshot/recording modes selected without leaving the toolbar,
+  and stopping through the visible badge.
+
+Visual inspection used the native diagnostic marker for the toolbar, area and
+window overlays, adjusted selection and recording indicator. Tests run inside
+an isolated Weston host and use private capture folders and Wayland clipboard.
+They do not replace or restart the logged-in desktop.
+
+The development machine is x86_64. Physical M1/Asahi, mixed-monitor DRM setups,
+and sustained 4K/60 software-encoding performance remain hardware validation
+items. Audio selection, hardware encoding, window-following recordings,
+annotation and the open/review experience are deferred.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -33,11 +33,21 @@ ever do disagree, the source wins.
 | `alt+shift+right`  | `workspace-carry-next` | Carry the focused window to the next          |
 | `alt+shift+left`   | `workspace-carry-prev` | Carry the focused window back                 |
 | `super+up`         | `overview`             | The modal Overview: every window as a card    |
+| `super+shift+3`    | `capture-screen`       | Save screen PNG and copy it (Wayland)        |
+| `super+shift+4`    | `capture-area`         | Select area; Space selects a window          |
+| `super+shift+5`    | `capture`              | Screenshot / recording controls              |
+| `super+ctrl+escape`| `capture-stop`         | Finish recording                             |
 | `control+escape`   | `window-menu`          | Window commands menu, no titlebar required    |
 
 Window-targeted actions (`close`, `toggle-maximize`, `toggle-shade`,
 `miniaturize`, `toggle-fullscreen`, `window-menu`) act on the focused
 window and do nothing when no window is focused.
+
+See [Capture](capture.md) for saving, clipboard, selection and recording.
+The Omarchy keymap uses **Super+Ctrl+Shift+3/4/5** instead, because
+Super+Shift+digits already carries windows to desktops there. Its unmodified
+Print screenshot command opens the native area selector on Wayland. Explicit
+live Hyprland bindings and unbinds always override the new capture defaults.
 
 Every root, window, and dock-tile menu is keyboard-modal while open.
 Up/Down changes the highlighted row, Right or Enter opens a submenu,
@@ -80,7 +90,8 @@ time. Bind them like anything else:
 keymap = "omarchy"        # ...or desktop = "omarchy", which defaults it
 ```
 
-127 bindings, derived from Omarchy's own configuration on the machine —
+131 bindings, including four native capture shortcuts, derived from Omarchy's
+own configuration on the machine —
 `$OMARCHY_PATH/default/hypr/bindings/*.lua` — rather than from memory of
 Hyprland, with the `o.bind` helpers expanded the way `helpers.lua`
 expands them. A `run <name>` action names an entry the preset declares
@@ -107,6 +118,10 @@ helpers are supported directly.
 
 | Binding                  | Action                                 | Omarchy's own command                                                                                               |
 |--------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `super+ctrl+shift+3` | `capture-screen` | -- |
+| `super+ctrl+shift+4` | `capture-area` | -- |
+| `super+ctrl+shift+5` | `capture` | -- |
+| `super+ctrl+escape` | `capture-stop` | -- |
 | `super+return`           | `spawn-terminal`                       | --                                                                                                                  |
 | `super+shift+return`     | `run omarchy-browser`                  | `omarchy-launch-browser`                                                                                            |
 | `super+shift+b`          | `run omarchy-browser`                  | `omarchy-launch-browser`                                                                                            |

--- a/docs/omarchy-mode.md
+++ b/docs/omarchy-mode.md
@@ -204,7 +204,7 @@ between "chonkstep knows what Omarchy's chords were in August" and
 their UI and the running session follows it within a second.
 
 On the machine this was developed on the live read produced **153
-bindings over 113 commands**, against the baked table's 127 over 77 —
+bindings over 113 commands**, against the baked table's 131 over 77 —
 the extra ones are mostly the preinstalled webapp and TUI chords, which
 a table of constants had to write off because Omarchy gates them on a
 file test that only a live read can make.
@@ -224,7 +224,7 @@ what the live read falls back to.
 
 Both tables live in the keybinding card, beside chonkstep's own:
 **[keybindings.md](keybindings.md), under "The Omarchy keymap"**
-— 127 bindings over 77 declared commands, then the 32 groups of Omarchy
+— 131 bindings over 77 declared commands, then the 32 groups of Omarchy
 chords that are deliberately dead here and why. Both are transcribed
 from `crates/wm-config/src/preset.rs`, which is the authoritative list;
 `crates/wm-config/tests/preset_doc.rs` fails if the card and the table

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -42,6 +42,11 @@ arch=('x86_64' 'aarch64')
 url="https://github.com/iconidentify/chonkstep"
 license=('GPL-3.0-only')
 depends=(
+  'wl-clipboard'     # lossless PNG clipboard ownership
+  'wf-recorder'      # native Wayland recording (software H.264 works on Asahi)
+  'ffmpeg'           # finalize recoverable MKV recordings as fast-start MP4
+  'libnotify'        # capture completion / failure notifications
+  'xdg-user-dirs'    # localized Pictures / Videos destinations
   'bash'             # the session launcher scripts in /usr/lib/chonkstep
   'gcc-libs'
   'glibc'
@@ -212,6 +217,7 @@ DESKTOP
   install -Dm644 docs/config.example.toml -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/quickstart.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/keybindings.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/capture.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/gestures.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/instrument-platform.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/dockapp-protocol.md -t "$pkgdir/usr/share/doc/$pkgname"

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -46,6 +46,11 @@ arch=('x86_64' 'aarch64')
 url="https://github.com/iconidentify/chonkstep"
 license=('GPL-3.0-only')
 depends=(
+  'wl-clipboard'     # lossless PNG clipboard ownership
+  'wf-recorder'      # native Wayland recording (software H.264 works on Asahi)
+  'ffmpeg'           # finalize recoverable MKV recordings as fast-start MP4
+  'libnotify'        # capture completion / failure notifications
+  'xdg-user-dirs'    # localized Pictures / Videos destinations
   'bash'             # the session launcher scripts in /usr/lib/chonkstep
   'gcc-libs'
   'glibc'
@@ -219,6 +224,7 @@ DESKTOP
   install -Dm644 docs/config.example.toml -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/quickstart.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/keybindings.md -t "$pkgdir/usr/share/doc/$pkgname"
+  install -Dm644 docs/capture.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/gestures.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/instrument-platform.md -t "$pkgdir/usr/share/doc/$pkgname"
   install -Dm644 docs/dockapp-protocol.md -t "$pkgdir/usr/share/doc/$pkgname"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,6 +132,7 @@ pacman -Qq | grep -qx 'ttf-jetbrains-mono-nerd\(-basic\)\?' && jb_font=""
 sudo pacman -S --needed --noconfirm \
     xorg-server xorg-xinit xorg-xauth \
     foot picom wireplumber \
+    wl-clipboard wf-recorder ffmpeg libnotify xdg-user-dirs \
     ttf-dejavu gsfonts $jb_font noto-fonts \
     libxkbcommon libglvnd mesa xorg-xwayland \
     libdrm libinput systemd-libs seatd hwdata \


### PR DESCRIPTION
## Summary

Adds a compositor-native screenshot and recording workflow: area/window/display selection, automatic lossless PNG saving and PNG clipboard ownership, a keyboard/pointer toolbar, and display/area recording with a visible stop indicator and recoverable MP4 finalization.

Omarchy keeps its existing workspace/group shortcuts. New capture shortcuts are Super+Ctrl+Shift+3/4/5, plus its standard Print command for area capture. The Chonkstep keymap uses Super+Shift+3/4/5. Explicit user bindings/unbinds still win.

Encoding and filesystem work run off the input loop. Capture controls are excluded from screenshots and recordings. The selector handles Escape, held pointer releases, moving/resizing, keyboard adjustment, save failures, and existing modal/drag ownership.

## Verification

- Full local preflight passed: strict workspace Clippy, documentation, 1,941 Rust tests/doctests, and 26 Python harness tests.
- Eight real nested-Wayland capture cases passed against debug and optimized binaries: 1x/1.5x/2x pixels, exact PNG clipboard data, occlusion, cancellation/focus, resizing, failure handling, playable recording, and badge exclusion/stop.
- Chromium Wayland/XWayland scale matrix: six cases passed.
- Optimized keyboard repeat/focus: 13 + 7 cases passed.
- Installed Omarchy menu/theme checks passed.

## Boundaries

Physical M1/Asahi and sustained 4K/60 software-encoding performance remain hardware validation items. This does not claim complete macOS parity. Audio/hardware encoding, window-following recording, annotation and open/review UI are deferred. No changes were made to the running desktop session.

User guide: docs/capture.md. Detailed evidence and implementation findings: docs/engineering/2026-09-06-capture.md.

Opening this PR so required GitHub checks can run before main changes.