### PR TITLE
Native finger-following gestures and Overview window dragging

### DIFF
--- a/crates/chonk-shell/src/desktop.rs
+++ b/crates/chonk-shell/src/desktop.rs
@@ -38,7 +38,7 @@ use crate::dockapp::panel::{self as instrument, InstrumentPanel};
 use crate::dockapp::tile::{clamp_panel_grant, reserved_filter, RemoteTile, ServiceContext, StopReason, TileState};
 use crate::dockapp::{self, DockHost, Farewell};
 use crate::omarchy_shell::BarVisibility;
-use crate::overview::{OverviewHit, OverviewItem, OverviewPanel};
+use crate::overview::{OverviewHit, OverviewItem, OverviewPanel, OverviewRelease};
 use crate::wallpaper::Wallpaper;
 use crate::widgets::{
     run_detached, BluetoothWidget, ClockWidget, DockInput, DockItem, DockWidget, Effect, NetTrafficWidget, PanelCtx,
@@ -3540,11 +3540,12 @@ impl<B: Backend> Desktop<B> {
         theme: &Theme,
         items: Vec<OverviewItem<B>>,
         workspace: (usize, usize),
+        workspace_counts: &[usize],
         selected: usize,
     ) {
         let Self { overview, fonts, tile, primary, .. } = self;
         let (mut font_system, mut swash_cache) = (fonts.system(), fonts.swash());
-        overview.show(backend, theme, &mut font_system, &mut swash_cache, *primary, *tile, items, workspace, selected);
+        overview.show(backend, theme, &mut font_system, &mut swash_cache, *primary, *tile, items, workspace, workspace_counts, selected);
     }
 
     pub fn overview_visible(&self) -> bool {
@@ -3596,6 +3597,32 @@ impl<B: Backend> Desktop<B> {
 
     pub fn overview_selected(&self) -> usize {
         self.overview.selected()
+    }
+
+    pub fn overview_workspace(&self) -> (usize, usize) { self.overview.workspace() }
+
+    pub fn overview_pointer_pending(&self) -> bool { self.overview.pointer_pending() }
+
+    pub fn overview_pointer_press(&mut self, backend: &mut B, index: usize, local: Point) {
+        self.overview.pointer_press(backend, index, local);
+    }
+
+    pub fn overview_pointer_motion(&mut self, backend: &mut B, theme: &Theme, root: Point) -> bool {
+        let Self { overview, fonts, .. } = self;
+        let (mut font_system, mut swash_cache) = (fonts.system(), fonts.swash());
+        overview.pointer_motion(backend, theme, &mut font_system, &mut swash_cache, root)
+    }
+
+    pub fn overview_pointer_release(&mut self, backend: &mut B, theme: &Theme, local: Point) -> Option<OverviewRelease> {
+        let Self { overview, fonts, .. } = self;
+        let (mut font_system, mut swash_cache) = (fonts.system(), fonts.swash());
+        overview.pointer_release(backend, theme, &mut font_system, &mut swash_cache, local)
+    }
+
+    pub fn cancel_overview_pointer(&mut self, backend: &mut B, theme: &Theme) -> bool {
+        let Self { overview, fonts, .. } = self;
+        let (mut font_system, mut swash_cache) = (fonts.system(), fonts.swash());
+        overview.cancel_pointer(backend, theme, &mut font_system, &mut swash_cache)
     }
 
     pub fn overview_item(&self, index: usize) -> Option<&OverviewItem<B>> {

--- a/crates/chonk-shell/src/overview.rs
+++ b/crates/chonk-shell/src/overview.rs
@@ -6,7 +6,7 @@
 //! Noncompositing backends retain the raster fallback: a full panel on entry,
 //! a separate selection surface, and one catch-up fetch for sharper previews.
 
-use wm_core::{Backend, ClientId};
+use wm_core::{Backend, ClientId, DragHandle, OverviewDrag};
 use wm_theme::overview::{self as ov, OverviewEntry, OverviewLayout};
 use wm_theme::Theme;
 use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
@@ -37,6 +37,45 @@ pub enum OverviewHit {
     Background,
 }
 
+#[derive(Clone, Copy)]
+struct CardPress {
+    client: ClientId,
+    index: usize,
+    start: Point,
+    cell: Rect,
+    workspace: usize,
+    grab: DragHandle,
+    dragging: bool,
+    cancelled: bool,
+}
+
+/// A release can commit exactly the card armed by its matching press. A drag
+/// never falls back to activation, even when dropped over another card.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OverviewRelease {
+    Click(usize),
+    Move { client: ClientId, source: usize, target: usize },
+    Cancelled,
+}
+
+fn passed_threshold(start: Point, point: Point, threshold: i32) -> bool {
+    let dx = i64::from(point.x) - i64::from(start.x);
+    let dy = i64::from(point.y) - i64::from(start.y);
+    // Unsigned saturating squares also handle adversarial/global coordinates.
+    dx.unsigned_abs().saturating_pow(2).saturating_add(dy.unsigned_abs().saturating_pow(2))
+        >= (threshold.max(1) as u64).pow(2)
+}
+
+fn drag_rect(cell: Rect, start: Point, point: Point, limit: Size) -> Rect {
+    let scale = (limit.w as f64 / cell.size.w.max(1) as f64)
+        .min(limit.h as f64 / cell.size.h.max(1) as f64).min(1.0);
+    let offset_x = ((i64::from(start.x) - i64::from(cell.pos.x)) as f64 * scale).round() as i32;
+    let offset_y = ((i64::from(start.y) - i64::from(cell.pos.y)) as f64 * scale).round() as i32;
+    Rect::new(Point::new(point.x.saturating_sub(offset_x), point.y.saturating_sub(offset_y)),
+        Size::new((cell.size.w as f64 * scale).round().max(1.0) as u32,
+            (cell.size.h as f64 * scale).round().max(1.0) as u32))
+}
+
 pub struct OverviewPanel<B: Backend> {
     window: Option<B::ShellId>,
     /// The selection: highlight plate plus the awake card, on its own
@@ -59,6 +98,10 @@ pub struct OverviewPanel<B: Backend> {
     awaiting_previews: bool,
     preview_generation: u64,
     live: bool,
+    press: Option<CardPress>,
+    drag: Option<OverviewDrag>,
+    drag_threshold: i32,
+    drag_limit: Size,
 }
 
 impl<B: Backend> Default for OverviewPanel<B> {
@@ -75,6 +118,10 @@ impl<B: Backend> Default for OverviewPanel<B> {
             awaiting_previews: false,
             preview_generation: 0,
             live: false,
+            press: None,
+            drag: None,
+            drag_threshold: 3,
+            drag_limit: Size::new(168, 112),
         }
     }
 }
@@ -94,8 +141,10 @@ impl<B: Backend> OverviewPanel<B> {
         tile: u32,
         items: Vec<OverviewItem<B>>,
         workspace: (usize, usize),
+        workspace_counts: &[usize],
         selected: usize,
     ) {
+        self.invalidate_pointer(backend);
         if self.window.is_some() && self.geometry != primary {
             // The monitor arrangement moved under a kept surface; a
             // stale-sized buffer would letterbox or clip the panel.
@@ -108,6 +157,8 @@ impl<B: Backend> OverviewPanel<B> {
         self.items = items;
         self.workspace = workspace;
         self.live = backend.supports_live_overview();
+        self.drag_threshold = (tile as f64 * 3.0 / 56.0).ceil().max(2.0) as i32;
+        self.drag_limit = Size::new(tile * 3, tile * 2);
         let layout = if self.live {
             let sizes: Vec<_> = self.items.iter().map(|item| item.geometry.size).collect();
             ov::live::layout(primary.size, tile, &sizes, workspace.1)
@@ -178,10 +229,12 @@ impl<B: Backend> OverviewPanel<B> {
                                 theme,
                                 font_system,
                                 swash_cache,
-                                &format!("Desktop {}", i + 1),
+                                &format!("Desktop {} · {}", i + 1, workspace_counts.get(i).copied().unwrap_or(0)),
                                 rect.size.w,
                                 label_h,
                             ),
+                            drop_label: ov::live::label(theme, font_system, swash_cache,
+                                &format!("Move to Desktop {}", i + 1), rect.size.w, label_h),
                             close: layout.workspace_close_rect(i)
                                 .map(|rect| (rect, ov::workspace_close_glyph(rect.size.w))),
                     })
@@ -275,7 +328,8 @@ impl<B: Backend> OverviewPanel<B> {
             return;
         };
         let started = std::time::Instant::now();
-        let plate = ov::plate_rect(*cell, layout.pad);
+        let cell = self.drag.map_or(*cell, |drag| drag.destination);
+        let plate = ov::plate_rect(cell, layout.pad);
         // The layout speaks panel-local coordinates; surfaces live in
         // the global space the panel's own rect is in.
         let global = Rect {
@@ -391,7 +445,7 @@ impl<B: Backend> OverviewPanel<B> {
         if self.selection == Some(surface) {
             if let Some(layout) = self.layout.as_ref() {
                 if let Some(cell) = layout.cells.get(self.selected) {
-                    let plate = ov::plate_rect(*cell, layout.pad);
+                    let plate = ov::plate_rect(self.drag.map_or(*cell, |d| d.destination), layout.pad);
                     return Point::new(local.x + plate.pos.x, local.y + plate.pos.y);
                 }
             }
@@ -401,6 +455,105 @@ impl<B: Backend> OverviewPanel<B> {
 
     pub fn selected(&self) -> usize {
         self.selected
+    }
+
+    pub fn workspace(&self) -> (usize, usize) {
+        self.workspace
+    }
+
+    pub fn pointer_pending(&self) -> bool {
+        self.press.is_some()
+    }
+
+    /// Grab on press, not on crossing the threshold: a quick throw can leave
+    /// the output before its next motion, but its release still belongs here.
+    pub fn pointer_press(&mut self, backend: &mut B, index: usize, local: Point) {
+        self.end_pointer(backend);
+        let (Some(item), Some(cell)) = (self.items.get(index), self.layout.as_ref().and_then(|l| l.cells.get(index))) else { return };
+        self.press = Some(CardPress {
+            client: item.client, index, start: local, cell: *cell,
+            workspace: self.workspace.0, grab: backend.grab_pointer_for_drag(),
+            dragging: false, cancelled: false,
+        });
+    }
+
+    /// Invalidation consumes the eventual release instead of letting it click
+    /// a newly laid-out card or a desktop close control. The grab stays owned
+    /// until release (or teardown), including after Escape while still held.
+    fn invalidate_pointer(&mut self, backend: &mut B) {
+        if let Some(press) = &mut self.press {
+            press.cancelled = true;
+        }
+        self.drag = None;
+        backend.drag_live_overview(None);
+    }
+
+    fn end_pointer(&mut self, backend: &mut B) {
+        self.drag = None;
+        backend.drag_live_overview(None);
+        if let Some(press) = self.press.take() {
+            backend.ungrab_pointer(press.grab);
+        }
+    }
+
+    pub fn cancel_pointer(&mut self, backend: &mut B, theme: &Theme,
+        fonts: &mut cosmic_text::FontSystem, cache: &mut cosmic_text::SwashCache) -> bool {
+        if !self.press.is_some_and(|p| !p.cancelled) { return false; }
+        self.invalidate_pointer(backend);
+        self.place_selection(backend, theme, fonts, cache);
+        true
+    }
+
+    pub fn pointer_motion(&mut self, backend: &mut B, theme: &Theme,
+        fonts: &mut cosmic_text::FontSystem, cache: &mut cosmic_text::SwashCache, root: Point) -> bool {
+        let local = Point::new(root.x.saturating_sub(self.geometry.pos.x), root.y.saturating_sub(self.geometry.pos.y));
+        self.update_pointer(backend, theme, fonts, cache, local)
+    }
+
+    fn update_pointer(&mut self, backend: &mut B, theme: &Theme,
+        fonts: &mut cosmic_text::FontSystem, cache: &mut cosmic_text::SwashCache, local: Point) -> bool {
+        let Some(press) = &mut self.press else { return false };
+        if press.cancelled { return true; }
+        press.dragging |= passed_threshold(press.start, local, self.drag_threshold);
+        if !press.dragging { return true; }
+        let workspace = self.layout.as_ref().and_then(|l| l.workspace_at(local))
+            .filter(|target| *target != press.workspace);
+        let drag = OverviewDrag { index: press.index,
+            destination: drag_rect(press.cell, press.start, local, self.drag_limit), workspace };
+        let first = self.drag.is_none();
+        if self.drag == Some(drag) { return true; }
+        self.drag = Some(drag);
+        if self.live {
+            backend.drag_live_overview(Some(drag));
+        } else if first {
+            // Legacy X11 retains the existing small raster selection as its
+            // drag image. Paint once on pickup; subsequent motions only move it.
+            self.place_selection(backend, theme, fonts, cache);
+        } else if let (Some(selection), Some(layout)) = (self.selection, &self.layout) {
+            let plate = ov::plate_rect(drag.destination, layout.pad);
+            backend.configure_shell_surface(selection, Rect::new(
+                Point::new(plate.pos.x + self.geometry.pos.x, plate.pos.y + self.geometry.pos.y), plate.size));
+        }
+        true
+    }
+
+    pub fn pointer_release(&mut self, backend: &mut B, theme: &Theme,
+        fonts: &mut cosmic_text::FontSystem, cache: &mut cosmic_text::SwashCache,
+        local: Point) -> Option<OverviewRelease> {
+        // A coalesced press/motion/release burst may not have delivered an
+        // intermediate motion to the shell. The release's coordinates count.
+        self.update_pointer(backend, theme, fonts, cache, local);
+        let press = self.press?;
+        let result = if press.cancelled { OverviewRelease::Cancelled }
+        else if press.dragging {
+            self.drag.and_then(|d| d.workspace).map_or(OverviewRelease::Cancelled, |target|
+                OverviewRelease::Move { client: press.client, source: press.workspace, target })
+        } else if self.hit(local) == OverviewHit::Card(press.index) {
+            OverviewRelease::Click(press.index)
+        } else { OverviewRelease::Cancelled };
+        self.end_pointer(backend);
+        self.place_selection(backend, theme, fonts, cache);
+        Some(result)
     }
 
     pub fn item(&self, index: usize) -> Option<&OverviewItem<B>> {
@@ -453,6 +606,7 @@ impl<B: Backend> OverviewPanel<B> {
     /// withdrawn with the session: the backend's snapshots go back to
     /// icon-sized on their own schedule.
     pub fn hide(&mut self, backend: &mut B) {
+        self.end_pointer(backend);
         if self.live {
             backend.hide_live_overview();
         }
@@ -480,6 +634,7 @@ impl<B: Backend> OverviewPanel<B> {
     /// serve would wedge every key on the desk. Ungrabbing when not
     /// grabbed is a no-op on both backends.
     pub fn discard(&mut self, backend: &mut B) {
+        self.end_pointer(backend);
         if self.live {
             backend.hide_live_overview();
         }
@@ -503,5 +658,26 @@ impl<B: Backend> OverviewPanel<B> {
     /// The panel's current size, for tests and diagnostics.
     pub fn size(&self) -> Size {
         self.geometry.size
+    }
+}
+
+#[cfg(test)]
+mod drag_tests {
+    use super::*;
+    #[test]
+    fn threshold_is_radial_scale_aware_and_overflow_safe() {
+        for scale in [1, 2] {
+            assert!(!passed_threshold(Point::new(0, 0), Point::new(scale, scale), 3 * scale));
+            assert!(passed_threshold(Point::new(0, 0), Point::new(3 * scale, 0), 3 * scale));
+        }
+        assert!(passed_threshold(Point::new(i32::MIN, i32::MIN), Point::new(i32::MAX, i32::MAX), 3));
+    }
+    #[test]
+    fn drag_image_keeps_the_grab_anchor_and_never_upscales() {
+        let cell = Rect::new(Point::new(100, 200), Size::new(400, 200));
+        let rect = drag_rect(cell, Point::new(200, 250), Point::new(800, 300), Size::new(200, 100));
+        assert_eq!(rect, Rect::new(Point::new(750, 275), Size::new(200, 100)));
+        let small = Rect::new(Point::new(100, 200), Size::new(40, 20));
+        assert_eq!(drag_rect(small, small.pos, Point::new(500, 300), Size::new(200, 100)).size, small.size);
     }
 }

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -29,7 +29,7 @@ use crate::desktop::{
 };
 use crate::dockapp::Farewell;
 use crate::launchdock::{LaunchDock, LaunchDockAction};
-use crate::overview::{OverviewHit, OverviewItem};
+use crate::overview::{OverviewHit, OverviewItem, OverviewRelease};
 use crate::session_layout::{relative_to_monitor, restored_geometry, RelaunchPlan, SessionLayout, WindowRecord};
 use crate::startup::SessionState;
 use crate::widgets::DockInput;
@@ -1919,6 +1919,16 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                 } else {
                     let rebound_toggle =
                         key.as_ref().is_some_and(|combo| self.keymap.get(combo) == Some(&Action::Overview));
+                    if self.desktop.overview_pointer_pending() && !rebound_toggle {
+                        // Escape cancels the drag first; the panel remains for
+                        // another attempt. Other keys cannot activate a card or
+                        // start a second modal operation under a held pointer.
+                        if key.is_some_and(|combo| combo.keysym == crate::desktop::PANEL_DISMISS_KEYSYM)
+                            && !self.desktop.cancel_overview_pointer(wm.backend_mut(), &self.theme) {
+                            self.close_overview(wm);
+                        }
+                        return ShellOutcome::Continue;
+                    }
                     match key {
                         Some(combo) if !rebound_toggle => match overview_intent(&combo) {
                             OverviewIntent::Move(dx, dy) => {
@@ -2032,10 +2042,50 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         self.state.input.gestures
     }
 
+    /// Prepare a neighboring live Overview without switching the WM or taking
+    /// any input ownership. Called once at horizontal axis lock, never per frame.
+    pub fn desktop_gesture_overview_scene(&self, wm: &WindowManager<B>, workspace: usize,
+        geometry: Rect) -> wm_core::OverviewScene<B::WindowId, B::FrameId> {
+        use wm_theme::overview::live;
+        let tile = crate::desktop::tile_px(self.state.scale);
+        let clients: Vec<_> = wm.iter_clients().filter(|(_, c)| c.workspace == workspace
+            && matches!(c.lifecycle, Lifecycle::Normal | Lifecycle::Miniaturized)).collect();
+        let sources: Vec<_> = clients.iter().map(|(_, c)| if c.frame.is_some() {
+            Rect::new(Point::new(c.geometry.pos.x - c.layout.client_offset.x,
+                c.geometry.pos.y - c.layout.client_offset.y), c.layout.frame_size)
+        } else { c.geometry }).collect();
+        let sizes: Vec<_> = sources.iter().map(|r| r.size).collect();
+        let layout = live::layout(geometry.size, tile, &sizes, wm.workspace_count().max(workspace + 1));
+        let (mut fonts, mut swash) = (self.fonts.system(), self.fonts.swash());
+        let label_h = (tile / 2).max(16);
+        let mut label = |text: &str, width| live::label(&self.theme, &mut fonts, &mut swash, text, width, label_h);
+        let windows = clients.iter().zip(sources).zip(&layout.cells).map(|(((_, c), source), destination)| {
+            wm_core::OverviewWindow { window: c.window, frame: c.frame, source, destination: *destination,
+                label: label(&c.title, (tile * 6).min(geometry.size.w)) }
+        }).collect();
+        let spaces = layout.strip.iter().enumerate().map(|(i, rect)| {
+            let count = wm.iter_clients().filter(|(_, c)| c.workspace == i
+                && matches!(c.lifecycle, Lifecycle::Normal | Lifecycle::Miniaturized)).count();
+            wm_core::OverviewWorkspace { rect: *rect,
+                label: label(&format!("Desktop {} · {}", i + 1, count), rect.size.w),
+                drop_label: label(&format!("Move to Desktop {}", i + 1), rect.size.w),
+                close: layout.workspace_close_rect(i).map(|r| (r, wm_theme::overview::workspace_close_glyph(r.size.w))) }
+        }).collect();
+        let selected = wm.focused_client().and_then(|focused| clients.iter().position(|(id, _)| *id == focused)).unwrap_or(0);
+        wm_core::OverviewScene { geometry, windows, spaces, workspace, selected, gap: layout.pad }
+    }
+
     /// A desktop swipe can share Overview's grab, but cannot displace another
     /// modal UI or an interactive window drag.
     pub fn desktop_gesture_available(&self, wm: &WindowManager<B>) -> bool {
         !wm.cycle_active() && !wm.interactive_drag_active() && !self.desktop.menu_visible()
+            && !self.desktop.overview_pointer_pending()
+    }
+
+    /// A transition's cleanup must release its own Overview grab even after a
+    /// lock or another modal owner has made new desktop gestures unavailable.
+    pub fn finish_desktop_gesture_overview(&mut self, wm: &mut WindowManager<B>, opened: bool) {
+        if !opened { self.close_overview(wm); }
     }
 
     /// Explicit open/close semantics keep repeated upward swipes from toggling
@@ -2153,7 +2203,13 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             .and_then(|focused| items.iter().position(|item| item.client == focused))
             .unwrap_or(0);
         let workspace = (current, wm.workspace_count());
-        self.desktop.show_overview(wm.backend_mut(), &self.theme, items, workspace, selected);
+        let mut workspace_counts = vec![0; workspace.1];
+        for (_, client) in wm.iter_clients() {
+            if matches!(client.lifecycle, Lifecycle::Normal | Lifecycle::Miniaturized) {
+                if let Some(count) = workspace_counts.get_mut(client.workspace) { *count += 1; }
+            }
+        }
+        self.desktop.show_overview(wm.backend_mut(), &self.theme, items, workspace, &workspace_counts, selected);
     }
 
     /// Ends the session without committing: grab released first, so
@@ -2204,6 +2260,30 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         pressed: bool,
     ) -> ShellOutcome {
         let hit = self.desktop.overview_hit(local);
+        if self.desktop.overview_pointer_pending() {
+            if button == MouseButton::Right && pressed {
+                self.desktop.cancel_overview_pointer(wm.backend_mut(), &self.theme);
+            } else if button == MouseButton::Left && !pressed {
+                match self.desktop.overview_pointer_release(wm.backend_mut(), &self.theme, local) {
+                    Some(OverviewRelease::Click(index)) => {
+                        self.desktop.select_overview_card(wm.backend_mut(), &self.theme, index);
+                        self.commit_overview(wm);
+                    }
+                    Some(OverviewRelease::Move { client, source, target })
+                        // Revalidate both identity and the displayed desktop
+                        // row. Never turn a stale drop into desktop creation.
+                        if self.desktop.overview_workspace() == (wm.current_workspace(), wm.workspace_count())
+                            && target < wm.workspace_count()
+                            && wm.client(client).is_some_and(|c| c.workspace == source
+                                && matches!(c.lifecycle, Lifecycle::Normal | Lifecycle::Miniaturized)) => {
+                            wm.move_client_to_workspace(client, target);
+                            self.populate_overview(wm);
+                    }
+                    _ => {}
+                }
+            }
+            return ShellOutcome::Continue;
+        }
         if pressed {
             self.overview_close_pressed = None;
             match (button, hit) {
@@ -2212,6 +2292,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                 }
                 (MouseButton::Left, OverviewHit::Card(index)) => {
                     self.desktop.select_overview_card(wm.backend_mut(), &self.theme, index);
+                    self.desktop.overview_pointer_press(wm.backend_mut(), index, local);
                 }
                 // Right-click: the same window-commands menu a
                 // titlebar right-click opens, for the window this card
@@ -2257,10 +2338,6 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             if let Some(index) = self.overview_close_pressed.take() {
                 if hit == OverviewHit::CloseWorkspace(index) && wm.remove_workspace(index) {
                     self.populate_overview(wm);
-                }
-            } else if let OverviewHit::Card(index) = hit {
-                if index == self.desktop.overview_selected() {
-                    self.commit_overview(wm);
                 }
             }
         }
@@ -2750,6 +2827,12 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
     /// does.
     pub fn on_motion(&mut self, wm: &mut WindowManager<B>, root: Point) {
         self.pointer_root = root;
+        if self.desktop.overview_pointer_motion(wm.backend_mut(), &self.theme, root) {
+            // A held card owns motion even outside the Overview output. Drain
+            // stale hover so a later release cannot select a different card.
+            while wm.backend_mut().take_shell_motion().is_some() {}
+            return;
+        }
         self.desktop.drag_icon_motion(wm.backend_mut(), root);
         self.desktop.drag_item_motion(wm.backend_mut(), &self.theme, root);
         // Which dock tile the pointer is inside, from root coordinates
@@ -3018,6 +3101,9 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             self.desktop.update_overview_previews(wm.backend_mut(), &self.theme, previews, generation);
         }
         let (current, count) = (wm.current_workspace(), wm.workspace_count());
+        if self.desktop.overview_visible() && self.desktop.overview_workspace() != (current, count) {
+            self.populate_overview(wm);
+        }
         self.desktop.set_workspace_display(wm.backend_mut(), &self.theme, current, count);
         self.desktop.tick_menu(wm.backend_mut(), &self.theme);
         self.desktop.tick_items(wm.backend_mut(), &self.theme);

--- a/crates/chonk-testkit/src/bin/chonk-input-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-input-probe.rs
@@ -27,6 +27,10 @@ use wayland_client::protocol::{
     wl_touch,
 };
 use wayland_client::{Connection, Dispatch, QueueHandle};
+use wayland_protocols::wp::pointer_gestures::zv1::client::{
+    zwp_pointer_gestures_v1::ZwpPointerGesturesV1,
+    zwp_pointer_gesture_swipe_v1::{self, ZwpPointerGestureSwipeV1},
+};
 use wayland_protocols::wp::keyboard_shortcuts_inhibit::zv1::client::{
     zwp_keyboard_shortcuts_inhibit_manager_v1::ZwpKeyboardShortcutsInhibitManagerV1,
     zwp_keyboard_shortcuts_inhibitor_v1::{self, ZwpKeyboardShortcutsInhibitorV1},
@@ -65,6 +69,7 @@ struct Probe {
     seat: Option<wl_seat::WlSeat>,
     seat_version: u32,
     pointer: Option<wl_pointer::WlPointer>,
+    gestures: Option<ZwpPointerGesturesV1>,
     keyboard: Option<wl_keyboard::WlKeyboard>,
     text_input_manager: Option<ZwpTextInputManagerV3>,
     input_method_manager: Option<ZwpInputMethodManagerV2>,
@@ -121,6 +126,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
                     probe.compositor = Some(registry.bind(name, version.min(4), qh, ()))
                 }
                 "wl_subcompositor" => probe.subcompositor = Some(registry.bind(name, 1, qh, ())),
+                "zwp_pointer_gestures_v1" => probe.gestures = Some(registry.bind(name, version.min(3), qh, ())),
                 "wl_shm" => probe.shm = Some(registry.bind(name, 1, qh, ())),
                 "xdg_wm_base" => probe.wm_base = Some(registry.bind(name, version.min(3), qh, ())),
                 "wl_seat" => {
@@ -521,7 +527,20 @@ impl Dispatch<XdgSurface, ()> for Probe {
         _: &QueueHandle<Self>,
     ) {
         if let xdg_surface::Event::Configure { serial } = event {
+            say(&format!("surface configure {serial}"));
             surface.ack_configure(serial);
+        }
+    }
+}
+
+impl Dispatch<ZwpPointerGestureSwipeV1, ()> for Probe {
+    fn event(_: &mut Self, _: &ZwpPointerGestureSwipeV1, event: zwp_pointer_gesture_swipe_v1::Event,
+        _: &(), _: &Connection, _: &QueueHandle<Self>) {
+        match event {
+            zwp_pointer_gesture_swipe_v1::Event::Begin { fingers, .. } => say(&format!("swipe begin {fingers}")),
+            zwp_pointer_gesture_swipe_v1::Event::Update { dx, dy, .. } => say(&format!("swipe update {dx} {dy}")),
+            zwp_pointer_gesture_swipe_v1::Event::End { cancelled, .. } => say(&format!("swipe end {cancelled}")),
+            _ => {}
         }
     }
 }
@@ -539,6 +558,7 @@ macro_rules! ignore_events {
 }
 
 ignore_events!(
+    ZwpPointerGesturesV1,
     ZwpKeyboardShortcutsInhibitManagerV1,
     ZwpInputMethodManagerV2,
     ZwpTextInputManagerV3,
@@ -583,6 +603,7 @@ fn main() {
     };
     queue.roundtrip(&mut probe).expect("registry");
     queue.roundtrip(&mut probe).expect("seat capabilities");
+    let _swipe = probe.gestures.as_ref().map(|manager| manager.get_swipe_gesture(probe.pointer.as_ref().expect("pointer"), &qh, ()));
     let _input_method = std::env::args().any(|arg| arg == "ime").then(|| {
         probe
             .input_method_manager

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1107,10 +1107,29 @@ pub struct World {
     pub shells: Vec<ShellInfo>,
     pub overview: Option<OverviewInfo>,
     pub overview_windows: Vec<OverviewWindowInfo>,
+    pub overview_drag: Option<OverviewDragInfo>,
+    pub gesture: Option<GestureInfo>,
+    pub logical_focus: Option<u64>,
+    pub seat_focus: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+pub struct GestureInfo {
+    pub kind: String, pub axis: String, pub x: f64, pub y: f64,
+    pub raw_progress: f64, pub progress: f64, pub velocity: f64, pub projected: f64,
+    pub target: f64, pub settling: bool, pub origin: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct OverviewDragInfo {
+    pub id: u64,
+    pub rect: wm_theme_api::Rect,
+    pub target: Option<usize>,
 }
 
 #[derive(Clone, Debug)]
 pub struct OverviewInfo {
+    pub progress: f64,
     pub selected: usize,
     pub label_bytes: usize,
     pub preview_edge: u32,
@@ -1309,6 +1328,9 @@ pub struct FrameStats {
     pub render_calls: u64,
     pub render_us: u128,
     pub render_max_us: u128,
+    pub gesture_build_calls: u64,
+    pub gesture_build_us: u128,
+    pub gesture_build_max_us: u128,
     pub flush_us: u128,
     pub ipc_us: u128,
     pub dispatch_histogram: [u64; 16],
@@ -1393,6 +1415,23 @@ impl Door {
     /// Begin a touchpad swipe through the compositor's physical input route.
     pub fn swipe_begin(&mut self, fingers: u32) -> Result<(), String> {
         self.send(&format!("swipe begin {fingers}"))
+    }
+    pub fn reset_input(&mut self, resume: bool) -> Result<(), String> {
+        self.send(if resume { "input-reset resume" } else { "input-reset device" })
+    }
+    pub fn pause_gesture_input(&mut self) -> Result<(), String> {
+        self.send("input-reset pause")
+    }
+
+    /// Timestamped physical-path samples, independent of machine/test speed.
+    pub fn swipe_begin_at(&mut self, fingers: u32, time: u32) -> Result<(), String> {
+        self.send(&format!("swipe-at {time} begin {fingers}"))
+    }
+    pub fn swipe_update_at(&mut self, dx: f64, dy: f64, time: u32) -> Result<(), String> {
+        self.send(&format!("swipe-at {time} update {dx} {dy}"))
+    }
+    pub fn swipe_end_at(&mut self, cancelled: bool, time: u32) -> Result<(), String> {
+        self.send(&format!("swipe-at {time} {}", if cancelled { "cancel" } else { "end" }))
     }
 
     /// Logical touchpad displacement, independent of the nested output scale.
@@ -1610,6 +1649,9 @@ impl Door {
             render_calls: required!("render_calls="),
             render_us: required!("render_us="),
             render_max_us: required!("render_max_us="),
+            gesture_build_calls: field(&line, "gesture_build_calls=").unwrap_or_default(),
+            gesture_build_us: field(&line, "gesture_build_us=").unwrap_or_default(),
+            gesture_build_max_us: field(&line, "gesture_build_max_us=").unwrap_or_default(),
             flush_us: required!("flush_us="),
             ipc_us: required!("ipc_us="),
             dispatch_histogram: histogram_field(&line, "dispatch_hist=")?,
@@ -1735,9 +1777,30 @@ impl Door {
                 world.workspace_count = field(&line, "count=").unwrap_or_default();
             } else if line.starts_with("overview ") {
                 world.overview = Some(OverviewInfo {
+                    progress: field(&line, "progress=").unwrap_or(1.0),
                     selected: field(&line, "selected=").unwrap_or_default(),
                     label_bytes: field(&line, "label_bytes=").unwrap_or_default(),
                     preview_edge: field(&line, "preview_edge=").unwrap_or_default(),
+                });
+            } else if line.starts_with("gesture-focus ") {
+                world.logical_focus = field::<u64>(&line, "logical=").filter(|id| *id != 0);
+                world.seat_focus = field::<u64>(&line, "seat=").filter(|id| *id != 0);
+            } else if line.starts_with("gesture ") {
+                world.gesture = Some(GestureInfo {
+                    kind: field(&line, "kind=").unwrap_or_default(), axis: field(&line, "axis=").unwrap_or_default(),
+                    x: field(&line, "x=").unwrap_or_default(), y: field(&line, "y=").unwrap_or_default(),
+                    raw_progress: field(&line, "raw_progress=").unwrap_or_default(), progress: field(&line, "progress=").unwrap_or_default(),
+                    velocity: field(&line, "velocity=").unwrap_or_default(), projected: field(&line, "projected=").unwrap_or_default(),
+                    target: field(&line, "target=").unwrap_or_default(), settling: field(&line, "settling=").unwrap_or_default(),
+                    origin: field(&line, "origin=").unwrap_or_default(),
+                });
+            } else if line.starts_with("overview-drag ") {
+                world.overview_drag = Some(OverviewDragInfo {
+                    id: field(&line, "id=").unwrap_or_default(),
+                    rect: wm_theme_api::Rect::new(
+                        wm_theme_api::Point::new(field(&line, "x=").unwrap_or_default(), field(&line, "y=").unwrap_or_default()),
+                        wm_theme_api::Size::new(field(&line, "w=").unwrap_or_default(), field(&line, "h=").unwrap_or_default())),
+                    target: field::<i64>(&line, "target=").and_then(|i| usize::try_from(i).ok()),
                 });
             } else if line.starts_with("overview-window ") {
                 world.overview_windows.push(OverviewWindowInfo {

--- a/crates/chonk-testkit/tests/desktop_gestures.rs
+++ b/crates/chonk-testkit/tests/desktop_gestures.rs
@@ -1,13 +1,462 @@
 //! Drive the actual swipe input route against real windows and layer surfaces.
-use chonk_testkit::{poll_until, profile_binary, Session, SessionOptions, World};
+use chonk_testkit::{keys, poll_until, profile_binary, Session, SessionOptions, World};
 use std::time::Duration;
 
 fn swipe(session: &mut Session, fingers: u32, x: f64, y: f64, cancelled: bool) {
     let door = session.door();
-    door.swipe_begin(fingers).unwrap();
-    door.swipe_update(x, y).unwrap();
-    door.swipe_end(cancelled).unwrap();
+    door.swipe_begin_at(fingers, 0).unwrap();
+    door.swipe_update_at(x, y, 200).unwrap();
+    door.swipe_end_at(cancelled, 350).unwrap();
     door.barrier().unwrap();
+    settled(session);
+}
+
+fn settled(session: &mut Session) -> World {
+    poll_until(Duration::from_secs(4), "gesture spring settlement", || {
+        let world = session.world().ok()?;
+        world.gesture.is_none().then_some(world)
+    })
+    .unwrap()
+}
+
+fn probe(session: &mut Session, scale: f64) -> u64 {
+    let binary = profile_binary("chonk-input-probe").unwrap();
+    session
+        .launch(binary.to_str().unwrap(), &[&scale.to_string()])
+        .unwrap();
+    poll_until(Duration::from_secs(15), "gesture input probe", || {
+        session
+            .world()
+            .ok()?
+            .window_matching("input-probe")
+            .map(|w| w.id)
+    })
+    .unwrap()
+}
+
+fn following(session: &mut Session, x: f64, y: f64, time: u32) -> chonk_testkit::GestureInfo {
+    session.door().swipe_update_at(x, y, time).unwrap();
+    session
+        .world()
+        .unwrap()
+        .gesture
+        .expect("finger-following scene")
+}
+
+fn red_center(shot: &chonk_testkit::Screenshot) -> (f64, f64) {
+    let (mut xsum, mut ysum, mut count) = (0_u64, 0_u64, 0_u64);
+    for y in (0..shot.height).step_by(3) {
+        for x in (0..shot.width).step_by(3) {
+            let [r, g, b, _] = shot.pixel(x, y);
+            if r > 140 && g < 100 && b < 100 {
+                xsum += u64::from(x);
+                ysum += u64::from(y);
+                count += 1;
+            }
+        }
+    }
+    assert!(
+        count > 100,
+        "live red client pixels: {}",
+        shot.path.display()
+    );
+    (xsum as f64 / count as f64, ysum as f64 / count as f64)
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn fingers_move_live_pixels_without_switching_configuring_or_exposing_pointer_targets() {
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(
+            &format!("gesture-follow-{scale}"),
+            SessionOptions {
+                scale: Some(scale),
+                config_extra: "show_dock = false\n".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let id = probe(&mut session, f64::from(scale));
+        session.door().barrier().unwrap();
+        let initial = session.world().unwrap();
+        let window = initial.windows.iter().find(|w| w.id == id).unwrap();
+        let (cx, cy) = (
+            window.x + window.w as i32 / 2,
+            window.y + window.h as i32 / 2,
+        );
+        session.door().motion(cx as f64, cy as f64).unwrap();
+        let before = red_center(&session.screenshot("before").unwrap());
+        let configures = session
+            .client_log("chonk-input-probe")
+            .matches("surface configure ")
+            .count();
+        session.door().swipe_begin_at(3, 0).unwrap();
+        session.door().swipe_update_at(-5.0, -2.0, 20).unwrap();
+        assert!(
+            session.world().unwrap().gesture.is_none(),
+            "jitter has no visual owner"
+        );
+        let first = following(&mut session, -15.0, 0.0, 40);
+        assert_eq!(first.progress, 0.125);
+        assert_eq!(session.door().hit(cx, cy).unwrap(), "root");
+        let moved = red_center(&session.screenshot("following").unwrap());
+        // New clients begin at the left edge. Measure the visible clipped
+        // rectangle, not the centroid of pixels that have left the output.
+        let shift = initial.output_w as f64 * 0.125;
+        let expected = ((window.x as f64 - shift).max(0.0)
+            + (window.x as f64 + window.w as f64 - shift).min(initial.output_w as f64))
+            / 2.0;
+        assert!(
+            (moved.0 - expected).abs() < 3.0,
+            "normalized slide: {moved:?}, expected x={expected}"
+        );
+        let second = following(&mut session, -20.0, 0.0, 60);
+        assert_eq!(second.progress, 0.25);
+        let reverse = following(&mut session, 20.0, 0.0, 80);
+        assert_eq!(reverse.progress, 0.125);
+        assert_eq!(session.world().unwrap().current_workspace, 0);
+        let unchanged = session.world().unwrap();
+        let actual = unchanged.windows.iter().find(|w| w.id == id).unwrap();
+        assert_eq!(
+            (actual.x, actual.y, actual.w, actual.h),
+            (window.x, window.y, window.w, window.h)
+        );
+        assert_eq!(
+            session
+                .client_log("chonk-input-probe")
+                .matches("surface configure ")
+                .count(),
+            configures
+        );
+        session.door().swipe_end_at(false, 250).unwrap();
+        assert_eq!(
+            settled(&mut session).current_workspace,
+            0,
+            "slow early release cancels"
+        );
+        let restored = red_center(&session.screenshot("restored").unwrap());
+        assert!((before.0 - restored.0).abs() < 1.0);
+
+        // A fast release at 1/4 span must commit, despite insufficient distance.
+        session.door().swipe_begin_at(4, 1000).unwrap();
+        following(&mut session, -20.0, 0.0, 1020);
+        following(&mut session, -20.0, 0.0, 1040);
+        session.door().swipe_end_at(false, 1040).unwrap();
+        assert_eq!(settled(&mut session).current_workspace, 1);
+        swipe(&mut session, 3, 100.0, 0.0, false);
+        // Cross midpoint, then reverse briskly: trajectory wins over max distance.
+        session.door().swipe_begin_at(3, 2000).unwrap();
+        following(&mut session, -120.0, 0.0, 2200);
+        following(&mut session, 16.0, 0.0, 2220);
+        following(&mut session, 16.0, 0.0, 2240);
+        session.door().swipe_end_at(false, 2240).unwrap();
+        assert_eq!(settled(&mut session).current_workspace, 0);
+        // Continuous topology crosses origin; first-desktop edge is elastic.
+        session.door().swipe_begin_at(3, 3000).unwrap();
+        following(&mut session, -40.0, 0.0, 3020);
+        let edge = following(&mut session, 80.0, 0.0, 3040);
+        assert!(edge.progress < 0.0 && edge.progress > -0.18);
+        let farther = following(&mut session, 10000.0, 0.0, 3060);
+        assert!(farther.progress < edge.progress && farther.progress > -0.18);
+        session.door().swipe_end_at(false, 3060).unwrap();
+        assert_eq!(settled(&mut session).current_workspace, 0);
+    }
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn overview_morph_follows_reverses_flicks_and_never_resizes_live_clients() {
+    for scale in [1.0, 2.0] {
+        let mut session = Session::boot(
+            &format!("overview-morph-{scale}"),
+            SessionOptions {
+                scale: Some(scale),
+                config_extra: "show_dock = false\n".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        probe(&mut session, f64::from(scale));
+        session.door().barrier().unwrap();
+        let before = red_center(&session.screenshot("desktop").unwrap());
+        let configures = session
+            .client_log("chonk-input-probe")
+            .matches("surface configure ")
+            .count();
+        session.door().swipe_begin_at(3, 0).unwrap();
+        assert_eq!(following(&mut session, 0.0, -40.0, 100).progress, 0.25);
+        let quarter = red_center(&session.screenshot("quarter").unwrap());
+        assert_eq!(session.world().unwrap().overview.unwrap().progress, 0.25);
+        assert_eq!(following(&mut session, 0.0, -40.0, 200).progress, 0.5);
+        let half_shot = session.screenshot("half").unwrap();
+        let half = red_center(&half_shot);
+        let half_world = session.world().unwrap();
+        let card = &half_world.overview_windows[0];
+        let source = half_world.frame_of(card.id).unwrap();
+        let ring_x = ((source.x + card.rect.pos.x) as f64 / 2.0).round() as u32 - 1;
+        let ring_y = ((source.y + card.rect.pos.y) as f64 / 2.0
+            + (source.h + card.rect.size.h) as f64 / 4.0).round() as u32;
+        let [r, g, b, _] = half_shot.pixel(ring_x, ring_y);
+        assert!(b > g.saturating_add(20) && b > r.saturating_add(40),
+            "selection ring must follow the interpolated window, not float at its final position: {r},{g},{b}");
+        assert!((half.1 - before.1).abs() > (quarter.1 - before.1).abs() + 1.0);
+        assert_eq!(following(&mut session, 0.0, 40.0, 300).progress, 0.25);
+        session.door().swipe_end_at(false, 450).unwrap();
+        assert!(settled(&mut session).overview.is_none());
+        assert_eq!(
+            session
+                .client_log("chonk-input-probe")
+                .matches("surface configure ")
+                .count(),
+            configures,
+            "morphs transform client textures without issuing configure events"
+        );
+        session.door().swipe_begin_at(4, 1000).unwrap();
+        following(&mut session, 0.0, -20.0, 1020);
+        following(&mut session, 0.0, -20.0, 1040);
+        session.door().swipe_end_at(false, 1040).unwrap();
+        assert_eq!(settled(&mut session).overview.unwrap().progress, 1.0);
+        session.door().swipe_begin_at(3, 2000).unwrap();
+        assert_eq!(following(&mut session, 0.0, 40.0, 2100).progress, 0.75);
+        assert_eq!(following(&mut session, 0.0, -20.0, 2200).progress, 0.875);
+        session.door().swipe_end_at(false, 2350).unwrap();
+        assert_eq!(settled(&mut session).overview.unwrap().progress, 1.0);
+        session.door().swipe_begin_at(3, 3000).unwrap();
+        following(&mut session, 0.0, 20.0, 3020);
+        following(&mut session, 0.0, 20.0, 3040);
+        session.door().swipe_end_at(false, 3040).unwrap();
+        assert!(settled(&mut session).overview.is_none());
+    }
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn cancellation_resume_device_loss_and_spring_interruption_release_scene_ownership() {
+    let mut session = Session::boot("gesture-ownership", SessionOptions::default()).unwrap();
+    let id = probe(&mut session, 2.0);
+    for (x, y) in [(-60.0, 0.0), (0.0, -60.0)] {
+        for resume in [false, true] {
+            session.door().swipe_begin_at(3, 0).unwrap();
+            following(&mut session, x, y, 20);
+            session.door().reset_input(resume).unwrap();
+            let world = session.world().unwrap();
+            assert!(world.gesture.is_none() && world.overview.is_none());
+            session.door().swipe_update_at(x, y, 40).unwrap();
+            session.door().swipe_end_at(false, 60).unwrap();
+            assert_eq!(settled(&mut session).current_workspace, 0);
+        }
+        swipe(&mut session, 3, x * 3.0, y * 3.0, true);
+        session.door().swipe_begin_at(3, 0).unwrap();
+        following(&mut session, x, y, 20);
+        session.door().pause_gesture_input().unwrap();
+        assert!(session.world().unwrap().gesture.is_none());
+        session.door().swipe_end_at(false, 40).unwrap();
+        assert_eq!(session.world().unwrap().current_workspace, 0);
+        assert!(session.world().unwrap().overview.is_none());
+    }
+    session.door().swipe_begin_at(3, 1000).unwrap();
+    following(&mut session, -100.0, 0.0, 1200);
+    session.door().swipe_end_at(false, 1350).unwrap();
+    session.door().swipe_begin_at(4, 1400).unwrap();
+    let caught = session.world().unwrap().gesture.unwrap();
+    assert!(!caught.settling && caught.progress >= 0.625);
+    let reversed = following(&mut session, 40.0, 0.0, 1420);
+    assert!(reversed.progress < caught.progress);
+    session.door().swipe_end_at(true, 1440).unwrap();
+    assert_eq!(settled(&mut session).current_workspace, 0);
+    assert!(session.world().unwrap().frame_of(id).unwrap().mapped);
+    // A modal command interrupts before it can operate on a visual neighbor.
+    session.door().swipe_begin_at(3, 2000).unwrap();
+    following(&mut session, -60.0, 0.0, 2020);
+    session.door().chord(keys::LEFTMETA, keys::UP).unwrap();
+    assert!(session.world().unwrap().gesture.is_none());
+    session.door().tap_key(keys::ESC).unwrap();
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn unclaimed_swipe_protocol_streams_reach_clients_whole() {
+    for enabled in [true, false] {
+        let mut session = Session::boot(
+            &format!("gesture-passthrough-{enabled}"),
+            SessionOptions {
+                scale: Some(1.0),
+                config_extra: format!("[input.gestures]\nenabled = {enabled}\n"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let id = probe(&mut session, 1.0);
+        let world = session.world().unwrap();
+        let window = world.windows.iter().find(|w| w.id == id).unwrap();
+        session
+            .door()
+            .motion((window.x + 100) as f64, (window.y + 100) as f64)
+            .unwrap();
+        for fingers in [2, 5, 3, 4] {
+            swipe(&mut session, fingers, -30.0, 0.0, false);
+        }
+        let count = if enabled { 2 } else { 4 };
+        poll_until(
+            Duration::from_secs(5),
+            "complete client swipe streams",
+            || {
+                let log = session.client_log("chonk-input-probe");
+                (log.matches("swipe end 0").count() == count).then_some(())
+            },
+        )
+        .unwrap();
+        let log = session.client_log("chonk-input-probe");
+        assert_eq!(log.matches("swipe begin ").count(), count);
+        assert_eq!(log.matches("swipe update ").count(), count);
+    }
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn adjacent_live_workspace_has_no_focus_until_the_single_commit_and_then_stops_animating() {
+    let mut session = Session::boot(
+        "gesture-adjacent-focus",
+        SessionOptions {
+            scale: Some(1.0),
+            config_extra: "show_dock = false\n[keybindings]\n\"super+2\" = \"workspace 2\"\n"
+                .into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let red = probe(&mut session, 1.0);
+    session.door().chord(keys::LEFTMETA, keys::TWO).unwrap();
+    let green = terminal(&mut session);
+    session.door().barrier().unwrap();
+    let initial = session.world().unwrap();
+    assert_eq!(
+        (
+            initial.current_workspace,
+            initial.logical_focus,
+            initial.seat_focus
+        ),
+        (1, Some(green), Some(green))
+    );
+    session.door().swipe_begin_at(3, 0).unwrap();
+    following(&mut session, 140.0, 0.0, 200);
+    let visible = session.world().unwrap();
+    assert_eq!(
+        (
+            visible.current_workspace,
+            visible.logical_focus,
+            visible.seat_focus
+        ),
+        (1, Some(green), Some(green))
+    );
+    assert!(
+        !visible.frame_of(red).unwrap().mapped,
+        "neighbor remains semantically hidden"
+    );
+    let red_pixels = red_center(&session.screenshot("adjacent-live-red").unwrap());
+    assert!(
+        red_pixels.0 < 250.0,
+        "hidden neighbor's live pixels enter from the left"
+    );
+    session.door().motion(red_pixels.0, red_pixels.1).unwrap();
+    session.door().barrier().unwrap();
+    assert_eq!(session.world().unwrap().logical_focus, Some(green));
+    session.door().swipe_end_at(false, 350).unwrap();
+    settled(&mut session);
+    session.door().barrier().unwrap();
+    let committed = session.world().unwrap();
+    assert_eq!(
+        (
+            committed.current_workspace,
+            committed.logical_focus,
+            committed.seat_focus
+        ),
+        (0, Some(red), Some(red))
+    );
+
+    // Warm a scene, then measure genuine frame work independently of test-door
+    // round-trip wall time. Metrics are diagnostic, not flaky timing limits.
+    session.door().swipe_begin_at(3, 1000).unwrap();
+    following(&mut session, -20.0, 0.0, 1020);
+    session.door().barrier().unwrap();
+    session.door().frame_stats().unwrap();
+    for i in 1..=120 {
+        following(
+            &mut session,
+            if i % 40 < 20 { -0.5 } else { 0.5 },
+            0.0,
+            1020 + i * 8,
+        );
+        session.door().barrier().unwrap();
+    }
+    let frames = session.door().frame_stats().unwrap();
+    eprintln!("120 warm finger-following updates (nested GLES): {frames:?}");
+    session.door().swipe_end_at(true, 2100).unwrap();
+    settled(&mut session);
+    session.door().barrier().unwrap();
+    session.door().frame_stats().unwrap();
+    let until = std::time::Instant::now() + Duration::from_millis(160);
+    poll_until(Duration::from_secs(2), "settled scene remains idle", || {
+        let world = session.world().ok()?;
+        assert!(world.gesture.is_none());
+        (std::time::Instant::now() >= until).then_some(())
+    })
+    .unwrap();
+    assert_eq!(
+        session.door().frame_stats().unwrap().render_calls,
+        0,
+        "no spring deadline or animation frames survive settlement"
+    );
+}
+
+#[test]
+#[ignore = "requires nested Wayland"]
+fn lock_and_held_client_pointer_grabs_cannot_inherit_partial_desktop_scenes() {
+    for (name, x, y) in [("workspace", -60.0, 0.0), ("overview", 0.0, -60.0)] {
+        let mut session = Session::boot(
+            &format!("gesture-lock-{name}"),
+            SessionOptions {
+                scale: Some(1.0),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let id = probe(&mut session, 1.0);
+        let world = session.world().unwrap();
+        let window = world.windows.iter().find(|w| w.id == id).unwrap();
+        session
+            .door()
+            .motion((window.x + 100) as f64, (window.y + 100) as f64)
+            .unwrap();
+        session.door().button("left", true).unwrap();
+        session.door().barrier().unwrap();
+        session.door().swipe_begin_at(3, 0).unwrap();
+        session.door().swipe_update_at(x, y, 20).unwrap();
+        assert!(session.world().unwrap().gesture.is_none());
+        session.door().swipe_end_at(false, 40).unwrap();
+        session.door().button("left", false).unwrap();
+        session.door().barrier().unwrap();
+        session.door().swipe_begin_at(4, 1000).unwrap();
+        following(&mut session, x, y, 1020);
+        let locker = profile_binary("chonk-lock-probe").unwrap();
+        session
+            .launch(locker.to_str().unwrap(), &["--hold"])
+            .unwrap();
+        poll_until(Duration::from_secs(10), "lock owns presentation", || {
+            session
+                .client_log("chonk-lock-probe")
+                .contains("locked ")
+                .then_some(())
+        })
+        .unwrap();
+        let locked = session.world().unwrap();
+        assert!(locked.gesture.is_none() && locked.overview.is_none());
+        session.door().swipe_update_at(x, y, 1040).unwrap();
+        session.door().swipe_end_at(false, 1060).unwrap();
+        session.door().barrier().unwrap();
+        assert_eq!(session.world().unwrap().current_workspace, 0);
+        assert!(session.world().unwrap().gesture.is_none());
+    }
 }
 
 fn overview(world: &World) -> Option<u64> {
@@ -67,6 +516,7 @@ fn swipes_switch_once_and_open_close_reusable_overview_at_both_scales() {
             "motion alone does not commit"
         );
         session.door().swipe_end(false).unwrap();
+        settled(&mut session);
         assert!(
             !visible(&mut session, window),
             "left advances to the next workspace"
@@ -75,8 +525,11 @@ fn swipes_switch_once_and_open_close_reusable_overview_at_both_scales() {
             swipe(&mut session, 3, -100.0, 0.0, false);
         }
         let empty = session.world().unwrap();
-        assert_eq!((empty.current_workspace, empty.workspace_count), (1, 2),
-            "swiping on the empty final desktop must not create a chain of empty desktops");
+        assert_eq!(
+            (empty.current_workspace, empty.workspace_count),
+            (1, 2),
+            "swiping on the empty final desktop must not create a chain of empty desktops"
+        );
         swipe(&mut session, 4, 100.0, 0.0, false);
         assert!(
             visible(&mut session, window),
@@ -91,10 +544,11 @@ fn swipes_switch_once_and_open_close_reusable_overview_at_both_scales() {
             assert!(visible(&mut session, window));
             assert!(overview(&session.world().unwrap()).is_none());
         }
-        session.door().swipe_begin(4).unwrap();
-        session.door().swipe_update(-120.0, 0.0).unwrap();
-        session.door().swipe_update(115.0, 0.0).unwrap();
-        session.door().swipe_end(false).unwrap();
+        session.door().swipe_begin_at(4, 0).unwrap();
+        session.door().swipe_update_at(-120.0, 0.0, 20).unwrap();
+        session.door().swipe_update_at(115.0, 0.0, 40).unwrap();
+        session.door().swipe_end_at(false, 200).unwrap();
+        settled(&mut session);
         assert!(
             visible(&mut session, window),
             "returning the fingers cancels"

--- a/crates/chonk-testkit/tests/overview.rs
+++ b/crates/chonk-testkit/tests/overview.rs
@@ -431,6 +431,72 @@ fn center(rect: wm_theme_api::Rect) -> (f64, f64) {
 }
 
 #[test]
+#[ignore = "requires nested Wayland"]
+fn dragging_a_live_card_moves_only_that_window_and_keeps_overview_open() {
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(&format!("overview-window-drag-{scale}"), SessionOptions {
+            scale: Some(scale),
+            config_extra: "[keybindings]\n\"super+1\" = \"workspace 1\"\n\"super+2\" = \"workspace 2\"\n".into(),
+            ..Default::default()
+        }).unwrap();
+        launch_terminal(&mut session, "DraggedCard");
+        launch_terminal(&mut session, "StationaryCard");
+        let original = session.world().unwrap();
+        let dragged = original.window_matching("DraggedCard").unwrap().id;
+        let stationary = original.window_matching("StationaryCard").unwrap().id;
+        session.door().chord(keys::LEFTMETA, keys::TWO).unwrap();
+        session.door().chord(keys::LEFTMETA, keys::ONE).unwrap();
+        open_overview(&mut session);
+        let world = session.world().unwrap();
+        let panel = overview_shell(&world).unwrap().id;
+        let cell = world.overview_windows.iter().find(|w| w.id == dragged).unwrap().rect;
+        let from = center(cell);
+        // Tiny finger jitter remains a click, and cannot start the drag scene.
+        session.door().motion(from.0, from.1).unwrap();
+        session.door().button("left", true).unwrap();
+        session.door().motion(from.0 + 1.0, from.1).unwrap();
+        assert!(session.world().unwrap().overview_drag.is_none());
+        // Escape cancels the armed press, not Overview; release cannot activate.
+        session.door().tap_key(keys::ESC).unwrap();
+        session.door().button("left", false).unwrap();
+        assert_eq!(overview_shell(&session.world().unwrap()).unwrap().id, panel);
+        let target = workspace_layout(&world).workspace_close_rect(1).unwrap();
+        let to = center(target);
+        session.door().drag_to(from, to).unwrap();
+        let active = session.world().unwrap();
+        let preview = active.overview_drag.as_ref().expect("live drag image");
+        assert_eq!((preview.id, preview.target), (dragged, Some(1)));
+        assert!(preview.rect.size.w <= world.dock().unwrap().w * 3);
+        assert_eq!(active.current_workspace, 0, "hovering the target is visual, not a switch");
+        session.screenshot("window-over-desktop").unwrap();
+        session.door().button("left", false).unwrap();
+        session.door().barrier().unwrap();
+        let moved = session.world().unwrap();
+        assert!(moved.overview_drag.is_none());
+        assert_eq!(overview_shell(&moved).unwrap().id, panel);
+        assert_eq!((moved.current_workspace, moved.workspace_count), (0, 2), "drop on close corner is a move, never delete");
+        assert!(!moved.frame_of(dragged).unwrap().mapped);
+        assert!(moved.frame_of(stationary).unwrap().mapped);
+        assert!(!moved.overview_windows.iter().any(|w| w.id == dragged));
+        let to = center(workspace_layout(&moved).strip[1]);
+        session.door().click(to.0, to.1).unwrap();
+        let destination = session.world().unwrap();
+        assert_eq!(destination.current_workspace, 1);
+        assert!(destination.overview_windows.iter().any(|w| w.id == dragged));
+        assert!(!destination.overview_windows.iter().any(|w| w.id == stationary));
+        // Dragging into empty space is cancellation, never card activation.
+        let card = destination.overview_windows.iter().find(|w| w.id == dragged).unwrap().rect;
+        session.door().drag_to(center(card), (8.0, destination.output_h as f64 - 8.0)).unwrap();
+        session.door().button("left", false).unwrap();
+        session.door().barrier().unwrap();
+        assert!(session.world().unwrap().overview.is_some());
+        session.door().tap_key(keys::ESC).unwrap();
+        assert_overview_closed(&mut session, "ending drag session");
+        assert!(session.world().unwrap().frame_of(dragged).unwrap().mapped);
+    }
+}
+
+#[test]
 #[ignore = "requires nested Wayland: scripts/e2e.sh --headless --test overview"]
 fn desktop_close_controls_remove_empty_and_occupied_desktops_without_losing_windows() {
     for scale in [1.0, 2.0] {

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -21,6 +21,7 @@ pub struct OverviewWindow<W, F> {
 pub struct OverviewWorkspace {
     pub rect: Rect,
     pub label: DecorationBuffer,
+    pub drop_label: DecorationBuffer,
     pub close: Option<(Rect, DecorationBuffer)>,
 }
 
@@ -33,6 +34,16 @@ pub struct OverviewScene<W, F> {
     pub workspace: usize,
     pub selected: usize,
     pub gap: u32,
+}
+
+/// Pointer-owned Overview presentation. Updating it only moves existing GPU
+/// content; it never configures the application or changes workspace membership.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OverviewDrag {
+    pub index: usize,
+    pub destination: Rect,
+    /// A valid destination desktop, excluding the source desktop.
+    pub workspace: Option<usize>,
 }
 
 /// Everything the protocol-agnostic core needs from a windowing backend
@@ -143,6 +154,10 @@ pub trait Backend {
         let _ = selected;
     }
     fn hide_live_overview(&mut self) {}
+
+    fn drag_live_overview(&mut self, drag: Option<OverviewDrag>) {
+        let _ = drag;
+    }
 
     /// Paints the desktop background — solid color or a wallpaper
     /// image. On X11 this is the root window (plus the root-pixmap

--- a/crates/wm-core/src/gestures.rs
+++ b/crates/wm-core/src/gestures.rs
@@ -1,16 +1,15 @@
-//! Desktop swipe recognition in libinput's logical motion units. No timers,
-//! event buffers or allocations: only the net displacement survives an update.
+//! Allocation-free desktop gesture ownership and timed motion. Progress is
+//! dimensionless: output pixels never enter the recognizer or shared physics.
+pub mod physics;
 
-/// Native touchpad settings, independent of two-finger scrolling and output scale.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct GestureConfig {
     pub enabled: bool,
     /// Zero accepts both three and four fingers; otherwise three or four.
     pub fingers: u32,
-    /// Minimum net travel before lifting the fingers commits an action.
+    /// Slow-release midpoint in logical touchpad units. Full span is twice this.
     pub distance: f64,
 }
-
 impl Default for GestureConfig {
     fn default() -> Self {
         Self {
@@ -20,7 +19,6 @@ impl Default for GestureConfig {
         }
     }
 }
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DesktopGesture {
     WorkspaceNext,
@@ -28,27 +26,161 @@ pub enum DesktopGesture {
     OverviewOpen,
     OverviewClose,
 }
-
-/// One seat's swipe ownership. Once claimed, even a cancelled gesture consumes
-/// its remaining events, so clients never receive half a desktop gesture.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SwipeAxis {
+    Horizontal,
+    Vertical,
+}
+/// Positive progress means left/up. Velocity is progress units per second.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SwipeMotion {
+    pub axis: SwipeAxis,
+    pub x: f64,
+    pub y: f64,
+    pub progress: f64,
+    pub velocity: f64,
+}
+const AXIS_DISTANCE: f64 = 12.0;
+const AXIS_DOMINANCE: f64 = 1.25;
+const SAMPLE_COUNT: usize = 8;
+const SAMPLE_INTERVAL_MS: u32 = 12;
+const HISTORY_MS: u32 = 100;
+const RECENCY_SECONDS: f64 = 0.035;
+#[derive(Clone, Copy, Debug, Default)]
+struct Sample {
+    time: u32,
+    x: f64,
+    y: f64,
+}
+#[derive(Debug)]
+pub struct SwipeState {
+    x: f64,
+    y: f64,
+    axis: Option<SwipeAxis>,
+    span: f64,
+    samples: [Sample; SAMPLE_COUNT],
+    next: usize,
+    count: usize,
+}
+impl SwipeState {
+    fn new(distance: f64, time: u32) -> Self {
+        let mut state = Self {
+            x: 0.0,
+            y: 0.0,
+            axis: None,
+            span: if distance.is_finite() {
+                distance.clamp(24.0, 1000.0) * 2.0
+            } else {
+                160.0
+            },
+            samples: [Sample::default(); SAMPLE_COUNT],
+            next: 0,
+            count: 0,
+        };
+        state.sample(time);
+        state
+    }
+    fn sample(&mut self, time: u32) {
+        if self.count > 0 {
+            let last = self.samples[(self.next + SAMPLE_COUNT - 1) % SAMPLE_COUNT];
+            let elapsed = time.wrapping_sub(last.time);
+            if elapsed > i32::MAX as u32 {
+                self.count = 0;
+            } else if elapsed < SAMPLE_INTERVAL_MS {
+                return;
+            }
+        }
+        self.samples[self.next] = Sample {
+            time,
+            x: self.x,
+            y: self.y,
+        };
+        self.next = (self.next + 1) % SAMPLE_COUNT;
+        self.count = (self.count + 1).min(SAMPLE_COUNT);
+    }
+    fn motion(&self, time: u32) -> Option<SwipeMotion> {
+        let axis = self.axis?;
+        let position = |sample: Sample| {
+            -match axis {
+                SwipeAxis::Horizontal => sample.x,
+                SwipeAxis::Vertical => sample.y,
+            } / self.span
+        };
+        let mut recent = Sample {
+            time,
+            x: self.x,
+            y: self.y,
+        };
+        let mut weighted_motion = 0.0;
+        let mut weighted_time = 0.0;
+        let mut covered_ms = 0;
+        for age in 0..self.count {
+            let older = self.samples[(self.next + SAMPLE_COUNT - age - 1) % SAMPLE_COUNT];
+            let age_ms = time.wrapping_sub(older.time);
+            if age_ms > HISTORY_MS {
+                break;
+            }
+            let dt = recent.time.wrapping_sub(older.time) as f64 / 1000.0;
+            if dt > 0.0 {
+                let weight = (-(age_ms as f64 / 1000.0) / RECENCY_SECONDS).exp();
+                weighted_motion += (position(recent) - position(older)) * weight;
+                weighted_time += dt * weight;
+                covered_ms = age_ms;
+                recent = older;
+            }
+        }
+        Some(SwipeMotion {
+            axis,
+            x: self.x,
+            y: self.y,
+            progress: -match axis {
+                SwipeAxis::Horizontal => self.x,
+                SwipeAxis::Vertical => self.y,
+            } / self.span,
+            velocity: if weighted_time > 0.0 && covered_ms >= SAMPLE_INTERVAL_MS {
+                (weighted_motion / weighted_time)
+                    .clamp(-physics::MAX_VELOCITY, physics::MAX_VELOCITY)
+            } else {
+                0.0
+            },
+        })
+    }
+}
+/// A claimed stream stays consumed through cancellation. Settings are latched.
 #[derive(Default, Debug)]
+// The fixed history deliberately stays on the seat: boxing it would add an
+// allocation at every begin and indirection at every input sample.
+#[allow(clippy::large_enum_variant)]
 pub enum SwipeTracker {
     #[default]
     Idle,
     Client,
     Suppressed,
-    Desktop {
-        x: f64,
-        y: f64,
-        horizontal: Option<bool>,
-        distance: f64,
-    },
+    Desktop(SwipeState),
 }
-
 impl SwipeTracker {
-    /// Returns whether the compositor owns this stream. Settings are latched
-    /// until end, so reloading configuration cannot change its recipient.
-    pub fn begin(&mut self, fingers: u32, config: GestureConfig, available: bool) -> bool {
+    /// Read-only test/debug state; no production logging or owned strings.
+    pub fn state_name(&self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Client => "client",
+            Self::Suppressed => "suppressed",
+            Self::Desktop(_) => "desktop",
+        }
+    }
+    pub fn displacement(&self) -> (f64, f64) {
+        match self {
+            Self::Desktop(state) => (state.x, state.y),
+            _ => (0.0, 0.0),
+        }
+    }
+    pub fn begin(
+        &mut self,
+        fingers: u32,
+        config: GestureConfig,
+        available: bool,
+        time: u32,
+    ) -> bool {
         let claimed = config.enabled
             && matches!(fingers, 3 | 4)
             && (config.fingers == 0 || config.fingers == fingers);
@@ -57,74 +189,60 @@ impl SwipeTracker {
         } else if !available {
             Self::Suppressed
         } else {
-            Self::Desktop {
-                x: 0.0,
-                y: 0.0,
-                horizontal: None,
-                distance: config.distance,
-            }
+            Self::Desktop(SwipeState::new(config.distance, time))
         };
         claimed
     }
-
-    pub fn update(&mut self, dx: f64, dy: f64, available: bool) -> bool {
-        if let Self::Desktop {
-            x, y, horizontal, ..
-        } = self
-        {
+    pub fn update(&mut self, dx: f64, dy: f64, available: bool, time: u32) -> bool {
+        if let Self::Desktop(state) = self {
             if !available || !dx.is_finite() || !dy.is_finite() {
                 *self = Self::Suppressed;
                 return true;
             }
-            *x += dx;
-            *y += dy;
-            if !x.is_finite() || !y.is_finite() {
+            state.x += dx;
+            state.y += dy;
+            if !state.x.is_finite()
+                || !state.y.is_finite()
+                || state.x.abs().max(state.y.abs()) > 1e9
+            {
                 *self = Self::Suppressed;
                 return true;
             }
-            // Ignore initial jitter and ambiguous diagonals. Once an axis is
-            // chosen, a curved stroke cannot turn into a different action.
-            if horizontal.is_none() && x.abs().max(y.abs()) >= 12.0 {
-                if x.abs() > y.abs() * 1.25 {
-                    *horizontal = Some(true);
-                } else if y.abs() > x.abs() * 1.25 {
-                    *horizontal = Some(false);
+            if state.axis.is_none() && state.x.abs().max(state.y.abs()) >= AXIS_DISTANCE {
+                if state.x.abs() > state.y.abs() * AXIS_DOMINANCE {
+                    state.axis = Some(SwipeAxis::Horizontal);
+                } else if state.y.abs() > state.x.abs() * AXIS_DOMINANCE {
+                    state.axis = Some(SwipeAxis::Vertical);
                 }
             }
+            state.sample(time);
         }
         !matches!(self, Self::Client)
     }
-
-    /// Commit only on a successful lift. Net distance makes reversing back to
-    /// the start a cancellation; a long stroke still advances exactly once.
-    pub fn end(&mut self, cancelled: bool, available: bool) -> (bool, Option<DesktopGesture>) {
+    pub fn motion(&self, time: u32) -> Option<SwipeMotion> {
+        match self {
+            Self::Desktop(state) => state.motion(time),
+            _ => None,
+        }
+    }
+    pub fn end(
+        &mut self,
+        cancelled: bool,
+        available: bool,
+        time: u32,
+    ) -> (bool, Option<SwipeMotion>) {
         let stream = std::mem::take(self);
         let consumed = !matches!(stream, Self::Client);
-        let action = match stream {
-            Self::Desktop {
-                x,
-                y,
-                horizontal: Some(horizontal),
-                distance,
-            } if !cancelled && available => {
-                let travel = if horizontal { x } else { y };
-                if travel.abs() < distance {
-                    None
-                } else {
-                    Some(match (horizontal, travel < 0.0) {
-                        (true, true) => DesktopGesture::WorkspaceNext,
-                        (true, false) => DesktopGesture::WorkspacePrevious,
-                        (false, true) => DesktopGesture::OverviewOpen,
-                        (false, false) => DesktopGesture::OverviewClose,
-                    })
-                }
-            }
-            _ => None,
-        };
-        (consumed, action)
+        (
+            consumed,
+            if !cancelled && available {
+                stream.motion(time)
+            } else {
+                None
+            },
+        )
     }
-
-    /// Returns whether a forwarded client needs a cancellation event.
+    /// Whether a forwarded client needs a cancelled end.
     pub fn cancel(&mut self) -> bool {
         let client = matches!(self, Self::Client);
         *self = Self::Suppressed;
@@ -135,46 +253,40 @@ impl SwipeTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
-    fn mac_directions_and_finger_counts() {
+    fn fingers_axes_jitter_and_reversal() {
         for fingers in [3, 4] {
-            for (dx, dy, action) in [
-                (-90.0, 1.0, DesktopGesture::WorkspaceNext),
-                (90.0, 1.0, DesktopGesture::WorkspacePrevious),
-                (1.0, -90.0, DesktopGesture::OverviewOpen),
-                (1.0, 90.0, DesktopGesture::OverviewClose),
-            ] {
-                let mut swipe = SwipeTracker::default();
-                assert!(swipe.begin(fingers, GestureConfig::default(), true));
-                assert!(swipe.update(dx, dy, true));
-                assert_eq!(swipe.end(false, true), (true, Some(action)));
-                assert_eq!(swipe.end(false, true), (true, None));
-            }
+            let mut s = SwipeTracker::default();
+            assert!(s.begin(fingers, GestureConfig::default(), true, 0));
+            s.update(-5.0, -2.0, true, 16);
+            assert!(s.motion(16).is_none());
+            s.update(-35.0, 0.0, true, 32);
+            assert_eq!(s.motion(32).unwrap().axis, SwipeAxis::Horizontal);
+            assert_eq!(s.motion(32).unwrap().progress, 0.25);
+            s.update(20.0, -100.0, true, 48);
+            assert_eq!(s.motion(48).unwrap().progress, 0.125);
+            s.update(60.0, 0.0, true, 64);
+            assert_eq!(s.motion(64).unwrap().progress, -0.25);
+            assert!(s.end(true, true, 80).1.is_none());
+            assert!(matches!(s, SwipeTracker::Idle));
         }
     }
-
     #[test]
-    fn jitter_diagonals_reversals_and_cancellation_do_nothing() {
-        for (updates, cancelled) in [
-            (vec![(5.0, 2.0)], false),
-            (vec![(100.0, 100.0)], false),
-            (vec![(-120.0, 0.0), (110.0, 0.0)], false),
-            (vec![(-120.0, 0.0)], true),
-            (vec![(f64::NAN, 0.0)], false),
-            (vec![(0.0, f64::INFINITY)], false),
+    fn ambiguous_invalid_and_lost_ownership_stay_consumed() {
+        for (dx, dy, available) in [
+            (100.0, 100.0, true),
+            (f64::NAN, 0.0, true),
+            (0.0, f64::INFINITY, true),
+            (-100.0, 0.0, false),
         ] {
-            let mut swipe = SwipeTracker::default();
-            swipe.begin(4, GestureConfig::default(), true);
-            for (x, y) in updates {
-                swipe.update(x, y, true);
-            }
-            assert_eq!(swipe.end(cancelled, true), (true, None));
+            let mut s = SwipeTracker::default();
+            s.begin(3, GestureConfig::default(), true, 0);
+            assert!(s.update(dx, dy, available, 16));
+            assert_eq!(s.end(false, true, 32), (true, None));
         }
     }
-
     #[test]
-    fn client_streams_and_disabled_gestures_remain_whole() {
+    fn client_streams_are_whole_and_can_be_cancelled() {
         for (fingers, config) in [
             (2, GestureConfig::default()),
             (5, GestureConfig::default()),
@@ -193,39 +305,53 @@ mod tests {
                 },
             ),
         ] {
+            let mut s = SwipeTracker::default();
+            assert!(!s.begin(fingers, config, true, 0));
+            assert!(!s.update(-100.0, 0.0, true, 16));
+            assert_eq!(s.end(false, true, 32), (false, None));
+            s.begin(fingers, config, true, 40);
+            assert!(s.cancel());
+            assert!(!s.cancel());
+            assert!(s.update(-100.0, 0.0, true, 48));
+        }
+    }
+    #[test]
+    fn velocity_uses_history_and_decays_when_the_hand_stops() {
+        let mut s = SwipeTracker::default();
+        s.begin(4, GestureConfig::default(), true, 1000);
+        for time in (1016..=1096).step_by(16) {
+            s.update(-8.0, 0.0, true, time);
+        }
+        assert!((s.motion(1096).unwrap().velocity - 3.125).abs() < 0.01);
+        s.update(0.0, 0.0, true, 1097);
+        assert!(s.motion(1097).unwrap().velocity > 2.5);
+        for time in (1112..=1160).step_by(16) {
+            s.update(12.0, 0.0, true, time);
+        }
+        assert!(s.motion(1160).unwrap().velocity < -2.0);
+        assert_eq!(s.motion(1300).unwrap().velocity, 0.0);
+    }
+    #[test]
+    fn high_rate_history_covers_time_not_just_eight_events() {
+        let mut s = SwipeTracker::default();
+        s.begin(3, GestureConfig::default(), true, u32::MAX - 40);
+        for i in 1..=100 {
+            s.update(-0.5, 0.0, true, (u32::MAX - 40).wrapping_add(i));
+        }
+        assert!((s.motion(59).unwrap().velocity - 3.125).abs() < 0.01);
+        assert!(std::mem::size_of::<SwipeTracker>() < 320);
+    }
+    #[test]
+    fn coalesced_same_timestamp_reversal_keeps_the_newest_position() {
+        for time in 0..=40 {
             let mut swipe = SwipeTracker::default();
-            assert!(!swipe.begin(fingers, config, true));
-            assert!(!swipe.update(-100.0, 0.0, true));
-            assert_eq!(swipe.end(false, true), (false, None));
+            swipe.begin(3, GestureConfig::default(), true, 0);
+            swipe.update(-120.0, 0.0, true, time);
+            swipe.update(115.0, 0.0, true, time);
+            let motion = swipe.end(false, true, time).1.unwrap();
+            assert_eq!(motion.progress, 0.03125);
+            assert_eq!(physics::settle_target(motion.progress, motion.velocity, -1.0, 1.0), 0.0,
+                "zero-duration samples cannot resurrect the pre-reversal position at {time}ms");
         }
-    }
-
-    #[test]
-    fn lost_ownership_never_resumes_or_leaks_a_partial_stream() {
-        let mut swipe = SwipeTracker::default();
-        swipe.begin(3, GestureConfig::default(), true);
-        swipe.update(-120.0, 0.0, false);
-        swipe.update(-120.0, 0.0, true);
-        assert_eq!(swipe.end(false, true), (true, None));
-        swipe.begin(2, GestureConfig::default(), true);
-        assert!(swipe.cancel());
-        assert!(!swipe.cancel());
-        assert!(swipe.update(100.0, 0.0, true));
-        assert_eq!(swipe.end(false, true), (true, None));
-    }
-
-    #[test]
-    fn axis_locks_and_high_rate_motion_stays_bounded() {
-        let mut swipe = SwipeTracker::default();
-        swipe.begin(4, GestureConfig::default(), true);
-        swipe.update(-20.0, 0.0, true);
-        for _ in 0..100_000 {
-            swipe.update(-0.01, -0.1, true);
-        }
-        assert_eq!(
-            swipe.end(false, true),
-            (true, Some(DesktopGesture::WorkspaceNext))
-        );
-        assert!(std::mem::size_of::<SwipeTracker>() <= 40);
     }
 }

--- a/crates/wm-core/src/gestures/physics.rs
+++ b/crates/wm-core/src/gestures/physics.rs
@@ -1,0 +1,177 @@
+//! Shared, analytically integrated gesture physics. All tuning lives here.
+pub const PROJECTION_SECONDS: f64 = 0.18;
+pub const MAX_VELOCITY: f64 = 8.0;
+pub const SPRING_OMEGA: f64 = 22.0;
+pub const POSITION_EPSILON: f64 = 0.0001;
+pub const VELOCITY_EPSILON: f64 = 0.003;
+pub const EDGE_LIMIT: f64 = 0.18;
+pub const COMMIT_MIDPOINT: f64 = 0.5;
+pub fn projected(position: f64, velocity: f64) -> f64 {
+    position + velocity.clamp(-MAX_VELOCITY, MAX_VELOCITY) * PROJECTION_SECONDS
+}
+/// A reversing flick can return home, but cannot skip across home to a
+/// neighbor that the fingers have not yet exposed. Crossing home while held
+/// changes sides immediately and makes the opposite neighbor eligible.
+pub fn settle_target(position: f64, velocity: f64, minimum: f64, maximum: f64) -> f64 {
+    let projected = projected(position, velocity);
+    if maximum > 0.0 && position > 0.0 && projected > COMMIT_MIDPOINT {
+        1.0
+    } else if minimum < 0.0 && position < 0.0 && projected < -COMMIT_MIDPOINT {
+        -1.0
+    } else {
+        0.0
+    }
+}
+/// Position and derivative; the derivative maps finger velocity to visual
+/// velocity so the spring starts with precisely the motion already on screen.
+pub fn resisted(position: f64, minimum: f64, maximum: f64) -> (f64, f64) {
+    let edge = position.clamp(minimum, maximum);
+    let excess = position - edge;
+    if excess == 0.0 {
+        return (position, 1.0);
+    }
+    let denominator = EDGE_LIMIT + excess.abs();
+    (
+        edge + excess.signum() * EDGE_LIMIT * excess.abs() / denominator,
+        (EDGE_LIMIT / denominator).powi(2),
+    )
+}
+/// Inverse for catching a settling scene with a fresh gesture. Avoid a visual
+/// jump when the finger first returns to a rubber-banded edge.
+pub fn unresisted(position: f64, minimum: f64, maximum: f64) -> f64 {
+    let edge = position.clamp(minimum, maximum);
+    let excess = position - edge;
+    edge + excess.signum() * EDGE_LIMIT * excess.abs() / (EDGE_LIMIT - excess.abs()).max(1e-6)
+}
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Spring {
+    pub position: f64,
+    pub velocity: f64,
+    pub target: f64,
+}
+impl Spring {
+    pub fn new(position: f64, velocity: f64, target: f64) -> Self {
+        Self {
+            position: finite_bound(position, 16.0),
+            velocity: finite_bound(velocity, MAX_VELOCITY),
+            target: finite_bound(target, 1.0),
+        }
+    }
+    /// Exact critical-damping solution, stable even after a long frame.
+    pub fn advance(&mut self, dt: f64) -> bool {
+        self.position = finite_bound(self.position, 16.0);
+        self.velocity = finite_bound(self.velocity, 1024.0);
+        self.target = finite_bound(self.target, 1.0);
+        if !dt.is_finite() || dt < 0.0 {
+            return false;
+        }
+        if dt > 2.0 {
+            self.position = self.target;
+            self.velocity = 0.0;
+            return true;
+        }
+        let offset = self.position - self.target;
+        let c = self.velocity + SPRING_OMEGA * offset;
+        let decay = (-SPRING_OMEGA * dt).exp();
+        self.position = self.target + (offset + c * dt) * decay;
+        self.velocity = (self.velocity - SPRING_OMEGA * c * dt) * decay;
+        let settled = (self.position - self.target).abs() < POSITION_EPSILON
+            && self.velocity.abs() < VELOCITY_EPSILON;
+        if settled {
+            self.position = self.target;
+            self.velocity = 0.0;
+        }
+        settled
+    }
+}
+fn finite_bound(value: f64, limit: f64) -> f64 {
+    if value.is_finite() {
+        value.clamp(-limit, limit)
+    } else {
+        0.0
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn projection_handles_slow_flick_and_reverse_releases() {
+        assert!(projected(0.4, 0.0) < 0.5);
+        assert!(projected(0.6, 0.0) > 0.5);
+        assert!(projected(0.2, 2.0) > 0.5);
+        assert!(projected(0.7, -2.0) < 0.5);
+        assert_eq!(settle_target(0.7, -8.0, -1.0, 1.0), 0.0);
+        assert_eq!(settle_target(-0.2, -2.0, -1.0, 1.0), -1.0);
+    }
+    #[test]
+    fn rubber_band_is_monotonic_bounded_and_differentiable() {
+        let mut previous = 0.0;
+        for p in [0.1, 0.2, 0.4, 0.8, 1.6, 1000.0] {
+            let (x, derivative) = resisted(p, -1.0, 0.0);
+            assert!(x > previous && x < EDGE_LIMIT);
+            assert!(derivative > 0.0 && derivative < 1.0);
+            let numeric = (resisted(p + 1e-6, -1.0, 0.0).0 - x) / 1e-6;
+            assert!((numeric - derivative).abs() < 1e-5);
+            previous = x;
+        }
+    }
+    #[test]
+    fn handoff_preserves_motion_and_settles_at_all_refresh_rates() {
+        for hz in [30, 60, 120, 144, 240, 360] {
+            for target in [-1.0, 0.0, 1.0] {
+                for velocity in [-4.0, 0.0, 4.0] {
+                    let mut s = Spring::new(0.37, velocity, target);
+                    assert_eq!((s.position, s.velocity), (0.37, velocity));
+                    assert!(!s.advance(0.0));
+                    for _ in 0..hz * 2 {
+                        if s.advance(1.0 / hz as f64) {
+                            break;
+                        }
+                    }
+                    assert_eq!((s.position, s.velocity), (target, 0.0));
+                }
+            }
+        }
+    }
+    #[test]
+    fn exact_solution_is_partition_independent_and_handles_bad_time() {
+        let mut a = Spring::new(0.3, 2.0, 1.0);
+        let mut b = a;
+        a.advance(0.08);
+        for _ in 0..8 {
+            b.advance(0.01);
+        }
+        assert!((a.position - b.position).abs() < 1e-12);
+        assert!((a.velocity - b.velocity).abs() < 1e-12);
+        for dt in [f64::NAN, f64::INFINITY, -1.0, 1e100] {
+            a.advance(dt);
+            assert!(a.position.is_finite() && a.velocity.is_finite());
+        }
+        assert_eq!((a.position, a.velocity), (1.0, 0.0));
+    }
+    #[test]
+    fn malformed_state_cannot_poison_the_renderer() {
+        for value in [f64::NAN, f64::INFINITY, -f64::INFINITY, f64::MAX, -f64::MAX] {
+            let mut spring = Spring {
+                position: value,
+                velocity: value,
+                target: value,
+            };
+            for dt in [0.0, 0.008, 0.016, f64::MAX] {
+                spring.advance(dt);
+                assert!(
+                    spring.position.is_finite()
+                        && spring.velocity.is_finite()
+                        && spring.target.is_finite()
+                );
+            }
+        }
+    }
+    #[test]
+    fn catching_elastic_edges_preserves_the_presented_position() {
+        for raw in [-10.0, -1.1, -0.5, 0.0, 0.8, 1.1, 10.0] {
+            let visual = resisted(raw, -1.0, 1.0).0;
+            assert!((unresisted(visual, -1.0, 1.0) - raw).abs() < 1e-9);
+        }
+    }
+}

--- a/crates/wm-core/src/lib.rs
+++ b/crates/wm-core/src/lib.rs
@@ -29,12 +29,12 @@ mod types;
 #[cfg(any(test, feature = "test-support"))]
 pub mod fake_backend;
 
-pub use backend::{Backend, OverviewScene, OverviewWindow, OverviewWorkspace};
+pub use backend::{Backend, OverviewDrag, OverviewScene, OverviewWindow, OverviewWorkspace};
 pub use client::{
     Client, ClientFlags, ClientId, Lifecycle, MaximizeDirections, MonitorId, MonitorInfo,
 };
 pub use focus::{FocusDirection, FocusPolicy};
-pub use gestures::{DesktopGesture, GestureConfig, SwipeTracker};
+pub use gestures::{physics as gesture_physics, DesktopGesture, GestureConfig, SwipeAxis, SwipeMotion, SwipeTracker};
 pub use hittest::{hit_test, HitTarget};
 pub use manager::{Notification, WindowManager, DEFAULT_DRAG_MODIFIER, MAX_WORKSPACES};
 pub use motif::{hints_say_client_decorates, MIN_HINT_WORDS};

--- a/crates/wm-core/tests/gesture_allocations.rs
+++ b/crates/wm-core/tests/gesture_allocations.rs
@@ -1,5 +1,5 @@
 use chonk_test_support::{measure, AllocationCounter};
-use wm_core::{DesktopGesture, GestureConfig, Point, Rect, Size, SwipeTracker};
+use wm_core::{GestureConfig, Point, Rect, Size, SwipeTracker};
 
 #[global_allocator]
 static ALLOCATOR: AllocationCounter = AllocationCounter;
@@ -9,18 +9,53 @@ fn high_rate_swipes_and_snap_queries_allocate_nothing() {
     let mut swipe = SwipeTracker::default();
     let targets = [Rect::new(Point::new(0, 40), Size::new(1920, 1040)); 32];
     let (action, allocations) = measure(|| {
-        swipe.begin(4, GestureConfig::default(), true);
-        for _ in 0..100_000 {
-            swipe.update(std::hint::black_box(-0.01), 0.0, true);
+        swipe.begin(4, GestureConfig::default(), true, 0);
+        for time in 1..=100_000 {
+            swipe.update(std::hint::black_box(-0.01), 0.0, true, time);
+            std::hint::black_box(swipe.motion(time));
             std::hint::black_box(wm_core::snap_position(
                 Rect::new(Point::new(3, 43), Size::new(640, 480)),
                 std::hint::black_box(&targets),
                 8,
             ));
         }
-        swipe.end(false, true)
+        swipe.end(false, true, 100_000)
     });
-    assert_eq!(action, (true, Some(DesktopGesture::WorkspaceNext)));
+    assert!(action.0);
+    assert!(action.1.unwrap().progress > 6.0);
     assert_eq!(allocations.calls, 0);
     assert_eq!(allocations.requested_bytes, 0);
+}
+
+#[test]
+fn timed_motion_projection_resistance_and_settling_allocate_nothing() {
+    use wm_core::gesture_physics::{projected, resisted, Spring};
+    let mut swipe = SwipeTracker::default();
+    let started = std::time::Instant::now();
+    let (_, allocations) = measure(|| {
+        swipe.begin(3, GestureConfig::default(), true, 0);
+        for time in 1..=100_000 {
+            swipe.update(
+                std::hint::black_box(if time % 400 < 200 { -0.5 } else { 0.5 }),
+                0.0,
+                true,
+                time,
+            );
+            if let Some(motion) = swipe.motion(time) {
+                let (p, derivative) = resisted(motion.progress, 0.0, 1.0);
+                let v = motion.velocity * derivative;
+                let mut spring = Spring::new(p, v, if projected(p, v) > 0.5 { 1.0 } else { 0.0 });
+                spring.advance(std::hint::black_box(1.0 / 240.0));
+                std::hint::black_box(spring);
+            }
+        }
+        swipe.end(false, true, 100_000)
+    });
+    eprintln!(
+        "100000 timed gesture/physics updates: {:?}; tracker {} bytes; allocations={}",
+        started.elapsed(),
+        std::mem::size_of::<SwipeTracker>(),
+        allocations.calls
+    );
+    assert_eq!((allocations.calls, allocations.requested_bytes), (0, 0));
 }

--- a/crates/wm-theme/src/overview/live.rs
+++ b/crates/wm-theme/src/overview/live.rs
@@ -119,7 +119,11 @@ pub fn label(
     height: u32,
 ) -> DecorationBuffer {
     let font = &theme.menu.item_font;
-    let width = ((text.chars().count() as f32 * font.size * 0.65) as u32 + height)
+    // Bound shaping work for arbitrarily long client titles before doing the
+    // accurate fit. Twice the display budget keeps ordinary captions intact.
+    let bounded = paint::elide(text, max_width.saturating_mul(2), font.size);
+    let text = bounded.as_str();
+    let width = paint::text_width(fonts, font, text).saturating_add(height / 2)
         .min(max_width)
         .max(1);
     let height = height.max(1);
@@ -132,11 +136,15 @@ pub fn label(
         tiny_skia::Transform::identity(),
         None,
     );
+    // These captions are cached at layout time, so shape once rather than
+    // conservatively eliding short desktop names that already fit on screen.
+    let text = paint::fit_measured_prefix(text, width.saturating_sub(height / 2), "…",
+        |candidate| paint::text_width(fonts, font, candidate));
     paint::draw_text(
         &mut pixmap,
         fonts,
         cache,
-        &paint::elide(text, width.saturating_sub(height / 2), font.size),
+        &text,
         font,
         Color::rgb(255, 255, 255),
         (height / 4) as i32,

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -532,6 +532,15 @@ impl Backend for WaylandBackend {
         }
     }
 
+    fn drag_live_overview(&mut self, drag: Option<wm_core::OverviewDrag>) {
+        if let Some(overview) = &mut self.overview {
+            if overview.drag != drag {
+                overview.drag = drag;
+                self.mark_damaged();
+            }
+        }
+    }
+
     fn set_layer_surface_hidden(&mut self, namespace: &str, hidden: bool) {
         let changed = if hidden {
             self.hidden_layer_namespaces.insert(namespace.to_string())

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -168,7 +168,7 @@ impl ScreenshotRequestPoller {
 pub(crate) fn refresh_snapshots(comp: &mut Compositor) {
     // Overview composes the clients' existing GPU surfaces. Readbacks have no
     // consumer here and would synchronously stall input for unrelated icons.
-    if comp.wm.backend().overview.is_some() {
+    if comp.wm.backend().overview.is_some() || comp.wm.backend().gesture_scene.is_some() {
         return;
     }
     let now = Instant::now();

--- a/crates/wm-wayland/src/gesture_scene.rs
+++ b/crates/wm-wayland/src/gesture_scene.rs
@@ -1,0 +1,495 @@
+//! Transient scene ownership for finger-driven desktop transitions. WM topology
+//! and focus are untouched until settlement; every frame reuses live textures.
+use crate::overview::{Overview, Window};
+use crate::renderer::SceneElement;
+use crate::state::{Compositor, Graphics, StackEntry, WaylandBackend};
+use smithay::backend::renderer::element::Id;
+use smithay::backend::renderer::{gles::GlesRenderer, Color32F};
+use std::time::{Duration, Instant};
+use wm_core::{
+    gesture_physics as physics, ClientFlags, DesktopGesture, Lifecycle, SwipeAxis, SwipeMotion,
+};
+use wm_theme_api::{Point, Rect};
+
+struct Plane {
+    workspace: usize,
+    windows: Vec<Window>,
+    overview: Option<Overview>,
+    background: Id,
+}
+
+pub(crate) struct Transition {
+    pub motion: SwipeMotion,
+    pub origin: usize,
+    count: usize,
+    pub previous: Option<usize>,
+    pub next: Option<usize>,
+    pub position: f64,
+    pub velocity: f64,
+    pub projected: f64,
+    pub spring: Option<physics::Spring>,
+    overview_origin: bool,
+    base: f64,
+    planes: Vec<Plane>,
+    monitors: Vec<(Rect, f64)>,
+    last_frame: Instant,
+    next_frame: Instant,
+    frame_interval: Duration,
+    overview_token: Option<Id>,
+}
+impl Transition {
+    pub fn horizontal(&self) -> bool {
+        self.motion.axis == SwipeAxis::Horizontal
+    }
+    fn bounds(&self) -> (f64, f64) {
+        if self.horizontal() {
+            (
+                if self.previous.is_some() { -1.0 } else { 0.0 },
+                if self.next.is_some() { 1.0 } else { 0.0 },
+            )
+        } else {
+            (0.0, 1.0)
+        }
+    }
+    fn follow(&mut self, motion: SwipeMotion) {
+        self.motion = motion;
+        let raw = self.base
+            + motion.progress
+            + if !self.horizontal() && self.overview_origin {
+                1.0
+            } else {
+                0.0
+            };
+        let (min, max) = self.bounds();
+        let (position, derivative) = physics::resisted(raw, min, max);
+        self.position = position;
+        self.velocity = motion.velocity * derivative;
+        self.projected = physics::projected(position, self.velocity);
+    }
+}
+
+pub(crate) fn update(comp: &mut Compositor, motion: SwipeMotion) {
+    if comp
+        .wm
+        .backend()
+        .gesture_scene
+        .as_ref()
+        .is_some_and(|s| s.motion.axis != motion.axis)
+    {
+        cancel(comp);
+    }
+    if comp.wm.backend().gesture_scene.is_none() {
+        let opened = comp.wm.backend().overview.is_some();
+        if motion.axis == SwipeAxis::Vertical {
+            if (opened && motion.progress >= 0.0) || (!opened && motion.progress <= 0.0) {
+                return;
+            }
+            if !opened {
+                comp.shell
+                    .on_desktop_gesture(&mut comp.wm, DesktopGesture::OverviewOpen);
+            }
+            if comp.wm.backend().overview.is_none() {
+                return;
+            }
+        }
+        let origin = comp.wm.current_workspace();
+        let count = comp.wm.workspace_count();
+        let previous = origin.checked_sub(1);
+        let next = (origin + 1 < wm_core::MAX_WORKSPACES
+            && (origin + 1 < count || comp.wm.workspace_has_windows(origin)))
+        .then_some(origin + 1);
+        let mut planes = Vec::new();
+        if motion.axis == SwipeAxis::Horizontal {
+            for workspace in [Some(origin), previous, next].into_iter().flatten() {
+                let windows: Vec<_> = comp
+                    .wm
+                    .backend()
+                    .stacking
+                    .iter()
+                    .rev()
+                    .filter_map(|entry| match entry {
+                        StackEntry::Window(id) => comp.wm.client_for_window(*id),
+                        StackEntry::Frame(id) => comp.wm.client_for_frame(*id),
+                    })
+                    .filter_map(|id| comp.wm.client(id))
+                    .filter(|c| {
+                        (if c.flags.contains(ClientFlags::STICKY) { workspace == origin } else { c.workspace == workspace })
+                            && c.lifecycle == Lifecycle::Normal
+                    })
+                    .map(|c| {
+                        let source = c.frame.and_then(|id| comp.wm.backend().frames.get(&id))
+                            .map_or(c.geometry, |frame| frame.geometry);
+                        let mut window = Window::snapshot(c.window, c.frame, source, comp.wm.backend());
+                        window.draw_content = !c.flags.contains(ClientFlags::SHADED);
+                        window.sticky = c.flags.contains(ClientFlags::STICKY);
+                        window
+                    })
+                    .collect();
+                let overview = comp
+                    .wm
+                    .backend()
+                    .overview
+                    .as_ref()
+                    .filter(|_| workspace != origin)
+                    .map(|o| {
+                        let scene = comp
+                            .shell
+                            .desktop_gesture_overview_scene(&comp.wm, workspace, o.geometry);
+                        Overview::new(o.surface, scene, comp.wm.backend())
+                    });
+                planes.push(Plane {
+                    workspace,
+                    windows,
+                    overview,
+                    background: Id::new(),
+                });
+            }
+        }
+        let now = Instant::now();
+        let monitors = comp
+            .wm
+            .backend()
+            .monitors
+            .iter()
+            .map(|m| (m.geometry, comp.wm.backend().scale_at(m.geometry)))
+            .collect();
+        let frame_interval = comp
+            .outputs
+            .iter()
+            .filter_map(|o| o.output.current_mode())
+            .filter(|m| m.refresh > 0)
+            .map(|m| {
+                Duration::from_nanos(1_000_000_000_000 / (m.refresh as u64).clamp(1000, 1_000_000))
+            })
+            .min()
+            .unwrap_or(Duration::from_nanos(1_000_000_000 / 60));
+        let overview_token = comp
+            .wm
+            .backend()
+            .overview
+            .as_ref()
+            .map(|o| o.token().clone());
+        comp.wm.backend_mut().gesture_scene = Some(Transition {
+            motion,
+            origin,
+            count,
+            previous,
+            next,
+            position: 0.0,
+            velocity: 0.0,
+            projected: 0.0,
+            spring: None,
+            overview_origin: opened,
+            base: 0.0,
+            planes,
+            monitors,
+            last_frame: now,
+            next_frame: now,
+            frame_interval,
+            overview_token,
+        });
+        crate::input::sync_pointer_focus(comp);
+    }
+    if let Some(scene) = comp.wm.backend_mut().gesture_scene.as_mut() {
+        scene.follow(motion);
+    }
+    sync_progress(comp);
+}
+
+/// Touching a moving desktop catches it at its exact current position. The
+/// next locked-axis delta is relative to that position, not the logical origin.
+pub(crate) fn catch(comp: &mut Compositor) -> bool {
+    let Some(scene) = comp
+        .wm
+        .backend_mut()
+        .gesture_scene
+        .as_mut()
+        .filter(|s| s.spring.is_some())
+    else {
+        return false;
+    };
+    let (min, max) = scene.bounds();
+    scene.base = physics::unresisted(scene.position, min, max)
+        - if !scene.horizontal() && scene.overview_origin {
+            1.0
+        } else {
+            0.0
+        };
+    scene.spring = None;
+    scene.velocity = 0.0;
+    true
+}
+
+fn sync_progress(comp: &mut Compositor) {
+    let backend = comp.wm.backend_mut();
+    if let Some(scene) = &backend.gesture_scene {
+        if !scene.horizontal() {
+            if let Some(overview) = backend.overview.as_mut() {
+                overview.progress = scene.position;
+            }
+        }
+        backend.mark_damaged();
+    }
+}
+
+pub(crate) fn release(comp: &mut Compositor, cancelled: bool, motion: Option<SwipeMotion>) {
+    if let Some(scene) = comp.wm.backend_mut().gesture_scene.as_mut() {
+        if let Some(motion) = motion {
+            scene.follow(motion);
+        }
+        let target = if cancelled {
+            if scene.horizontal() || !scene.overview_origin {
+                0.0
+            } else {
+                1.0
+            }
+        } else {
+            let (min, max) = scene.bounds();
+            physics::settle_target(scene.position, scene.velocity, min, max)
+        };
+        scene.spring = Some(physics::Spring::new(scene.position, scene.velocity, target));
+        scene.last_frame = Instant::now();
+        scene.next_frame = scene.last_frame;
+    }
+    sync_progress(comp);
+}
+
+/// Ownership loss is immediate, unlike a libinput cancellation which settles.
+pub(crate) fn cancel(comp: &mut Compositor) {
+    let Some(scene) = comp.wm.backend_mut().gesture_scene.take() else {
+        return;
+    };
+    if !scene.horizontal() && !scene.overview_origin {
+        comp.shell
+            .finish_desktop_gesture_overview(&mut comp.wm, false);
+    } else if let Some(overview) = comp.wm.backend_mut().overview.as_mut() {
+        overview.progress = 1.0;
+    }
+    comp.wm.backend_mut().mark_damaged();
+    crate::input::sync_pointer_focus(comp);
+}
+
+pub(crate) fn deadline(comp: &Compositor) -> Option<Instant> {
+    // Native KMS wakes at vblank and uses its existing FrameClock deadlines.
+    // Only the nested, non-vsynced backend needs a finite animation deadline.
+    if !matches!(comp.graphics, Graphics::Winit(_)) {
+        return None;
+    }
+    comp.wm
+        .backend()
+        .gesture_scene
+        .as_ref()
+        .filter(|s| s.spring.is_some())
+        .map(|s| s.next_frame)
+}
+
+pub(crate) fn validate(comp: &mut Compositor) {
+    let Some(scene) = comp.wm.backend().gesture_scene.as_ref() else {
+        return;
+    };
+    if comp.wm.current_workspace() != scene.origin
+        || comp.wm.workspace_count() != scene.count
+        || (scene.next == Some(scene.count) && !comp.wm.workspace_has_windows(scene.origin))
+        || !crate::input::gestures::available(comp)
+        || scene.monitors.len() != comp.wm.backend().monitors.len()
+        || scene
+            .monitors
+            .iter()
+            .zip(&comp.wm.backend().monitors)
+            .any(|((rect, scale), monitor)| {
+                *rect != monitor.geometry || *scale != comp.wm.backend().scale_at(monitor.geometry)
+            })
+        || scene.overview_token.as_ref() != comp.wm.backend().overview.as_ref().map(|o| o.token())
+    {
+        crate::input::gestures::cancel(comp);
+    }
+}
+pub(crate) fn tick(comp: &mut Compositor) {
+    validate(comp);
+    let Some(scene) = comp.wm.backend().gesture_scene.as_ref() else {
+        return;
+    };
+    if scene.spring.is_none() {
+        return;
+    }
+    let now = Instant::now();
+    let scene = comp.wm.backend_mut().gesture_scene.as_mut().unwrap();
+    let spring = scene.spring.as_mut().unwrap();
+    let finished = spring.advance(
+        now.saturating_duration_since(scene.last_frame)
+            .as_secs_f64(),
+    );
+    scene.last_frame = now;
+    scene.next_frame = now + scene.frame_interval;
+    scene.position = spring.position;
+    scene.velocity = spring.velocity;
+    if finished {
+        let scene = comp.wm.backend_mut().gesture_scene.take().unwrap();
+        let target = scene.spring.unwrap().target;
+        if scene.horizontal() {
+            if target > 0.0 {
+                comp.shell
+                    .on_desktop_gesture(&mut comp.wm, DesktopGesture::WorkspaceNext);
+            } else if target < 0.0 {
+                comp.shell
+                    .on_desktop_gesture(&mut comp.wm, DesktopGesture::WorkspacePrevious);
+            }
+        } else {
+            if let Some(overview) = comp.wm.backend_mut().overview.as_mut() {
+                overview.progress = target;
+            }
+            comp.shell
+                .finish_desktop_gesture_overview(&mut comp.wm, target > 0.5);
+        }
+        comp.wm.backend_mut().mark_damaged();
+        crate::input::sync_pointer_focus(comp);
+    } else {
+        sync_progress(comp);
+    }
+}
+
+pub(crate) fn render(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    scene: &Transition,
+    viewport: Rect,
+) -> Color32F {
+    if !scene.overview_origin {
+        crate::renderer::push_furniture(elements, renderer, backend, viewport, 1.0, true);
+        if let Some(origin) = scene.planes.first() {
+            for window in origin.windows.iter().filter(|w| w.sticky) {
+                let rect = Rect::new(Point::new(window.source.pos.x - viewport.pos.x,
+                    window.source.pos.y - viewport.pos.y), window.source.size);
+                crate::overview::render_window(elements, renderer, backend, window, rect, 1.0);
+            }
+        }
+    }
+    // Each output is its own viewport into the same normalized transition.
+    // Clipping to its translated source prevents windows on another monitor
+    // from leaking across a mixed-scale output boundary during the slide.
+    for plane in &scene.planes {
+        let direction = plane.workspace as f64 - scene.origin as f64;
+        let shift = plane_shift(direction, scene.position, viewport.size.w);
+        if shift.unsigned_abs() >= viewport.size.w {
+            continue;
+        }
+        let clip = Rect::new(Point::new(shift, 0), viewport.size);
+        let shifted_view = Rect::new(
+            Point::new(viewport.pos.x - shift, viewport.pos.y),
+            viewport.size,
+        );
+        let start = elements.len();
+        let overview = if plane.workspace == scene.origin {
+            backend.overview.as_ref()
+        } else {
+            plane.overview.as_ref()
+        };
+        if let Some(overview) = overview.filter(|o| o.covers(viewport)) {
+            crate::overview::render(elements, renderer, backend, overview, shifted_view);
+        } else {
+            for window in &plane.windows {
+                if window.sticky { continue; }
+                if !overlaps(window.source, viewport) {
+                    continue;
+                }
+                let rect = Rect::new(
+                    Point::new(
+                        window.source.pos.x - shifted_view.pos.x,
+                        window.source.pos.y - viewport.pos.y,
+                    ),
+                    window.source.size,
+                );
+                crate::overview::render_window(elements, renderer, backend, window, rect, 1.0);
+            }
+        }
+        if !scene.overview_origin && plane.workspace == scene.origin {
+            crate::renderer::push_furniture(elements, renderer, backend, shifted_view, 1.0, false);
+        }
+        crate::overview::space_background(
+            elements,
+            renderer,
+            backend,
+            viewport,
+            clip,
+            &plane.background,
+        );
+        crate::renderer::clip_plane(elements, start, clip, &plane.background);
+    }
+    Color32F::new(0.015, 0.015, 0.018, 1.0)
+}
+fn plane_shift(neighbor: f64, progress: f64, width: u32) -> i32 {
+    ((neighbor - progress) * f64::from(width)).round() as i32
+}
+fn overlaps(a: Rect, b: Rect) -> bool {
+    i64::from(a.pos.x) < i64::from(b.pos.x) + i64::from(b.size.w)
+        && i64::from(b.pos.x) < i64::from(a.pos.x) + i64::from(a.size.w)
+        && i64::from(a.pos.y) < i64::from(b.pos.y) + i64::from(b.size.h)
+        && i64::from(b.pos.y) < i64::from(a.pos.y) + i64::from(a.size.h)
+}
+
+pub(crate) fn for_each_neighbor(
+    backend: &WaylandBackend,
+    mut visit: impl FnMut(&crate::state::WindowRecord),
+) {
+    let Some(scene) = &backend.gesture_scene else {
+        return;
+    };
+    let target = if scene.position > 0.0 {
+        scene.next
+    } else if scene.position < 0.0 {
+        scene.previous
+    } else {
+        None
+    };
+    if let Some(plane) = scene.planes.iter().find(|p| Some(p.workspace) == target) {
+        for window in &plane.windows {
+            if !backend.scene_index.is_presented(window.window) {
+                if let Some(record) = backend
+                    .windows
+                    .get(&window.window)
+                    .filter(|r| r.surface.alive())
+                {
+                    visit(record);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn normalized_motion_has_identical_sensitivity_on_mixed_outputs() {
+        // 1x 1080p, fractional 1440p, 2x 4K: scale is deliberately not
+        // an input to the transform. Per-output widths affect travel only.
+        for width in [1920, 2560, 3840] {
+            for progress in [-0.75, -0.25, 0.0, 0.125, 0.5, 1.0] {
+                assert!(
+                    (f64::from(plane_shift(0.0, progress, width)) / f64::from(width) + progress)
+                        .abs()
+                        < 1e-6
+                );
+                assert_eq!(
+                    plane_shift(1.0, progress, width) - plane_shift(0.0, progress, width),
+                    width as i32
+                );
+            }
+        }
+    }
+    #[test]
+    fn overview_interpolation_is_reversible_and_preserves_endpoints() {
+        let source = Rect::new(Point::new(2000, 70), wm_theme_api::Size::new(800, 600));
+        let target = Rect::new(Point::new(180, 250), wm_theme_api::Size::new(400, 300));
+        assert_eq!(crate::overview::interpolate(source, target, 0.0), source);
+        assert_eq!(crate::overview::interpolate(source, target, 1.0), target);
+        let half = crate::overview::interpolate(source, target, 0.5);
+        assert_eq!(half.pos, Point::new(1090, 160));
+        assert_eq!(half.size, wm_theme_api::Size::new(600, 450));
+        assert_eq!(
+            crate::overview::interpolate(target, source, 0.75),
+            crate::overview::interpolate(source, target, 0.25)
+        );
+    }
+}

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -58,7 +58,7 @@
 //! it.
 
 pub(crate) mod constraints;
-mod gestures;
+pub(crate) mod gestures;
 pub(crate) mod keyboard;
 mod seat;
 pub(crate) mod surface;
@@ -827,7 +827,7 @@ pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event
             }
         }
         InputEvent::GestureSwipeUpdate { event } => {
-            if gestures::update(state, event.delta()) {
+            if gestures::update(state, event.delta(), event.time_msec()) {
                 return;
             }
             if let Some(pointer) = state.seat.get_pointer() {
@@ -838,7 +838,7 @@ pub(crate) fn process_input_event<I: InputBackend>(state: &mut Compositor, event
             }
         }
         InputEvent::GestureSwipeEnd { event } => {
-            if gestures::end(state, event.cancelled()) {
+            if gestures::end(state, event.cancelled(), event.time_msec()) {
                 return;
             }
             if let Some(pointer) = state.seat.get_pointer() {
@@ -1954,6 +1954,11 @@ fn pointer_button(
 ) {
     let serial = SERIAL_COUNTER.next_serial();
     let pressed = button_state == ButtonState::Pressed;
+    if !state.wm.backend().locked && pressed && state.wm.backend().gesture_scene.is_some() {
+        gestures::cancel(state);
+        with_input(&state.seat, |input| input.grab_dismissals.push(button_code));
+        return;
+    }
     if !state.wm.backend().locked && crate::capture_tool::button(state, button_code, pressed) {
         return;
     }
@@ -2707,6 +2712,7 @@ pub(crate) fn inject_pointer_axis(
 /// and the renderer's makes clicks land on things the user cannot see,
 /// so both sides cite `backend_impl.rs`'s stacking-band contract.
 fn hit_at(backend: &WaylandBackend, at: Point, position: LogicalPoint<f64, Logical>) -> Hit {
+    if !backend.locked && backend.gesture_scene.is_some() { return Hit::Root; }
     if !backend.locked && crate::capture_tool::modal(backend) { return Hit::Root; }
     // The lock is a scene domain, not one more band in the desktop's
     // z-order. Put its boundary on the shared hit-test itself so a new

--- a/crates/wm-wayland/src/input/gestures.rs
+++ b/crates/wm-wayland/src/input/gestures.rs
@@ -6,47 +6,93 @@ use smithay::utils::{Logical, Point, SERIAL_COUNTER};
 use super::with_input;
 use crate::state::Compositor;
 
-fn available(state: &Compositor) -> bool {
+pub(crate) fn inspect(
+    state: &Compositor,
+) -> (&'static str, (f64, f64), Option<wm_core::SwipeMotion>) {
+    let time = state.start_time.elapsed().as_millis() as u32;
+    with_input(&state.seat, |input| {
+        (
+            input.swipe.state_name(),
+            input.swipe.displacement(),
+            input.swipe.motion(time),
+        )
+    })
+}
+
+pub(crate) fn available(state: &Compositor) -> bool {
     !state.wm.backend().locked
+        && crate::session::input_active(&state.graphics)
         && !crate::capture_tool::modal(state.wm.backend())
         && state.layer_shell.exclusive_focus.is_none()
         && !state.focus_grab.is_active()
         && state.wm.backend().pointer_grab.is_none()
+        && !state
+            .seat
+            .get_pointer()
+            .is_some_and(|pointer| pointer.is_grabbed())
+        && with_input(&state.seat, |input| input.implicit_grab.is_none())
         && state.shell.desktop_gesture_available(&state.wm)
 }
 
 pub(super) fn begin(state: &mut Compositor, fingers: u32, time: u32) -> bool {
     // A replacement begin also retires a lost client end before choosing the
     // next owner. No client gets an update for a stream reserved by the shell.
-    cancel_at(state, time);
     let config = state.shell.desktop_gesture_config();
     let available = available(state);
+    let desktop = config.enabled
+        && matches!(fingers, 3 | 4)
+        && (config.fingers == 0 || config.fingers == fingers);
+    if available && desktop && crate::gesture_scene::catch(state) {
+        cancel_client(state, time);
+    } else {
+        cancel_at(state, time);
+    }
     with_input(&state.seat, |input| {
-        input.swipe.begin(fingers, config, available)
+        input.swipe.begin(fingers, config, available, time)
     })
 }
 
-pub(super) fn update(state: &mut Compositor, delta: Point<f64, Logical>) -> bool {
+pub(super) fn update(state: &mut Compositor, delta: Point<f64, Logical>, time: u32) -> bool {
     let available = available(state);
-    with_input(&state.seat, |input| {
-        input.swipe.update(delta.x, delta.y, available)
-    })
-}
-
-pub(super) fn end(state: &mut Compositor, cancelled: bool) -> bool {
-    let available = available(state);
-    let (consumed, action) = with_input(&state.seat, |input| input.swipe.end(cancelled, available));
-    if let Some(action) = action {
-        state.shell.on_desktop_gesture(&mut state.wm, action);
+    let (consumed, motion, suppressed) = with_input(&state.seat, |input| {
+        let consumed = input.swipe.update(delta.x, delta.y, available, time);
+        (
+            consumed,
+            input.swipe.motion(time),
+            matches!(input.swipe, wm_core::SwipeTracker::Suppressed),
+        )
+    });
+    if suppressed || !available || !delta.x.is_finite() || !delta.y.is_finite() {
+        crate::gesture_scene::cancel(state);
+    } else if let Some(motion) = motion {
+        crate::gesture_scene::update(state, motion);
     }
     consumed
 }
 
-pub(super) fn cancel(state: &mut Compositor) {
+pub(super) fn end(state: &mut Compositor, cancelled: bool, time: u32) -> bool {
+    let available = available(state);
+    // A cancelled end still supplies the measured velocity to its return
+    // spring, but can never select a commit target.
+    let (consumed, motion) =
+        with_input(&state.seat, |input| input.swipe.end(false, available, time));
+    if !available {
+        crate::gesture_scene::cancel(state);
+    } else if consumed {
+        crate::gesture_scene::release(state, cancelled, motion);
+    }
+    consumed
+}
+
+pub(crate) fn cancel(state: &mut Compositor) {
     cancel_at(state, state.start_time.elapsed().as_millis() as u32);
 }
 
 fn cancel_at(state: &mut Compositor, time: u32) {
+    crate::gesture_scene::cancel(state);
+    cancel_client(state, time);
+}
+fn cancel_client(state: &mut Compositor, time: u32) {
     if with_input(&state.seat, |input| input.swipe.cancel()) {
         if let Some(pointer) = state.seat.get_pointer() {
             pointer.gesture_swipe_end(

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -57,6 +57,7 @@ mod protocols;
 mod readback;
 mod renderer;
 mod overview;
+mod gesture_scene;
 mod selection;
 mod session;
 mod state;

--- a/crates/wm-wayland/src/overview.rs
+++ b/crates/wm-wayland/src/overview.rs
@@ -3,7 +3,7 @@
 //! textures and sparse frame buffers; only small captions own new pixels.
 
 use crate::backend_impl::import_buffer;
-use crate::renderer::{push_surface_tree, SceneElement};
+use crate::renderer::{push_surface_tree_alpha, SceneElement};
 use crate::state::{RootBackground, WaylandBackend, WlFrameId, WlShellId, WlWindowId};
 use smithay::backend::renderer::element::memory::{
     MemoryRenderBuffer, MemoryRenderBufferRenderElement,
@@ -25,6 +25,7 @@ struct Label {
 struct Workspace {
     rect: Rect,
     label: Label,
+    drop_label: Label,
     close: Option<(Rect, Label)>,
     background: Id,
 }
@@ -45,6 +46,19 @@ pub(crate) struct Window {
     label: Label,
     fallback: Option<MemoryRenderBuffer>,
     shadow: Id,
+    pub desktop_visible: bool,
+    pub draw_content: bool,
+    pub sticky: bool,
+}
+
+impl Window {
+    pub fn snapshot(window: WlWindowId, frame: Option<WlFrameId>, source: Rect, backend: &WaylandBackend) -> Self {
+        Self { window, frame, source, destination: source,
+            label: Label { buffer: None, size: Size::default() },
+            fallback: None, shadow: Id::new(),
+            desktop_visible: backend.windows.get(&window).is_some_and(|r| r.mapped),
+            draw_content: true, sticky: false }
+    }
 }
 
 pub(crate) struct Overview {
@@ -53,15 +67,22 @@ pub(crate) struct Overview {
     pub windows: Vec<Window>,
     spaces: Vec<Workspace>,
     pub selected: usize,
+    pub drag: Option<wm_core::OverviewDrag>,
+    /// Absolute desktop-to-Overview fraction, independent of output pixels.
+    pub progress: f64,
+    paint_order: Vec<usize>,
     workspace: usize,
     gap: u32,
     ring: [Id; 4],
     space_ring: [Id; 4],
+    drop_ring: [Id; 4],
+    drop_fill: Id,
     band: Id,
     backdrop: Id,
 }
 
 impl Overview {
+    pub fn token(&self) -> &Id { &self.backdrop }
     pub fn new(
         surface: WlShellId,
         scene: wm_core::OverviewScene<WlWindowId, WlFrameId>,
@@ -71,6 +92,23 @@ impl Overview {
             surface,
             geometry: scene.geometry,
             selected: scene.selected,
+            drag: None,
+            progress: 1.0,
+            paint_order: {
+                let mut indices: std::collections::HashMap<_, _> = scene.windows.iter().enumerate().map(|(i, w)| (w.window, i)).collect();
+                let mut order = Vec::with_capacity(scene.windows.len());
+                for entry in backend.stacking.iter().rev() {
+                    let window = match entry {
+                        crate::state::StackEntry::Window(id) => Some(*id),
+                        crate::state::StackEntry::Frame(id) => backend.frames.get(id).map(|f| f.window),
+                    };
+                    if let Some(index) = window.and_then(|id| indices.remove(&id)) { order.push(index); }
+                }
+                for (i, w) in scene.windows.iter().enumerate() {
+                    if indices.contains_key(&w.window) { order.push(i); }
+                }
+                order
+            },
             workspace: scene.workspace,
             gap: scene.gap,
             windows: scene
@@ -94,6 +132,10 @@ impl Overview {
                         label: Label::new(w.label),
                         fallback,
                         shadow: Id::new(),
+                        desktop_visible: backend.scene_index.is_presented(w.window)
+                            && backend.windows.get(&w.window).is_some_and(|r| r.mapped),
+                        draw_content: true,
+                        sticky: false,
                     }
                 })
                 .collect(),
@@ -103,12 +145,15 @@ impl Overview {
                 .map(|space| Workspace {
                     rect: space.rect,
                     label: Label::new(space.label),
+                    drop_label: Label::new(space.drop_label),
                     close: space.close.map(|(rect, glyph)| (rect, Label::new(glyph))),
                     background: Id::new(),
                 })
                 .collect(),
             ring: std::array::from_fn(|_| Id::new()),
             space_ring: std::array::from_fn(|_| Id::new()),
+            drop_ring: std::array::from_fn(|_| Id::new()),
+            drop_fill: Id::new(),
             band: Id::new(),
             backdrop: Id::new(),
         }
@@ -124,6 +169,7 @@ impl Overview {
             .iter()
             .map(|w| &w.label)
             .chain(self.spaces.iter().map(|space| &space.label))
+            .chain(self.spaces.iter().map(|space| &space.drop_label))
             .chain(self.spaces.iter().filter_map(|space| space.close.as_ref().map(|(_, glyph)| glyph)))
             .map(|l| l.size.w as usize * l.size.h as usize * 4)
             .sum()
@@ -171,8 +217,8 @@ fn solid(elements: &mut Vec<SceneElement<GlesRenderer>>, id: &Id, rect: Rect, co
     );
 }
 
-fn outline(elements: &mut Vec<SceneElement<GlesRenderer>>, ids: &[Id; 4], rect: Rect, edge: u32) {
-    let color = Color32F::new(0.23, 0.61, 1.0, 1.0);
+fn outline(elements: &mut Vec<SceneElement<GlesRenderer>>, ids: &[Id; 4], rect: Rect, edge: u32, alpha: f32) {
+    let color = Color32F::new(0.23 * alpha, 0.61 * alpha, alpha, alpha);
     let x = rect.pos.x - edge as i32;
     let y = rect.pos.y - edge as i32;
     for (id, r) in ids.iter().zip([
@@ -197,6 +243,7 @@ fn label(
     label: &Label,
     rect: Rect,
     gap: u32,
+    alpha: f32,
 ) {
     let Some(buffer) = &label.buffer else { return };
     let location = (
@@ -207,7 +254,7 @@ fn label(
         renderer,
         location,
         buffer,
-        None,
+        Some(alpha),
         None,
         None,
         Kind::Unspecified,
@@ -234,14 +281,35 @@ pub(crate) fn render(
         )
     };
     let edge = (overview.gap / 6).max(2);
-    if let Some(window) = overview.windows.get(overview.selected) {
-        let rect = local(window.destination);
-        outline(elements, &overview.ring, rect, edge);
-        label(elements, renderer, &window.label, rect, edge * 2);
+    // Geometry follows the spring, including its small elastic excursions.
+    // Only opacity saturates; clamping geometry would clip release velocity.
+    let progress = overview.progress;
+    let alpha = progress.clamp(0.0, 1.0) as f32;
+    let placed = |window: &Window| interpolate(
+        Rect::new(Point::new(window.source.pos.x - viewport.pos.x,
+            window.source.pos.y - viewport.pos.y), window.source.size),
+        local(window.destination), progress);
+    if let Some(drag) = overview.drag {
+        if let Some(window) = overview.windows.get(drag.index) {
+            let rect = local(drag.destination);
+            // Frontmost, translucent and bounded: the destination remains
+            // visible through the live image. No capture or client configure.
+            render_window(elements, renderer, backend, window, rect, 0.82);
+            solid(elements, &window.shadow, Rect::new(
+                Point::new(rect.pos.x - edge as i32, rect.pos.y - edge as i32),
+                Size::new(rect.size.w + edge * 2, rect.size.h + edge * 3)),
+                Color32F::new(0.0, 0.0, 0.0, 0.24));
+        }
+    } else if let Some(window) = overview.windows.get(overview.selected) {
+        let rect = placed(window);
+        outline(elements, &overview.ring, rect, edge, alpha);
+        label(elements, renderer, &window.label, rect, edge * 2, alpha);
     }
-    for window in &overview.windows {
-        let rect = local(window.destination);
-        render_window(elements, renderer, backend, window, rect);
+    for &index in &overview.paint_order {
+        let window = &overview.windows[index];
+        if overview.drag.is_some_and(|drag| drag.index == index) { continue; }
+        let rect = placed(window);
+        render_window(elements, renderer, backend, window, rect, if window.desktop_visible { 1.0 } else { alpha });
         solid(
             elements,
             &window.shadow,
@@ -249,27 +317,34 @@ pub(crate) fn render(
                 Point::new(rect.pos.x - edge as i32, rect.pos.y - edge as i32),
                 Size::new(rect.size.w + edge * 2, rect.size.h + edge * 3),
             ),
-            Color32F::new(0.0, 0.0, 0.0, 0.28),
+            Color32F::new(0.0, 0.0, 0.0, 0.28 * alpha),
         );
     }
     for (i, space) in overview.spaces.iter().enumerate() {
         let rect = local(space.rect);
-        if let Some((close, glyph)) = &space.close {
+        // A desktop is a single generous drop target during a drag, including
+        // its close-control corner. Never imply that dropping will delete it.
+        if let Some((close, glyph)) = space.close.as_ref().filter(|_| overview.drag.is_none()) {
             let close = local(*close);
             if let Some(buffer) = &glyph.buffer {
                 if let Ok(element) = MemoryRenderBufferRenderElement::from_buffer(
                     renderer, (close.pos.x as f64, close.pos.y as f64), buffer,
-                    None, None, None, Kind::Unspecified,
+                    Some(alpha), None, None, Kind::Unspecified,
                 ) {
                     elements.push(element.into());
                 }
             }
         }
-        label(elements, renderer, &space.label, rect, edge * 2);
-        if i == overview.workspace {
-            outline(elements, &overview.space_ring, rect, edge);
+        let targeted = overview.drag.is_some_and(|drag| drag.workspace == Some(i));
+        label(elements, renderer, if targeted { &space.drop_label } else { &space.label }, rect, edge * 2, alpha);
+        if overview.drag.is_some_and(|drag| drag.workspace == Some(i)) {
+            outline(elements, &overview.drop_ring, rect, edge * 2, alpha);
+            solid(elements, &overview.drop_fill, rect, Color32F::new(0.03, 0.09, 0.16, 0.24));
         }
-        space_background(elements, renderer, backend, overview.geometry, rect, &space.background);
+        if i == overview.workspace {
+            outline(elements, &overview.space_ring, rect, edge, alpha);
+        }
+        space_background_alpha(elements, renderer, backend, overview.geometry, rect, &space.background, alpha);
     }
     if let Some(space) = overview.spaces.first() {
         solid(
@@ -282,17 +357,26 @@ pub(crate) fn render(
                     space.rect.pos.y as u32 + space.rect.size.h + space.label.size.h + overview.gap,
                 ),
             ),
-            Color32F::new(0.0, 0.0, 0.0, 0.3),
+            Color32F::new(0.0, 0.0, 0.0, 0.3 * alpha),
         );
     }
 }
 
-fn render_window(
+pub(crate) fn interpolate(source: Rect, target: Rect, progress: f64) -> Rect {
+    let mix = |a: f64, b: f64| a + (b - a) * progress;
+    Rect::new(Point::new(mix(source.pos.x as f64, target.pos.x as f64).round() as i32,
+        mix(source.pos.y as f64, target.pos.y as f64).round() as i32),
+        Size::new(mix(source.size.w as f64, target.size.w as f64).round().max(1.0) as u32,
+        mix(source.size.h as f64, target.size.h as f64).round().max(1.0) as u32))
+}
+
+pub(crate) fn render_window(
     elements: &mut Vec<SceneElement<GlesRenderer>>,
     renderer: &mut GlesRenderer,
     backend: &WaylandBackend,
     window: &Window,
     destination: Rect,
+    alpha: f32,
 ) {
     let Some(record) = backend
         .windows
@@ -307,7 +391,7 @@ fn render_window(
         return;
     }
     let before = elements.len();
-    if let Some(surface) = record.surface.wl_surface() {
+    if let Some(surface) = record.surface.wl_surface().filter(|_| window.draw_content) {
         let origin = SPoint::<i32, Physical>::from((
             destination.pos.x
                 + ((record.content.pos.x - record.content_offset.x - window.source.pos.x) as f64
@@ -318,7 +402,7 @@ fn render_window(
                     * scale)
                     .round() as i32,
         ));
-        push_surface_tree(
+        push_surface_tree_alpha(
             elements,
             renderer,
             &surface,
@@ -326,6 +410,7 @@ fn render_window(
             backend.window_surface_scale(record) * scale,
             1.0,
             Kind::Unspecified,
+            alpha,
         );
     }
     if let Some(buffer) = window
@@ -339,7 +424,7 @@ fn render_window(
             renderer,
             (destination.pos.x as f64, destination.pos.y as f64),
             buffer,
-            None,
+            Some(alpha),
             None,
             None,
             Kind::Unspecified,
@@ -372,7 +457,7 @@ fn render_window(
                 renderer,
                 origin.to_f64(),
                 &part.buffer,
-                None,
+                Some(alpha),
                 None,
                 None,
                 Kind::Unspecified,
@@ -384,12 +469,12 @@ fn render_window(
             elements,
             &frame.fill_id,
             destination,
-            Color32F::new(0.0, 0.0, 0.0, 1.0),
+            Color32F::new(0.0, 0.0, 0.0, alpha),
         );
     }
 }
 
-fn space_background(
+pub(crate) fn space_background(
     elements: &mut Vec<SceneElement<GlesRenderer>>,
     renderer: &mut GlesRenderer,
     backend: &WaylandBackend,
@@ -397,6 +482,11 @@ fn space_background(
     destination: Rect,
     id: &Id,
 ) {
+    space_background_alpha(elements, renderer, backend, source, destination, id, 1.0);
+}
+#[allow(clippy::too_many_arguments)]
+fn space_background_alpha(elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
+    backend: &WaylandBackend, source: Rect, destination: Rect, id: &Id, alpha: f32) {
     let scale = destination.size.w as f64 / source.size.w.max(1) as f64;
     for record in backend.layers.iter().rev().filter(|r| {
         r.layer == Layer::Background && backend.layer_presented(r) && overlaps(r.geometry, source)
@@ -412,7 +502,7 @@ fn space_background(
             destination.pos.y
                 + ((record.geometry.pos.y - source.pos.y) as f64 * scale).round() as i32,
         );
-        push_surface_tree(
+        push_surface_tree_alpha(
             elements,
             renderer,
             surface,
@@ -420,6 +510,7 @@ fn space_background(
             factor * scale,
             1.0,
             Kind::Unspecified,
+            alpha,
         );
     }
     match &backend.root_background {
@@ -427,7 +518,7 @@ fn space_background(
             elements,
             id,
             destination,
-            Color32F::new(*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0, 1.0),
+            Color32F::new(*r as f32 / 255.0 * alpha, *g as f32 / 255.0 * alpha, *b as f32 / 255.0 * alpha, alpha),
         ),
         RootBackground::Image(buffer) => {
             let src = SRect::new(
@@ -438,7 +529,7 @@ fn space_background(
                 renderer,
                 (destination.pos.x as f64, destination.pos.y as f64),
                 buffer,
-                None,
+                Some(alpha),
                 Some(src),
                 Some((destination.size.w as i32, destination.size.h as i32).into()),
                 Kind::Unspecified,

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -86,7 +86,7 @@ use std::time::Duration;
 use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement;
 use smithay::backend::renderer::element::solid::SolidColorRenderElement;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
-use smithay::backend::renderer::element::utils::RescaleRenderElement;
+use smithay::backend::renderer::element::utils::{CropRenderElement, RescaleRenderElement};
 use smithay::backend::renderer::element::{Kind, RenderElementStates};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::utils::{CommitCounter, RendererSurfaceStateUserData};
@@ -118,6 +118,33 @@ render_elements! {
     Memory = MemoryRenderBufferRenderElement<R>,
     ScaledMemory = RescaleRenderElement<MemoryRenderBufferRenderElement<R>>,
     Solid = SolidColorRenderElement,
+    CroppedSurface = CropRenderElement<RescaleRenderElement<WaylandSurfaceRenderElement<R>>>,
+    CroppedMemory = CropRenderElement<MemoryRenderBufferRenderElement<R>>,
+    CroppedScaledMemory = CropRenderElement<RescaleRenderElement<MemoryRenderBufferRenderElement<R>>>,
+    CroppedSolid = CropRenderElement<SolidColorRenderElement>,
+}
+
+/// Clip a just-appended plane in place. Stable IDs and retained vector capacity
+/// survive the transform; no intermediate scene vector or texture is created.
+pub(crate) fn clip_plane(elements: &mut Vec<SceneElement<GlesRenderer>>, start: usize,
+    rect: Rect, id: &smithay::backend::renderer::element::Id) {
+    let crop = SRect::new((rect.pos.x, rect.pos.y).into(), (rect.size.w as i32, rect.size.h as i32).into());
+    let empty = SolidColorRenderElement::new(id.clone(), SRect::from_size((0, 0).into()),
+        CommitCounter::default(), Color32F::TRANSPARENT, Kind::Unspecified);
+    let mut index = 0;
+    elements.retain_mut(|element| {
+        index += 1;
+        if index <= start { return true; }
+        let old = std::mem::replace(element, empty.clone().into());
+        let clipped = match old {
+            SceneElement::Surface(e) => CropRenderElement::from_element(e, 1.0, crop).map(Into::into),
+            SceneElement::Memory(e) => CropRenderElement::from_element(e, 1.0, crop).map(Into::into),
+            SceneElement::ScaledMemory(e) => CropRenderElement::from_element(e, 1.0, crop).map(Into::into),
+            SceneElement::Solid(e) => CropRenderElement::from_element(e, 1.0, crop).map(Into::into),
+            other => Some(other),
+        };
+        if let Some(clipped) = clipped { *element = clipped; true } else { false }
+    });
 }
 
 /// Renders one full frame from the current ledger, submits it, sends
@@ -234,6 +261,10 @@ pub(crate) fn build_scene_into(
     // annotations) — including the desktop's own dock and menus.
     push_layer_band(elements, renderer, backend, WlrLayer::Overlay, viewport);
 
+    if let Some(transition) = backend.gesture_scene.as_ref().filter(|t| t.horizontal()) {
+        return crate::gesture_scene::render(elements, renderer, backend, transition, viewport);
+    }
+
     if let Some(overview) = backend
         .overview
         .as_ref()
@@ -249,7 +280,10 @@ pub(crate) fn build_scene_into(
                 push_shell_elements(elements, renderer, record, viewport);
             }
         }
+        let furniture_alpha = (1.0 - overview.progress.clamp(0.0, 1.0)) as f32;
+        push_furniture(elements, renderer, backend, viewport, furniture_alpha, true);
         crate::overview::render(elements, renderer, backend, overview, viewport);
+        push_furniture(elements, renderer, backend, viewport, furniture_alpha, false);
         return push_background(elements, renderer, backend, viewport);
     }
 
@@ -627,6 +661,7 @@ pub(crate) fn take_presentation_feedback(
 /// than rediscovering visibility from all windows and all stacking
 /// entries on every frame callback and presentation-feedback drain.
 fn for_each_presented_window(backend: &WaylandBackend, mut visit: impl FnMut(&WindowRecord)) {
+    crate::gesture_scene::for_each_neighbor(backend, &mut visit);
     for window in backend.scene_index.unmanaged() {
         if let Some(record) = backend
             .windows
@@ -794,7 +829,7 @@ fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> boo
     // framebuffer) mutates while the ledger is read — both live on
     // `Compositor`, so destructure instead of going through `&mut
     // self` methods.
-    let Compositor { wm, graphics, outputs, pointer_location, cursor_status, cursors, start_time, .. } = comp;
+    let Compositor { wm, graphics, outputs, pointer_location, cursor_status, cursors, start_time, frame_stats, .. } = comp;
     let Graphics::Winit(winit_backend) = graphics else {
         return false;
     };
@@ -842,6 +877,7 @@ fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> boo
             }
         };
 
+        let gesture_build = wm.backend().gesture_scene.as_ref().map(|_| std::time::Instant::now());
         let clear_color = build_scene_into(
             scene_scratch,
             wm.backend(),
@@ -851,6 +887,7 @@ fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> boo
             cursors,
             Rect::new(Point::new(0, 0), entry.size),
         );
+        if let Some(started) = gesture_build { frame_stats.record_gesture_build(started.elapsed()); }
 
         crate::capture_tool::render(scene_scratch, renderer, wm.backend(), Rect::new(Point::new(0, 0), entry.size));
         match damage_tracker.render_output(renderer, &mut framebuffer, age, scene_scratch, clear_color) {
@@ -1023,6 +1060,10 @@ fn push_layer_band(
     band: WlrLayer,
     viewport: Rect,
 ) {
+    push_layer_band_alpha(elements, renderer, backend, band, viewport, 1.0);
+}
+fn push_layer_band_alpha(elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
+    backend: &WaylandBackend, band: WlrLayer, viewport: Rect, alpha: f32) {
     for record in backend.layers.iter().rev() {
         if record.layer != band || !backend.layer_presented(record) {
             continue;
@@ -1062,10 +1103,10 @@ fn push_layer_band(
                 global.x - viewport.pos.x,
                 global.y - viewport.pos.y,
             ));
-            push_surface_tree(elements, renderer, popup_surface, location, popup_factor, 1.0, Kind::Unspecified);
+            push_surface_tree_alpha(elements, renderer, popup_surface, location, popup_factor, 1.0, Kind::Unspecified, alpha);
         }
         if surface_tree_reaches_viewport(surface, record.geometry.pos, record.geometry, factor, viewport) {
-            push_surface_tree(elements, renderer, surface, origin, factor, 1.0, Kind::Unspecified);
+            push_surface_tree_alpha(elements, renderer, surface, origin, factor, 1.0, Kind::Unspecified, alpha);
         }
     }
 }
@@ -1080,6 +1121,10 @@ fn push_shell_elements(
     record: &crate::state::ShellRecord,
     viewport: Rect,
 ) {
+    push_shell_elements_alpha(elements, renderer, record, viewport, 1.0);
+}
+fn push_shell_elements_alpha(elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
+    record: &crate::state::ShellRecord, viewport: Rect, alpha: f32) {
     if overlap_area(record.geometry, viewport) == 0 {
         return;
     }
@@ -1093,7 +1138,7 @@ fn push_shell_elements(
                 renderer,
                 location,
                 buffer,
-                None,
+                Some(alpha),
                 None,
                 None,
                 Kind::Unspecified,
@@ -1123,13 +1168,25 @@ fn push_shell_elements(
                     record.fill_id.clone(),
                     geometry,
                     CommitCounter::default(),
-                    Color32F::new(r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0, 1.0),
+                    Color32F::new(r as f32 / 255.0 * alpha, g as f32 / 255.0 * alpha, b as f32 / 255.0 * alpha, alpha),
                     Kind::Unspecified,
                 )
                 .into(),
             );
         }
     }
+}
+
+pub(crate) fn push_furniture(elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
+    backend: &WaylandBackend, viewport: Rect, alpha: f32, above: bool) {
+    if alpha <= 0.0 || fullscreen_occludes_desktop_bands(backend, viewport) { return; }
+    for id in backend.shell_stacking.iter().rev() {
+        if backend.overview.as_ref().is_some_and(|o| o.surface == *id) { continue; }
+        if let Some(record) = backend.shells.get(id).filter(|s| s.mapped && s.above == above) {
+            push_shell_elements_alpha(elements, renderer, record, viewport, alpha);
+        }
+    }
+    push_layer_band_alpha(elements, renderer, backend, if above { WlrLayer::Top } else { WlrLayer::Bottom }, viewport, alpha);
 }
 
 /// Pushes one managed window's client content (front to back): its
@@ -1295,6 +1352,15 @@ pub(crate) fn push_surface_tree(
     render_scale: f64,
     kind: Kind,
 ) {
+    push_surface_tree_alpha(elements, renderer, surface, location, factor, render_scale, kind, 1.0);
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn push_surface_tree_alpha(
+    elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
+    surface: &WlSurface, location: SPoint<i32, Physical>, factor: f64,
+    render_scale: f64, kind: Kind, alpha: f32,
+) {
     // This is smithay's `render_elements_from_surface_tree` traversal
     // with its sink made caller-owned. That helper necessarily returns
     // a fresh Vec, which meant one allocator round trip per visible
@@ -1380,7 +1446,7 @@ pub(crate) fn push_surface_tree(
                         return None;
                     }
                     Some(WaylandSurfaceRenderElement::from_surface(
-                        renderer, &node, states, location, 1.0, kind,
+                        renderer, &node, states, location, alpha, kind,
                     ))
                 });
                 match drawn {

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -1344,6 +1344,7 @@ pub(crate) fn init(
                 }
             }
             UdevEvent::Removed { device_id } => {
+                crate::input::gestures::cancel(comp);
                 tracing::warn!(?device_id, "a DRM device went away; if it is ours the session will stop painting");
             }
         })
@@ -1373,6 +1374,9 @@ pub(crate) fn init(
         .insert_source(notifier, |event, &mut (), comp: &mut Compositor| {
             match event {
                 SessionEvent::PauseSession => {
+                    // Retire transient scenes before vblank/input disappear;
+                    // an inactive seat must not finish a workspace commit.
+                    crate::input::gestures::cancel(comp);
                     let Graphics::Session(session) = &mut comp.graphics else {
                         return;
                     };
@@ -1757,6 +1761,10 @@ fn attach_output(
             vrr_enabled,
         },
     ))
+}
+
+pub(crate) fn input_active(graphics: &Graphics) -> bool {
+    match graphics { Graphics::Winit(_) => true, Graphics::Session(session) => session.drm.is_active() }
 }
 
 /// Whether any output is still waiting for a frame it has not been able
@@ -2499,6 +2507,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
         wm,
         graphics,
         outputs: output_entries,
+        frame_stats,
         output_mgmt,
         hyprland_state_dirty,
         pointer_location,
@@ -2612,6 +2621,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
                     .map(|monitor| monitor.geometry)
                     .unwrap_or_else(|| Rect::new(output.position, wm.backend().output_size))
             });
+        let gesture_build = wm.backend().gesture_scene.as_ref().map(|_| Instant::now());
         let clear_color = crate::renderer::build_scene_into(
             &mut output.scene_scratch,
             wm.backend(),
@@ -2621,6 +2631,7 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
             cursors,
             viewport,
         );
+        if let Some(started) = gesture_build { frame_stats.record_gesture_build(started.elapsed()); }
 
         crate::capture_tool::render(&mut output.scene_scratch, renderer, wm.backend(), viewport);
         let (rendered, direct_scanout, render_states) =

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -168,6 +168,7 @@ pub(crate) struct FrameStats {
     /// submissions alone can hide expensive work on an unchanged scene.
     pub render_attempts: u64,
     pub render: PhaseTiming,
+    pub gesture_build: PhaseTiming,
     pub flush: PhaseTiming,
     pub ipc: PhaseTiming,
     /// Power-of-two microsecond ceilings, from <=1 us through >16384 us.
@@ -176,6 +177,9 @@ pub(crate) struct FrameStats {
 }
 
 impl FrameStats {
+    pub(crate) fn record_gesture_build(&mut self, elapsed: Duration) {
+        self.gesture_build.record(elapsed);
+    }
     fn histogram_bucket(elapsed: Duration) -> usize {
         let micros = elapsed.as_micros().max(1);
         (u128::BITS - (micros - 1).leading_zeros()).min(15) as usize
@@ -621,6 +625,7 @@ pub struct WaylandBackend {
     pub(crate) frames: HashMap<WlFrameId, FrameRecord>,
     pub(crate) shells: HashMap<WlShellId, ShellRecord>,
     pub(crate) overview: Option<crate::overview::Overview>,
+    pub(crate) gesture_scene: Option<crate::gesture_scene::Transition>,
     pub(crate) capture_ui: Option<crate::capture_tool::Overlay>,
     /// Bottom-to-top managed application order — see [`StackEntry`].
     pub(crate) stacking: Vec<StackEntry>,
@@ -1010,6 +1015,7 @@ impl WaylandBackend {
             next_id: 1,
             windows: HashMap::new(),
             overview: None,
+            gesture_scene: None,
             capture_ui: None,
             scene_index: SceneIndex::default(),
             surface_windows: HashMap::new(),
@@ -2508,6 +2514,9 @@ impl Compositor {
         let dispatch_span = tracing::info_span!("dispatch_pass");
         let _dispatch_guard = dispatch_span.enter();
         let dispatch_started = Instant::now();
+        // Spring commits join the ordinary notification/focus/protocol drain
+        // below, so a workspace settles and receives keyboard focus together.
+        crate::gesture_scene::tick(self);
         self.apply_pending_keyboard();
         if let Some(config) = self.wm.backend_mut().pending_pointer.take() {
             self.wm.backend_mut().scroll_factor = config.scroll_factor.unwrap_or(1.0);
@@ -2542,6 +2551,7 @@ impl Compositor {
             // switcher open (see the X11 loop's longer commentary;
             // `KeyRelease` is never intercepted at all).
             if let BackendEvent::KeyPress(combo) = &event {
+                if self.wm.backend().gesture_scene.is_some() { crate::input::gestures::cancel(self); }
                 if crate::capture_tool::key(self, combo) {
                     continue;
                 }
@@ -2825,6 +2835,8 @@ impl Compositor {
         // before rendering. It is event-driven: without a new surface,
         // output change, or surface death this returns immediately.
         crate::lock::refresh(self);
+        crate::gesture_scene::validate(self);
+        crate::input::keyboard::sync_modal_focus(self);
 
         // Timed commits are independent of presentation, and an invisible
         // surface cannot ever satisfy a FIFO presentation barrier. Visibility
@@ -4216,6 +4228,9 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
             wait = wait.min(deadline.saturating_duration_since(now));
         }
         if let Some(deadline) = crate::session::next_render_deadline(&comp.graphics) {
+            wait = wait.min(deadline.saturating_duration_since(now));
+        }
+        if let Some(deadline) = crate::gesture_scene::deadline(&comp) {
             wait = wait.min(deadline.saturating_duration_since(now));
         }
         if let Some(deadline) = crate::session::next_hotplug_deadline(&comp.graphics) {

--- a/crates/wm-wayland/src/test_door.rs
+++ b/crates/wm-wayland/src/test_door.rs
@@ -554,7 +554,21 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
             };
             crate::input::process_input_event::<TestInput>(comp, input);
         }
-        Some("swipe") => {
+        Some("input-reset") => {
+            match words.next() {
+                Some("resume") => crate::input::resynchronise_input_after_resume(comp),
+                Some("pause") => crate::input::gestures::cancel(comp),
+                Some("device") => crate::input::process_input_event::<TestInput>(comp, InputEvent::DeviceRemoved { device: TestDevice }),
+                _ => reply_err(stream, "input-reset wants pause|resume|device"),
+            }
+        }
+        Some(command @ ("swipe" | "swipe-at")) => {
+            let time = if command == "swipe-at" {
+                let Some(time) = words.next().and_then(|s| s.parse::<u32>().ok()) else {
+                    reply_err(stream, "swipe-at wants a millisecond timestamp"); return;
+                };
+                u64::from(time) * 1000
+            } else { time };
             let mut event = TestSwipeEvent {
                 fingers: 0,
                 delta: (0.0, 0.0),
@@ -751,7 +765,7 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
             };
             let _ = stream.write_all(
                 format!(
-                    "frame-stats dispatch_calls={} dispatch_us={} dispatch_max_us={} input_us={} shell_us={} protocol_us={} layout_us={} render_calls={} render_us={} render_max_us={} flush_us={} ipc_us={} dispatch_hist={} render_hist={} render_attempts={}\n",
+                    "frame-stats dispatch_calls={} dispatch_us={} dispatch_max_us={} input_us={} shell_us={} protocol_us={} layout_us={} render_calls={} render_us={} render_max_us={} flush_us={} ipc_us={} dispatch_hist={} render_hist={} render_attempts={} gesture_build_calls={} gesture_build_us={} gesture_build_max_us={}\n",
                     stats.dispatch.calls,
                     micros(stats.dispatch.total),
                     micros(stats.dispatch.max),
@@ -767,6 +781,7 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                     buckets(&stats.dispatch_histogram),
                     buckets(&stats.render_histogram),
                     stats.render_attempts,
+                    stats.gesture_build.calls, micros(stats.gesture_build.total), micros(stats.gesture_build.max),
                 )
                 .as_bytes(),
             );
@@ -791,6 +806,13 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
         Some("windows") => {
             let mut reply = String::new();
             let backend = comp.wm.backend();
+            let logical_focus = comp.wm.focused_client().and_then(|id| comp.wm.client(id)).map(|c| c.window);
+            let seat_focus = comp.seat.get_keyboard().and_then(|k| k.current_focus())
+                .and_then(|focus| backend.window_for_surface(focus.surface()));
+            reply.push_str(&format!("gesture-focus logical={} seat={}\n",
+                logical_focus.map_or(0, |w| w.0), seat_focus.map_or(0, |w| w.0)));
+            let (owner, (x, y), motion) = crate::input::gestures::inspect(comp);
+            reply.push_str(&format!("swipe-stream owner={owner} x={x} y={y} axis={:?}\n", motion.map(|m| m.axis)));
             reply.push_str(&format!("scale {}\n", comp.ui_scale));
             reply.push_str(&format!("workspaces current={} count={}\n",
                 comp.wm.current_workspace(), comp.wm.workspace_count()));
@@ -875,10 +897,10 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
             }
             if let Some(overview) = &backend.overview {
                 reply.push_str(&format!(
-                    "overview selected={} label_bytes={} preview_edge={}\n",
+                    "overview selected={} label_bytes={} preview_edge={} progress={}\n",
                     overview.selected,
                     overview.label_bytes(),
-                    backend.preview_edge.unwrap_or(0)
+                    backend.preview_edge.unwrap_or(0), overview.progress
                 ));
                 for window in &overview.windows {
                     let r = window.destination;
@@ -893,6 +915,22 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                         window.source.size.h
                     ));
                 }
+                if let Some(drag) = overview.drag {
+                    if let Some(window) = overview.windows.get(drag.index) {
+                        let r = drag.destination;
+                        reply.push_str(&format!(
+                            "overview-drag id={} x={} y={} w={} h={} target={}\n",
+                            window.window.0, r.pos.x, r.pos.y, r.size.w, r.size.h,
+                            drag.workspace.map_or(-1, |index| index as i64)));
+                    }
+                }
+            }
+            if let Some(scene) = &backend.gesture_scene {
+                reply.push_str(&format!("gesture kind={} axis={:?} x={} y={} raw_progress={} progress={} velocity={} projected={} target={} settling={} origin={} previous={} next={}\n",
+                    if scene.horizontal() { "workspace" } else { "overview" }, scene.motion.axis,
+                    scene.motion.x, scene.motion.y, scene.motion.progress, scene.position, scene.velocity,
+                    scene.projected, scene.spring.map_or(f64::NAN, |s| s.target), scene.spring.is_some(), scene.origin,
+                    scene.previous.map_or(-1, |i| i as i64), scene.next.map_or(-1, |i| i as i64)));
             }
             reply.push_str("done\n");
             let _ = stream.write_all(reply.as_bytes());

--- a/docs/engineering/2026-09-06-interactive-gestures.md
+++ b/docs/engineering/2026-09-06-interactive-gestures.md
@@ -1,0 +1,193 @@
+# Interactive native desktop gestures
+
+## Architecture and ownership
+
+`wm-core::SwipeTracker` recognizes and owns a complete stream and produces timed
+`SwipeMotion`, without knowing about pixels, windows, or outputs. The Wayland
+input adapter owns protocol forwarding and cancellation. `gesture_scene` owns
+the transient scene, cached neighbors, and the shared spring. The renderer uses
+live surface trees, sparse frame textures, scene transforms and GPU clipping.
+No client geometry is changed for animation, and no screenshot is taken.
+
+At horizontal axis lock, cache the logical origin and at most its two neighbors.
+The final occupied workspace permits one provisional empty neighbor. This is
+only scene metadata: the workspace is created by the existing semantic action
+after settlement. An empty final workspace has no next neighbor. Reversals can
+cross the origin and expose the opposite side in the same stream. One gesture
+commits at most one neighboring workspace.
+
+Normal planes collect windows in compositor stacking order with indexed WM
+lookups. Overview neighbors prepare the same packing and captions once, without
+switching the WM. Overview caches desktop and packed geometry and a linear-time
+stack-order index. During a morph, only transforms, control alpha, and furniture
+alpha change; buffers and layout are reused. Existing minimized-window fallbacks
+reuse small cached previews only when no live surface is available.
+
+The real workspace and semantic keyboard focus stay at the origin until a
+commit. Partial scenes return the root from pointer hit-testing; no exposed
+neighbor can activate through hover or focus-follows-mouse. A pointer press
+cancels and consumes its matching release. Keyboard commands take over. Spring
+commits happen before the regular notification, focus and protocol drains, so
+activation is not deferred to an unrelated later event. Adjacent exposed live
+clients participate in frame callbacks and presentation feedback.
+
+Reserved streams stay compositor-owned after invalidation. Two/five fingers,
+disabled gestures, and unconfigured finger counts retain complete client
+streams. Existing pointer grabs (including implicit/client grabs), menus,
+Alt-Tab, exclusive layers, focus grabs, capture tools and locks suppress desktop
+gestures. Device loss/resume/lock clean up immediately. A libinput cancellation
+instead springs to the original state and can never commit. Output/topology
+changes and replacement of cached Overview contents cancel stale scenes.
+
+## Mapping and release velocity
+
+The configured `distance` remains the slow-release midpoint, with range
+24..1000 logical touchpad units. Full span is `2 * distance`, default 160.
+Positive `-dx/span` means next workspace; positive `-dy/span` means opening
+Overview. Output resolution, scale, scroll direction and scroll multiplier do
+not enter recognition or physics. Each output translates by its physical width
+times normalized progress, with a clip tied to the translated source viewport.
+This prevents content on another head leaking in through a mixed-scale boundary.
+
+Initial axis lock remains 12 logical units and 1.25x dominance. Once locked it
+does not oscillate with cross-axis noise. The inline ring retains eight position
+and timestamp samples, spaced at least 12 ms apart. High-rate devices therefore
+retain roughly 84 ms rather than only their final eight hardware events.
+Intervals older than 100 ms are ignored. Velocity is the weighted sum of interval
+displacements divided by weighted time, with exponential recency weighting
+`exp(-age / 0.035)`. The current endpoint accounts for motion after the last
+retained sample. A pause ages velocity to zero; one zero final sample does not
+erase the recent trajectory. Timestamp wrapping and invalid motion are guarded.
+Samples sharing a timestamp retain the newest endpoint, not the older stored
+position. Less than 12 ms of history is insufficient for a velocity estimate.
+This prevents a coalesced reversal from resurrecting the earlier direction.
+
+Projection uses 180 ms of estimated velocity, bounded to eight spans/second.
+Midpoint is 0.5. A slow short stroke cancels, a slow long one commits, and a fast
+short flick can commit. A reverse flick can cancel even past midpoint. Projection
+cannot select an opposite neighbor before the fingers actually cross the origin.
+All tuning constants and target selection are in `gestures/physics.rs`.
+
+## Spring and edges
+
+The critically damped spring uses angular frequency 22 radians/second. For
+offset `x = position - target`, `c = velocity + omega*x`, and elapsed time `dt`:
+
+```
+position = target + (x + c*dt) * exp(-omega*dt)
+velocity = (velocity - omega*c*dt) * exp(-omega*dt)
+```
+
+This analytic solution preserves release position and velocity and is stable
+across frame intervals. It is not an Euler integrator or a restarted easing
+curve. Negative/nonfinite times do not advance; an interruption exceeding two
+seconds snaps to the already-selected endpoint. Malformed state is sanitized.
+Settlement snaps exactly when error is below 0.0001 spans and velocity below
+0.003 spans/second. Tests compare 30/60/120/144/240/360 Hz and partitioned time.
+
+Beyond an available boundary, for excess `d`, visual excess is
+`sign(d) * L*abs(d)/(L+abs(d))`, with `L = 0.18` spans. Its derivative is
+`(L/(L+abs(d)))^2`; multiplying finger velocity by that derivative preserves
+the visible velocity at spring handoff. This is bounded and nonlinear, not a
+hard stop. A fresh desktop swipe can catch a moving spring: inverse resistance
+sets its new displacement origin to the exact currently presented position.
+
+## Scheduling and performance discipline
+
+Following updates change scalar state and mark damage. Native KMS uses the
+existing vblank events, per-output `FrameClock`, pending-flip gates and render
+deadlines. No extra animation thread or permanent timer exists. Only the nested
+non-vsynced backend contributes a temporary spring deadline, derived from its
+advertised refresh. An idle held gesture requests no frames on its own.
+
+History, projection, resistance and spring stepping allocate nothing. Preparing
+neighbors and Overview captions may allocate once at axis lock. Per-frame scene
+vectors and surface-tree traversal scratch reuse capacity. Clipping wraps scene
+elements in place, without another large vector, framebuffer or readback.
+Snapshots for icon previews are suspended during transitions and Overview.
+
+Measured on an Intel Core i9-9900K, release profile, nested Weston with Mesa
+llvmpipe (LLVM 22.1.8), not Apple hardware:
+
+- Inline tracker size: 240 bytes.
+- 100,000 timed tracker/projection/resistance/spring updates: zero allocation
+  calls and zero requested bytes; 9.54 ms total in the final optimized run
+  (approximately 95 ns/update; the initial run was 10.58 ms). The allocation suite also drives 100,000 snap
+  queries and remains allocation-free.
+- 120 warmed following updates: 240 scene-build attempts, 3,326 microseconds
+  total CPU scene-building time (13.86 microseconds/build), maximum 38
+  microseconds. The additional attempts include test-barrier damage no-ops.
+- Those updates submitted 120 frames. Whole render/submission time averaged
+  16.44 ms, including the nested display's presentation wait. That number is
+  **not** GPU execution time or scene-building CPU cost. The new
+  `gesture_build_calls/us/max_us` counters separate those quantities.
+- After settlement, the static-client test observes zero render calls across a
+  160 ms observation interval; no gesture animation deadline survives cleanup.
+
+These software-path results are not measured physical touch-to-photon latency.
+There is no allocation profiler enabled in the timing build. Allocation counts
+come from the separate allocation test, not inferred from low CPU time.
+
+## Overview window dragging
+
+[Apple Mission Control](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac)
+and [GNOME Overview](https://help.gnome.org/gnome-help/shell-workspaces-movewindow.html)
+both move windows by dragging them to workspace thumbnails. The implementation
+uses a scale-aware three-point pickup threshold, preserves the grabbed location,
+shrinks without enlarging small windows, and renders the live image at 82%
+opacity. The whole thumbnail, including the normally destructive close corner,
+is one drop target. A bright outline, tint, and “Move to Desktop N” caption
+provide continuous feedback. Drops stay on the source desktop with Overview open.
+
+Press records a stable client identity and acquires a pointer grab immediately.
+Release revalidates identity, lifecycle and workspace row. Escape invalidates the
+held press while retaining ownership of release. Invalid drops do not activate;
+layout changes invalidate a drag rather than moving whatever occupies its old
+index. Native pointer updates only move the cached image and selection metadata.
+X11 keeps its existing panel fallback with a lightweight moving selection plate.
+
+## Coverage and hardware boundary
+
+Unit/allocation tests cover recognition, finger settings, timing history,
+reversal, malformed input/time/state, midpoint/flick projection, resistance and
+its derivative/inverse, spring continuity/exact settlement, normalized output
+mapping, cached morph endpoints, and drag threshold/anchor arithmetic.
+
+Native Wayland E2E checks intermediate live pixels at 1x/1.5x/2x, untouched WM
+geometry, no configure events during morphing, pointer isolation, explicit
+Overview semantics, symmetric opening/closing, flicks, reversal, cancellation,
+device removal, resume, spring catching, client swipe protocol pass-through,
+empty-final-desktop policy, and existing layer-bar boundaries. Overview E2E
+checks scale-aware drops, small-motion cancellation, invalid drops, desktop
+close corners, keyboard/pointer activation, deletion and live rendering.
+
+The nested harness exposes one output, so physical mixed-output cadence and
+actual libinput devices still need hardware validation. Required manual matrix:
+Apple/M1 trackpad on Omarchy, another libinput trackpad, 60/120/144+ Hz KMS,
+mixed 1x/1.5x/2x heads, output hotplug, lock/unlock and VT suspend/resume. Confirm
+finger attachment, reversal on the next composed frame, release continuity,
+elasticity and focus with Chrome and native terminals. No headless test certifies
+subjective macOS parity, physical latency, or Apple hardware compatibility.
+
+Existing scope boundaries remain explicit: Overview uses ChonkStep's existing
+single-output arrangement, while horizontal workspace planes render on every
+output. The adjacent plane previews live windows; workspace-local minimized-icon
+shell surfaces are reconciled at semantic commit. Current-workspace icons slide
+with its plane, bars/dock and pinned windows remain fixed. The X11 login session
+does not receive native libinput gestures. Desktop/workspace geometry never
+changes just to animate any of these views.
+
+## Preflight record
+
+- `scripts/check.sh all`: strict workspace/all-target Clippy, strict rustdoc,
+  1,953 passing Rust tests (including Wayland and allocation tests), and 26
+  passing Python harness tests.
+- `scripts/e2e.sh --headless`: 223 passing Wayland E2E tests and three passing
+  installed-Omarchy checks. Includes real Chrome selection/repeat, capture,
+  focus, lock, workspace, Overview, gestures, and protocol regression suites.
+- Optimized `desktop_gestures`: nine passing E2E tests; Overview: five passing
+  E2E tests, with drag coverage at 1x/1.5x/2x.
+- Targeted final reruns cover the explicit pause cleanup, layer ordering and
+  interpolated selection outline. The first heavily concurrent preflight
+  exposed an existing 16 ms dock-IPC timing test at 18.37 ms; the clean serial
+  preflight passed it without changing its implementation or tolerance.

--- a/docs/gestures.md
+++ b/docs/gestures.md
@@ -6,7 +6,7 @@ default:
 | Swipe | Action |
 | --- | --- |
 | Left | Next workspace; creates one past an occupied final desktop |
-| Right | Previous workspace; stops at the first |
+| Right | Previous workspace; elastic resistance at the first |
 | Up | Open Overview with smaller previews of the current workspace's windows |
 | Down | Dismiss Overview |
 
@@ -19,6 +19,15 @@ Return and Escape work throughout. An upward swipe while it is open keeps it
 open; horizontal swipes also work inside Overview. X11 retains the rasterized
 card fallback.
 
+Drag a window upward onto a desktop thumbnail to move it there without leaving
+Overview. The live window image follows the pointer, becomes smaller and
+translucent, and highlights the entire destination thumbnail. Desktop labels
+include window counts. A drop keeps Overview open on the source desktop; a
+drop outside the row cancels. Escape cancels a held drag first, and a second
+Escape closes Overview. Releasing a cancelled drag cannot activate a window.
+The close-control corner is part of the drop target, not a delete operation.
+These generous targets follow [Mission Control's window-to-Space interaction](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac).
+
 Each desktop thumbnail has an × in its upper-right corner while more than one
 desktop exists. Click it to remove that desktop. Its windows move to the desktop
 on its left (or the next desktop when closing the first), keeping their sizes,
@@ -29,17 +38,38 @@ Swiping left on an empty final desktop stops there, so repeated swipes cannot
 create a chain of empty desktops. Minimized windows still count as occupying a
 desktop. Explicit workspace keyboard commands can still create desktops on demand.
 
-An action commits when the fingers lift after enough travel. Short movements,
-ambiguous diagonal strokes, cancelled gestures and strokes that return to their
-starting point do nothing. Each stroke switches at most one workspace. Windows
-do not animate along with the fingers. Two-finger scrolling and pinch-to-zoom
+Once the initial axis is recognized, the desktop follows the fingers on each
+composited frame. Moving left slides the current workspace left and brings the
+next one in from the right; moving right does the reverse. Reverse direction at
+any time, including through the origin toward the other neighbor. The logical
+workspace and keyboard focus do not change while neighboring windows are exposed.
+
+Lift slowly before halfway to cancel, or beyond halfway to commit. A quick
+flick can commit earlier; reversing before release can cancel even after crossing
+halfway. The release hands its current speed to a critically damped spring,
+not a fresh easing animation. Touching a settling desktop catches its current
+position. Missing neighbors have bounded, nonlinear elastic resistance and
+spring back. Each stroke switches at most one workspace.
+
+Overview also follows vertical finger movement: live windows move and scale
+between their desktop geometry and the cached Overview arrangement, while its
+controls fade in or out. Reversing reverses the morph. Opening and closing use
+the same velocity projection and spring as workspace movement. Up while already
+open does not close it, and down while closed does not open it.
+
+Initial jitter and ambiguous diagonal strokes do not start transitions.
+Cancelled libinput gestures settle back without committing. Two-finger scrolling and pinch-to-zoom
 continue to reach applications. Swipes are physical touchpad directions,
 independent of `natural_scroll`, `scroll_factor` and output scale.
 
 The compositor owns the complete reserved swipe stream, including cancellation.
-Session lock, seat resume and device removal retire an in-flight swipe. A drag,
+Session lock, seat pause/resume and device removal retire an in-flight swipe. A drag,
 menu, exclusive layer keyboard owner, focus grab or Alt+Tab session prevents a
 desktop action. Disabling gestures passes swipes through to applications.
+During a partial transition, pointer hit-testing cannot focus or activate an
+exposed window. A pointer press cancels the transition and consumes that click's
+matching release. Keyboard commands take over from the gesture. Topology, output
+layout/scale changes, or replacement of the cached Overview scene cancel safely.
 
 ## Configuration
 
@@ -50,7 +80,7 @@ the normal live reload:
 [input.gestures]
 enabled = true
 fingers = 0       # 0 = both three and four; or choose 3 or 4
-distance = 80    # logical touchpad travel; accepted range 24..1000
+distance = 80    # slow-release midpoint; full gesture span = 160 logical units
 ```
 
 Settings are latched at the beginning of each stroke. Hyprland's arbitrary
@@ -58,6 +88,9 @@ Settings are latched at the beginning of each stroke. Hyprland's arbitrary
 native desktop gestures. The X11 session does not receive this libinput gesture
 stream. A nested compositor depends on its host forwarding gestures; use the
 native login session for physical touchpad gestures.
+The accepted distance range remains 24..1000. There are no new configuration
+keys. Sensitivity is independent of output width, resolution, and scale; each
+output converts the same normalized progress into its own physical translation.
 
 ## Bar boundary
 
@@ -70,11 +103,15 @@ to cover the full output. No fixed bar height or Omarchy process lookup is used.
 
 ## Cost and verification
 
-The swipe recognizer stores at most 40 bytes per seat and performs no allocation
-or rendering during updates. It has no helper process, thread or polling timer.
-The committed action reuses workspace management. Native Overview reuses client
+The recognizer keeps eight timed samples inline on the seat and performs no
+heap allocation during updates. Axis lock prepares neighboring scene metadata
+once; updates change only motion/physics state and mark damage. Native KMS uses
+the existing vblank/frame-clock scheduling. The nested backend has an animation
+deadline only while a spring is active. There is no animation thread, helper
+process, permanent polling timer, screenshot animation, or per-update packing.
+The settled action reuses workspace management exactly once. Native Overview reuses client
 GPU textures and sparse decoration buffers, suspends screenshot readbacks while
-open, and never allocates a monitor-sized raster. Captions are painted once per
+open or transitioning, and never allocates a monitor-sized raster. Captions are painted once per
 entry set; selection changes only the outline and which cached caption is
 shown. Packing runs only when the entry set changes (at most 32 linear passes).
 Closing releases the scene, labels and any small minimized-window fallbacks.
@@ -86,7 +123,16 @@ on every pointer event, and repeated motion against the bar does not resend an
 unchanged frame position.
 
 `cargo test -p wm-core --test gesture_allocations` checks zero allocator requests
-over 100,000 recognition updates and snapping queries. This is an allocation
+over 100,000 timed recognition/physics updates and snapping queries. This is an allocation
 budget, not a hardware latency or RSS benchmark. `scripts/e2e.sh --headless
 --test desktop_gestures` checks actual input routing, workspace visibility,
-Overview lifecycle at 1x/2x, configuration and the layer-shell bar boundary.
+live pixel following at 1x/1.5x/2x, velocity decisions, Overview morph/lifecycle,
+client configure counts, cancellation, device/seat ownership, protocol pass-through,
+configuration and the layer-shell bar boundary. Overview E2E covers window drops,
+keyboard/pointer activation, Escape, and desktop deletion.
+
+The test door's `gesture` ledger reports raw displacement, axis, normalized and
+projected progress, release/spring velocity, settle target, and logical origin.
+`overview progress=` reports the morph fraction. Nothing is logged per sample
+in production. See the [engineering note](engineering/2026-09-06-interactive-gestures.md)
+for constants, measurements and remaining physical-hardware validation.


### PR DESCRIPTION
## Summary

Build continuous native Wayland interactions on the existing recognizer and live Overview scene:
- Reversible, normalized workspace planes with logical workspace/focus held at the origin until commit.
- Inline timestamped velocity history, projected release decisions, elastic bounds, and a shared velocity-preserving critically damped spring.
- Continuous live-texture Overview opening/closing, cached geometry, fading decorations, and no animation-induced client configure events.
- Whole-stream gesture ownership, pointer/modal/lock/seat/device cleanup, and frame scheduling that stops when settled.
- Live Overview window dragging to desktop thumbnails, with scale-aware pickup, anchored previews, drop feedback, and safe cancellation.
- Test-door instrumentation, allocation checks, regression coverage, user documentation, and an engineering/performance record.

The preceding native capture PR #137 is merged; this branch builds on that merge.

## Verification

- Full scripts/check.sh all: strict all-target Clippy and rustdoc, 1,953 Rust tests, 26 Python harness tests.
- Full headless Wayland E2E: 223 tests plus three installed-Omarchy checks, including Chrome selection/repeat, capture, input ownership, Overview, workspaces, and lock.
- Final targeted reruns: optimized desktop gestures (9), Overview (5), session lock (19), strict Clippy, and release allocation tests.
- Representative live-pixel gesture tests at 1x/1.5x/2x; Overview morph at 1x/2x and drag at all three scales.
- Zero allocations across 100,000 timed gesture/physics updates; inline tracker is 240 bytes.
- Optimized nested software-renderer measurement: 13.9 microseconds mean gesture scene CPU construction, 38 microseconds maximum over 240 builds. This excludes render/presentation waits and is not physical touch-to-photon latency.
- No gesture frames continue after settlement in the idle regression test.

## Explicit validation boundaries

Physical M1/libinput feel, high-refresh KMS, and mixed-output cadence still require hardware validation. The nested E2E harness exposes one output; normalized mixed-width behavior is unit-tested, not claimed as physical multi-monitor validation.

Overview keeps its existing single-output arrangement. Adjacent workspace planes preview live windows; workspace-local minimized-icon shell surfaces reconcile at semantic commit. Native gestures do not change the X11 login path.

Installed Omarchy/session configuration was not changed or restarted. See docs/engineering/2026-09-06-interactive-gestures.md for architecture, constants, measurements, and the manual hardware matrix.
