### PR TITLE
Reversible Freeform, Mosaic and Flow workspace layouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_call:
 
 jobs:
   dependency-audit:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -16,8 +16,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validation:
+    name: validate the release revision
+    uses: ./.github/workflows/ci.yml
+    permissions:
+      contents: read
+      checks: write
+
   package:
     name: package (${{ matrix.arch }})
+    needs: validation
     strategy:
       fail-fast: false
       matrix:
@@ -73,11 +81,13 @@ jobs:
           # asset so the main package stays small and only someone
           # reading a crash pays for it.
           debug_package_name="chonkstep-debug-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "package_release=$package_release" >> "$GITHUB_OUTPUT"
-          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "debug_package_name=$debug_package_name" >> "$GITHUB_OUTPUT"
-          echo "source_id=$source_id" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$version"
+            echo "package_release=$package_release"
+            echo "package_name=$package_name"
+            echo "debug_package_name=$debug_package_name"
+            echo "source_id=$source_id"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build the native Arch package environment
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
  "chonk-build-info",
  "chonk-hyprland-ipc",
  "chonk-shell",
+ "chonk-test-support",
  "chonk-xsettings",
  "cosmic-text",
  "libc",

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ and non-Omarchy sessions, see [Installing on Omarchy (or any Arch)](#installing-
   Omarchy applications run against ChonkStep rather than a replica.
 - **Traditional window management.** Windows float by default and can be
   minimized, maximized, shaded, resized from every edge, snapped, stacked, and
-  moved between workspaces. Tiling-only Hyprland commands are deliberately left
-  unbound instead of being mapped to surprising approximations.
+  moved between workspaces. Development builds also support Mosaic and Flow;
+  inapplicable split commands are quiet no-ops.
 - **A safe side-by-side install.** SDDM owns the choice of session. Installing
   ChonkStep does not uninstall or patch Hyprland or modify Omarchy-owned files.
 
@@ -71,6 +71,13 @@ and the release history in [CHANGELOG.md](CHANGELOG.md).
 
 ## Features
 
+- **Three workspace styles (development builds).** Freeform lets you place
+  windows yourself. Mosaic keeps everything visible. Flow lets windows extend
+  sideways beyond the screen. Native Wayland transitions animate live windows,
+  and returning to Freeform restores your original arrangement. **Super+L**
+  toggles Mosaic/Flow, **Super+Shift+L** returns to Freeform, and **Super+T**
+  floats/rejoins a window at its remembered place. Living Desktop saves the
+  organization. See the [keybinding card](docs/keybindings.md).
 - **Chiseled decorations.** Focused black/unfocused gray titlebars,
   flush full-height buttons with the stock glyphs, etched resizebar
   grips - every metric, bevel step, and glyph bitmap written down to

--- a/crates/chonk-hyprland-ipc/src/dispatch.rs
+++ b/crates/chonk-hyprland-ipc/src/dispatch.rs
@@ -1,21 +1,9 @@
 //! Dispatch: turning Hyprland's verbs into chonkstep's, or refusing.
 //!
-//! # The rule this module exists to enforce
-//!
-//! **A verb we cannot honour must fail, loudly, rather than succeed
-//! plausibly.**
-//!
-//! chonkstep is a floating window manager. Hyprland is a tiling one, and
-//! a large part of its dispatch vocabulary — `layoutmsg`, `togglesplit`,
-//! `swapwindow`, `pseudo`, `movewindow l` — means nothing here. The
-//! tempting thing is to answer `ok` and move on, because `ok` is what
-//! callers expect and nothing visibly breaks.
-//!
-//! It is the wrong thing, and the reason is worth being concrete about.
-//! A script that gets `ok` from `togglesplit` believes the layout
-//! changed and takes its next branch accordingly; the mistake is now
-//! invisible and permanent, and it surfaces later as behaviour the user
-//! cannot explain.
+//! Mosaic and Flow translate spatial actions directly; Freeform preserves
+//! traditional geometry. Inapplicable tree messages deliberately succeed
+//! quietly, so the same shortcut stays predictable in all three styles.
+//! Unavailable grouping and system actions remain explicit errors.
 //!
 //! Omarchy often appears to provide a fallback:
 //!
@@ -29,7 +17,7 @@
 //! therefore not treated as a compatibility mechanism: caller-visible
 //! paths are implemented, hidden from chonkstep-owned menus, or tracked
 //! as a bug. It remains the only truthful protocol answer for a request
-//! with no meaning on this floating desktop.
+//! whose requested behavior is unavailable.
 //!
 //! So: [`Outcome::Unsupported`] is a first-class result here, not a
 //! shortfall, and it is reported to the caller as an error string
@@ -69,6 +57,7 @@ pub enum Action {
     ExecArgv(Vec<String>),
     /// Set or toggle fullscreen on the focused window.
     Fullscreen(Fullscreen),
+    ToggleMaximize,
     /// Focus the next/previous window.
     CycleFocus { forward: bool },
     MoveWindow { window: u64, x: i32, y: i32, relative: bool },
@@ -92,9 +81,18 @@ pub enum Action {
     ReloadConfig,
     SetDiagnostic { name: String, enabled: bool },
     SetLogFilter(String),
-    /// The requested window is already floating; applying this still
-    /// validates that the target survived until the action ran.
-    ConfirmFloating(u64),
+    /// Set or toggle membership in the current workspace layout.
+    SetFloating {
+        window: u64,
+        floating: Option<bool>,
+    },
+    SetWorkspaceLayout {
+        workspace: usize,
+        mode: String,
+    },
+    ToggleLayout,
+    MoveDirection(Direction),
+    LayoutNoop,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -152,8 +150,7 @@ impl Outcome {
     }
 }
 
-/// Every tiling-only verb in Hyprland's dispatch table, with the reason
-/// chonkstep cannot honour it.
+/// Known operations outside ChonkStep's model, with their refusal reason.
 ///
 /// Listing them explicitly — rather than letting them fall through to
 /// "unknown dispatcher" — is the difference between "chonkstep does not
@@ -161,13 +158,7 @@ impl Outcome {
 /// asked for and is not able to do it". The second is a much better
 /// error to read at 2am, and it is the one that tells a script author
 /// their fallback path is the right one to write.
-const TILING_ONLY: &[(&str, &str)] = &[
-    ("layoutmsg", "chonkstep has no tiling layout to message"),
-    ("togglesplit", "chonkstep has no split direction; every window floats"),
-    ("swapsplit", "chonkstep has no split direction; every window floats"),
-    ("swapwindow", "chonkstep has no tiling order to swap within"),
-    ("swapnext", "chonkstep has no tiling order to swap within"),
-    ("pseudo", "pseudotiling is meaningless in a floating window manager"),
+const UNSUPPORTED: &[(&str, &str)] = &[
     ("togglegroup", "chonkstep has no window groups"),
     ("changegroupactive", "chonkstep has no window groups"),
     ("moveintogroup", "chonkstep has no window groups"),
@@ -176,13 +167,6 @@ const TILING_ONLY: &[(&str, &str)] = &[
     ("togglespecialworkspace", "chonkstep has no special (scratchpad) workspaces"),
     ("workspaceopt", "chonkstep has no per-workspace layout options"),
     ("submap", "chonkstep's keybindings do not have submaps"),
-];
-
-/// Verbs chonkstep understands but which target something it does not
-/// model, listed separately from the tiling ones because the reason is
-/// different and a reader deserves to know which kind of "no" this is.
-const NOT_MODELLED: &[(&str, &str)] = &[
-    ("settiled", "chonkstep cannot tile a window"),
 ];
 
 /// Parse a dispatch argument string.
@@ -220,14 +204,28 @@ fn split_verb(args: &str) -> (String, &str) {
 }
 
 fn parse_classic(verb: &str, rest: &str, snapshot: &Snapshot) -> Outcome {
-    if let Some((_, why)) = TILING_ONLY.iter().find(|(name, _)| *name == verb) {
-        return Outcome::Unsupported((*why).to_string());
-    }
-    if let Some((_, why)) = NOT_MODELLED.iter().find(|(name, _)| *name == verb) {
+    if let Some((_, why)) = UNSUPPORTED.iter().find(|(name, _)| *name == verb) {
         return Outcome::Unsupported((*why).to_string());
     }
 
     match verb {
+        "layoutmsg" | "togglesplit" | "swapsplit" | "pseudo" | "splitratio" => {
+            Outcome::Run(Action::LayoutNoop)
+        }
+        "togglelayout" => Outcome::Run(Action::ToggleLayout),
+        "layout" => layout_action(snapshot.active_workspace().map_or(0, |w| w.index), rest),
+        "swapnext" => Outcome::Run(Action::MoveDirection(if rest.contains("prev") {
+            Direction::Left
+        } else {
+            Direction::Right
+        })),
+        "movewindow" | "swapwindow" => match rest.trim() {
+            "l" | "left" => Outcome::Run(Action::MoveDirection(Direction::Left)),
+            "r" | "right" => Outcome::Run(Action::MoveDirection(Direction::Right)),
+            "u" | "up" => Outcome::Run(Action::MoveDirection(Direction::Up)),
+            "d" | "down" => Outcome::Run(Action::MoveDirection(Direction::Down)),
+            _ => Outcome::Unsupported("window movement requires a direction".into()),
+        },
         "workspace" => match workspace_target(rest, snapshot) {
             Ok(index) => Outcome::Run(Action::FocusWorkspace(index)),
             Err(why) => Outcome::Unsupported(why),
@@ -270,14 +268,15 @@ fn parse_classic(verb: &str, rest: &str, snapshot: &Snapshot) -> Outcome {
             Outcome::Run(Action::MoveToWorkspace { window, workspace, follow })
         }
         "exec" => classic_exec(rest),
-        "fullscreen" => Outcome::Run(Action::Fullscreen(match rest.trim() {
-            "" | "0" => Fullscreen::Toggle,
-            // Hyprland's `1` is "maximize to the window's monitor",
-            // which for a floating window manager with no tiling to
-            // return to is the same operation as fullscreen.
-            "1" | "2" => Fullscreen::On,
-            _ => Fullscreen::Toggle,
-        })),
+        "fullscreen" => {
+            if rest.trim() == "1" {
+                Outcome::Run(Action::ToggleMaximize)
+            } else if rest.trim() == "2" {
+                Outcome::Run(Action::Fullscreen(Fullscreen::On))
+            } else {
+                Outcome::Run(Action::Fullscreen(Fullscreen::Toggle))
+            }
+        }
         "fullscreenstate" => {
             let client = rest.split_whitespace().nth(1).unwrap_or("0");
             Outcome::Run(Action::Fullscreen(if client == "0" { Fullscreen::Off } else { Fullscreen::On }))
@@ -305,8 +304,17 @@ fn parse_classic(verb: &str, rest: &str, snapshot: &Snapshot) -> Outcome {
         "pin" => selected_window(rest, snapshot)
             .map(|window| Outcome::Run(Action::SetPinned { window: window.id, pinned: None }))
             .unwrap_or_else(|| Outcome::Unsupported(format!("no window matches {rest:?}"))),
-        "togglefloating" | "setfloating" => selected_window(rest, snapshot)
-            .map(|window| Outcome::Run(Action::ConfirmFloating(window.id)))
+        "togglefloating" | "setfloating" | "settiled" => selected_window(rest, snapshot)
+            .map(|window| {
+                Outcome::Run(Action::SetFloating {
+                    window: window.id,
+                    floating: match verb {
+                        "setfloating" => Some(true),
+                        "settiled" => Some(false),
+                        _ => None,
+                    },
+                })
+            })
             .unwrap_or_else(|| Outcome::Unsupported(format!("no window matches {rest:?}"))),
         "tagwindow" => classic_tag(rest, snapshot),
         "dpms" => parse_dpms(rest, snapshot),
@@ -357,7 +365,15 @@ fn parse_lua(rest: &str, snapshot: &Snapshot) -> Outcome {
             Some(command) => Outcome::Run(Action::ExecShell(command)),
             None => Outcome::Unknown("hl.dsp.exec_cmd with no command".to_string()),
         },
-        "window.float" => lua_window(body, snapshot, |window| Action::ConfirmFloating(window.id)),
+        "window.float" => lua_window(body, snapshot, |window| Action::SetFloating {
+            window: window.id,
+            floating: match lua_field(body, "action").as_deref() {
+                Some("on" | "set") => Some(true),
+                Some("off" | "unset") => Some(false),
+                _ => None,
+            },
+        }),
+        "layout" => Outcome::Run(Action::LayoutNoop),
         "window.pin" => lua_window(body, snapshot, |window| Action::SetPinned { window: window.id, pinned: None }),
         "window.resize" => lua_geometry(body, snapshot, true),
         "window.move" => lua_geometry(body, snapshot, false),
@@ -431,15 +447,53 @@ pub fn parse_eval(source: &str, snapshot: &Snapshot) -> Outcome {
         return Outcome::Unsupported("hl.device enable/disable is not supported by this input backend".to_string());
     }
     if source.starts_with("hl.workspace_rule(") {
-        return Outcome::Unsupported("chonkstep is floating-only and cannot apply a tiled workspace layout".to_string());
+        let workspace = lua_field(source, "workspace")
+            .and_then(|s| s.parse::<i32>().ok())
+            .and_then(workspace_index_from_hypr_id);
+        return match (workspace, lua_field(source, "layout")) {
+            (Some(workspace), Some(mode)) if workspace < 99 => layout_action(workspace, &mode),
+            _ => Outcome::Unsupported(
+                "workspace_rule requires a workspace from 1 to 99 and a layout".into(),
+            ),
+        };
     }
     Outcome::Unknown(format!("unknown eval expression {source:?}"))
 }
 
-/// Parse the one live `keyword` mutation chonkstep deliberately
-/// supports. The broad namespace remains a refusal; this exception is
-/// the exact fallback shipped by Omarchy's screensaver.
+fn layout_action(workspace: usize, mode: &str) -> Outcome {
+    if matches!(
+        mode.trim(),
+        "freeform" | "mosaic" | "flow" | "dwindle" | "scrolling"
+    ) {
+        Outcome::Run(Action::SetWorkspaceLayout {
+            workspace,
+            mode: mode.trim().into(),
+        })
+    } else {
+        Outcome::Unsupported(
+            "layout must be Freeform, Mosaic/dwindle or Flow/scrolling (lowercase)".into(),
+        )
+    }
+}
+
+/// Parse the supported workspace, monitor and diagnostic keyword mutations.
 pub fn parse_keyword(source: &str) -> Outcome {
+    if let Some(spec) = source.trim().strip_prefix("workspace ") {
+        if let Some((workspace, mode)) = spec.split_once(',') {
+            if let Some(index) = workspace
+                .trim()
+                .parse::<i32>()
+                .ok()
+                .and_then(workspace_index_from_hypr_id)
+                .filter(|&i| i < 99)
+            {
+                if let Some(mode) = mode.trim().strip_prefix("layout:") {
+                    return layout_action(index, mode);
+                }
+            }
+        }
+        return Outcome::Unsupported("workspace requires N, layout:MODE".into());
+    }
     let source = source.trim();
     if let Some(spec) = source.strip_prefix("monitor ") {
         if let Some((name, operation)) = spec.split_once(',') {

--- a/crates/chonk-hyprland-ipc/src/event.rs
+++ b/crates/chonk-hyprland-ipc/src/event.rs
@@ -206,6 +206,12 @@ impl Differ {
                     ),
                 ));
             }
+            if old.floating != window.floating {
+                events.push(Event::new(
+                    "changefloatingmode",
+                    format!("{},{}", address(window), u8::from(window.floating)),
+                ));
+            }
             if old.title != window.title {
                 events.push(Event::new("windowtitlev2", format!("{},{}", address(window), window.title)));
                 // Hyprland emits the v1 form too, and it carries the
@@ -326,6 +332,7 @@ mod tests {
     fn the_owned_diff_keeps_the_producers_snapshot_allocation() {
         let mut snapshot = Snapshot::default();
         snapshot.workspaces.push(Workspace {
+            layout: "freeform".into(),
             index: 0,
             monitor: "eDP-1".into(),
             monitor_id: 0,

--- a/crates/chonk-hyprland-ipc/src/server.rs
+++ b/crates/chonk-hyprland-ipc/src/server.rs
@@ -377,10 +377,10 @@ fn plain_clients(snapshot: &Snapshot) -> String {
 
 fn plain_client(window: &crate::state::Window) -> String {
     format!(
-        "Window {} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: 1\n\tpseudo: 0\n\tmonitor: {}\n\tclass: {}\n\ttitle: {}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: {}\n\txwayland: {}\n\tpinned: {}\n\tfullscreen: {}\n",
+        "Window {} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tpseudo: 0\n\tmonitor: {}\n\tclass: {}\n\ttitle: {}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: {}\n\txwayland: {}\n\tpinned: {}\n\tfullscreen: {}\n",
         window.address(), window.title, !window.hidden, window.hidden, window.x, window.y,
         window.width, window.height, window.workspace + 1, window.workspace + 1,
-        window.monitor, window.class, window.title, window.class, window.title, window.pid,
+        i32::from(window.floating), window.monitor, window.class, window.title, window.class, window.title, window.pid,
         window.xwayland, window.pinned, i32::from(window.fullscreen),
     )
 }

--- a/crates/chonk-hyprland-ipc/src/state.rs
+++ b/crates/chonk-hyprland-ipc/src/state.rs
@@ -23,19 +23,11 @@
 //! [`Workspace::hypr_id`] and [`workspace_index_from_hypr_id`], and
 //! nowhere else.
 //!
-//! **chonkstep has no tiling, so every window floats.** `wm-core` is a
-//! floating window manager; there is no flag recording "floating"
-//! because there is no alternative to it. The JSON therefore reports
-//! `floating: true` for every window, which is not a stub — it is the
-//! truth, and it is why the tiling dispatchers in [`crate::dispatch`]
-//! refuse rather than pretend.
-//!
-//! **A window's monitor is geometric, not stored.** `Client::monitor`
-//! in `wm-core` is an unset slotmap key; multi-monitor policy resolves a
-//! window's output from its frame centre against the backend's monitor
-//! list. The caller must do that resolution when filling in
-//! [`Window::monitor`], because reading the field would report every
-//! window on monitor zero.
+//! Floating membership and workspace style are projected from WindowManager.
+//! Managed windows report `floating: false`; workspace `tiledLayout` uses the
+//! compatible names dwindle/scrolling. Freeform reports freeform. Output
+//! ownership comes from core affinity for managed Flow windows, whose virtual
+//! geometry can extend beyond every physical output.
 
 use serde::Serialize;
 
@@ -105,6 +97,7 @@ const FALLBACK_REFRESH_HZ: f64 = 60.0;
 /// One workspace.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Workspace {
+    pub layout: String,
     /// The **0-based** chonkstep index. Converted on the way out.
     pub index: usize,
     /// Name of the monitor this workspace is on.
@@ -158,6 +151,7 @@ pub fn workspace_index_from_hypr_id(id: i32) -> Option<usize> {
 /// One managed window.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Window {
+    pub floating: bool,
     /// chonkstep's opaque `ClientId::as_u64()`. Rendered as Hyprland's
     /// hex `address`.
     pub id: u64,
@@ -368,6 +362,8 @@ pub struct MonitorJson {
 
 #[derive(Debug, Serialize)]
 pub struct WorkspaceJson {
+    #[serde(rename = "tiledLayout")]
+    pub tiled_layout: String,
     pub id: i32,
     pub name: String,
     pub monitor: String,
@@ -392,8 +388,7 @@ pub struct ClientJson {
     /// `[w, h]`, indexed as `.size[0]` / `.size[1]`.
     pub size: [i32; 2],
     pub workspace: WorkspaceRef,
-    /// Always true: chonkstep is a floating window manager and has no
-    /// other state for a window to be in. See the module doc.
+    /// True when this window is outside managed layout.
     pub floating: bool,
     pub pseudo: bool,
     pub monitor: i32,
@@ -497,6 +492,7 @@ impl Snapshot {
             monitor_id: workspace.monitor_id,
             windows: workspace.windows,
             hasfullscreen: workspace.has_fullscreen,
+            tiled_layout: workspace.layout.clone(),
             lastwindow: last.map(Window::address).unwrap_or_else(|| "0x0".to_string()),
             lastwindowtitle: last.map(|window| window.title.clone()).unwrap_or_default(),
             ispersistent: false,
@@ -520,7 +516,7 @@ impl Snapshot {
                 id: workspace.map_or(1, Workspace::hypr_id),
                 name: workspace.map_or_else(|| "1".to_string(), Workspace::hypr_name),
             },
-            floating: true,
+            floating: window.floating,
             pseudo: false,
             monitor: window.monitor,
             class: window.class.clone(),

--- a/crates/chonk-hyprland-ipc/tests/protocol.rs
+++ b/crates/chonk-hyprland-ipc/tests/protocol.rs
@@ -46,11 +46,19 @@ fn monitor(id: i32, name: &str, focused: bool, active_workspace: usize) -> Monit
 }
 
 fn workspace(index: usize, windows: u32) -> Workspace {
-    Workspace { index, monitor: "eDP-1".to_string(), monitor_id: 0, windows, has_fullscreen: false }
+    Workspace {
+        layout: "freeform".into(),
+        index,
+        monitor: "eDP-1".to_string(),
+        monitor_id: 0,
+        windows,
+        has_fullscreen: false,
+    }
 }
 
 fn window(id: u64, title: &str, class: &str, workspace: usize) -> Window {
     Window {
+        floating: true,
         id,
         title: title.to_string(),
         class: class.to_string(),
@@ -228,7 +236,6 @@ fn an_ok_answer_always_comes_with_an_action() {
         "workspace 100",
         "workspace 0",
         "workspace -1",
-        "togglesplit",
         "killactive",
         "movetoworkspace 4",
         "focuswindow class:^(foot)$",
@@ -408,13 +415,9 @@ fn live_diagnostic_commands_have_truthful_wire_shapes() {
 /// and each must produce an error a caller can branch on rather than
 /// an `ok` it will believe.
 #[test]
-fn tiling_dispatchers_fail_cleanly_and_never_act() {
+fn unsupported_group_and_special_workspace_dispatchers_fail_cleanly() {
     let snapshot = desktop();
     for verb in [
-        "layoutmsg orientationtop",
-        "togglesplit",
-        "swapwindow l",
-        "pseudo",
         "togglegroup",
         "togglespecialworkspace magic",
         "workspaceopt allfloat",
@@ -431,8 +434,8 @@ fn tiling_dispatchers_fail_cleanly_and_never_act() {
 /// the right path.
 #[test]
 fn refusals_explain_themselves() {
-    let (response, _) = answer_payload(b"/dispatch togglesplit", &desktop());
-    assert!(response.contains("float"), "got {response:?}");
+    let (response, _) = answer_payload(b"/dispatch togglegroup", &desktop());
+    assert!(response.contains("groups"), "got {response:?}");
 }
 
 /// Omarchy sends the Lua form first and the classic form on failure.
@@ -522,6 +525,8 @@ fn fullscreen_arguments_map() {
     let (_, actions) = answer_payload(b"/dispatch fullscreen", &snapshot);
     assert_eq!(actions, vec![Action::Fullscreen(Fullscreen::Toggle)]);
     let (_, actions) = answer_payload(b"/dispatch fullscreen 1", &snapshot);
+    assert_eq!(actions, vec![Action::ToggleMaximize]);
+    let (_, actions) = answer_payload(b"/dispatch fullscreen 2", &snapshot);
     assert_eq!(actions, vec![Action::Fullscreen(Fullscreen::On)]);
 }
 
@@ -1023,4 +1028,58 @@ fn cursor_visibility_does_not_turn_keyword_into_a_general_config_backdoor() {
     let (response, actions) = answer_payload(b"eval hl.config({ cursor = { invisible = maybe } })", &desktop());
     assert!(response.contains("requires true or false"), "got {response:?}");
     assert!(actions.is_empty());
+}
+
+#[test]
+fn spatial_aliases_toggles_and_inapplicable_messages_have_deliberate_answers() {
+    let (_, actions) = answer_payload(b"/dispatch settiled", &desktop());
+    assert!(matches!(
+        actions.as_slice(),
+        [Action::SetFloating {
+            floating: Some(false),
+            ..
+        }]
+    ));
+    let snapshot = desktop();
+    for command in [
+        "/dispatch layoutmsg togglesplit",
+        "/dispatch togglesplit",
+        "/dispatch pseudo",
+        "/dispatch hl.dsp.layout(\"togglesplit\")",
+    ] {
+        let (response, actions) = answer_payload(command.as_bytes(), &snapshot);
+        assert_eq!(response, "ok");
+        assert_eq!(actions, vec![Action::LayoutNoop]);
+    }
+    for (command, mode) in [
+        ("/keyword workspace 1, layout:scrolling", "scrolling"),
+        (
+            "/eval hl.workspace_rule({ workspace = \"1\", layout = \"dwindle\" })",
+            "dwindle",
+        ),
+    ] {
+        let (response, actions) = answer_payload(command.as_bytes(), &snapshot);
+        assert_eq!(response, "ok");
+        assert_eq!(
+            actions,
+            vec![Action::SetWorkspaceLayout {
+                workspace: 0,
+                mode: mode.into()
+            }]
+        );
+    }
+}
+
+#[test]
+fn membership_events_and_workspace_json_report_the_authoritative_layout() {
+    let mut snapshot = desktop();
+    let mut differ = chonk_hyprland_ipc::event::Differ::new();
+    differ.diff(&snapshot);
+    snapshot.windows[0].floating = false;
+    snapshot.workspaces[0].layout = "scrolling".into();
+    let events = differ.diff(&snapshot);
+    assert!(events.iter().any(|e| e.name() == "changefloatingmode"));
+    let (reply, _) = answer_payload(b"j/activeworkspace", &snapshot);
+    let workspace: serde_json::Value = serde_json::from_str(&reply).unwrap();
+    assert_eq!(workspace["tiledLayout"], "scrolling");
 }

--- a/crates/chonk-shell/Cargo.toml
+++ b/crates/chonk-shell/Cargo.toml
@@ -47,7 +47,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 # desktop asks a user to edit.
 toml = "0.9"
 tracing = "0.1"
+tempfile = "3"
 
 [dev-dependencies]
 wm-core = { path = "../wm-core", features = ["test-support"] }
-tempfile = "3"

--- a/crates/chonk-shell/src/overview.rs
+++ b/crates/chonk-shell/src/overview.rs
@@ -24,6 +24,7 @@ pub struct OverviewItem<B: Backend> {
     pub title: String,
     pub preview: Option<DecorationBuffer>,
     pub miniaturized: bool,
+    pub managed: bool,
 }
 
 /// What a panel-local point lands on — the shell resolves clicks and
@@ -161,7 +162,12 @@ impl<B: Backend> OverviewPanel<B> {
         self.drag_limit = Size::new(tile * 3, tile * 2);
         let layout = if self.live {
             let sizes: Vec<_> = self.items.iter().map(|item| item.geometry.size).collect();
-            ov::live::layout(primary.size, tile, &sizes, workspace.1)
+            let mut layout = ov::live::layout(primary.size, tile, &sizes, workspace.1);
+            if self.items.iter().any(|i| i.managed) {
+                let sources: Vec<_> = self.items.iter().map(|i| i.geometry).collect();
+                ov::live::preserve_arrangement(&mut layout, &sources);
+            }
+            layout
         } else {
             ov::layout(
                 primary.size,

--- a/crates/chonk-shell/src/session_layout.rs
+++ b/crates/chonk-shell/src/session_layout.rs
@@ -46,9 +46,11 @@
 //! when every pending record is matched or expired.
 
 use std::path::{Path, PathBuf};
+use std::io::{Read, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::time::{Duration, Instant};
 
-use wm_core::MonitorInfo;
+use wm_core::{LayoutMode, MonitorInfo};
 use wm_theme_api::{Point, Rect, Size};
 
 use crate::apps::{match_window_class, AppEntry};
@@ -65,10 +67,17 @@ pub const DEBOUNCE: Duration = Duration::from_secs(2);
 /// claim whatever same-class window the user opens next week.
 pub const RESTORE_GRACE: Duration = Duration::from_secs(30);
 
+// Restore is a bounded startup operation, including damaged files. These are
+// generous file/record limits, not user-facing window-management settings.
+const MAX_SESSION_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_RECORD_BYTES: usize = 64 * 1024;
+const MAX_RECORDS: usize = 4096;
+
 /// One remembered window: everything restore needs to relaunch its
 /// application and re-place its window, and nothing more.
 #[derive(Clone, Debug, PartialEq)]
 pub struct WindowRecord {
+    pub spatial: Option<SpatialRecord>,
     /// The window's `WM_CLASS` class / Wayland app id — the matching
     /// key at restore time.
     pub class: String,
@@ -93,6 +102,20 @@ pub struct WindowRecord {
     pub maximized: bool,
     pub shaded: bool,
     pub miniaturized: bool,
+}
+
+/// Optional layout metadata. Invalid metadata leaves the base record usable.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct SpatialRecord {
+    pub floating: bool,
+    pub order: usize,
+    pub flow_width: u32,
+    pub mosaic_weight: [u32; 2],
+    pub output: Option<String>,
+    pub focused: bool,
+    pub floating_geometry: Option<[i64; 4]>,
+    pub floating_monitor: Option<String>,
 }
 
 /// How one record's application should be brought back. Split from the
@@ -130,8 +153,20 @@ pub(crate) fn relative_to_monitor(monitor: Option<&MonitorInfo>, mut geometry: R
 /// preserving its within-monitor offset. Eight-field legacy records
 /// have no identity and remain absolute exactly as before.
 pub(crate) fn restored_geometry(monitors: &[MonitorInfo], record: &WindowRecord) -> Rect {
-    let Some(identity) = record.monitor_identity.as_deref() else {
-        return record.geometry;
+    restored_on_monitor(
+        monitors,
+        record.geometry,
+        record.monitor_identity.as_deref(),
+    )
+}
+
+pub(crate) fn restored_on_monitor(
+    monitors: &[MonitorInfo],
+    mut geometry: Rect,
+    identity: Option<&str>,
+) -> Rect {
+    let Some(identity) = identity else {
+        return geometry;
     };
     let target = monitors
         .iter()
@@ -139,9 +174,8 @@ pub(crate) fn restored_geometry(monitors: &[MonitorInfo], record: &WindowRecord)
         .or_else(|| monitors.iter().find(|monitor| monitor.primary))
         .or_else(|| monitors.first());
     let Some(target) = target else {
-        return record.geometry;
+        return geometry;
     };
-    let mut geometry = record.geometry;
     geometry.pos.x = geometry.pos.x.saturating_add(target.geometry.pos.x);
     geometry.pos.y = geometry.pos.y.saturating_add(target.geometry.pos.y);
     geometry
@@ -151,6 +185,9 @@ pub(crate) fn restored_geometry(monitors: &[MonitorInfo], record: &WindowRecord)
 /// and when the file was last worth writing.
 pub struct SessionLayout {
     path: Option<PathBuf>,
+    modes: Vec<LayoutMode>,
+    restored_modes: Option<Vec<LayoutMode>>,
+    persisted_modes: Vec<LayoutMode>,
     /// Records loaded at startup and not yet claimed by a mapped
     /// window. Non-empty exactly while a restore is in progress.
     pending: Vec<WindowRecord>,
@@ -179,6 +216,9 @@ impl SessionLayout {
     pub fn start_at(path: Option<PathBuf>, restore: bool, apps: &[AppEntry], now: Instant) -> (Self, Vec<RelaunchPlan>) {
         let mut layout = Self {
             path,
+            modes: Vec::new(),
+            restored_modes: None,
+            persisted_modes: Vec::new(),
             pending: Vec::new(),
             restore_deadline: None,
             last_snapshot: Vec::new(),
@@ -188,12 +228,15 @@ impl SessionLayout {
         if !restore {
             return (layout, Vec::new());
         }
-        let Some(text) = layout.path.as_deref().and_then(|p| std::fs::read_to_string(p).ok()) else {
+        let Some(text) = layout.path.as_deref().and_then(|p| read_session(p).ok()) else {
             // First opt-in session, or nothing recorded yet: nothing
             // to restore is the normal case, not a problem.
             return (layout, Vec::new());
         };
         let records = parse(&text);
+        layout.modes = parse_modes(&text);
+        layout.persisted_modes = layout.modes.clone();
+        layout.restored_modes = Some(layout.modes.clone());
         let plans: Vec<RelaunchPlan> = records.iter().filter_map(|record| relaunch_plan(record, apps)).collect();
         tracing::info!(
             windows = records.len(),
@@ -206,13 +249,29 @@ impl SessionLayout {
         (layout, plans)
     }
 
-    /// One housekeeping pass: expire an overdue restore, then decide
-    /// whether the snapshot has settled into something worth writing —
-    /// and write it if so. Call once per shell tick with a snapshot of
-    /// the live client set.
+    /// Whether application windows are still claiming saved records.
+    pub fn restoring(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    pub fn take_restored_modes(&mut self) -> Option<Vec<LayoutMode>> {
+        self.restored_modes.take()
+    }
+
+    pub fn note_modes(&mut self, modes: impl Iterator<Item = LayoutMode> + Clone, now: Instant) {
+        if self.modes.iter().copied().eq(modes.clone()) {
+            return;
+        }
+        self.modes.clear();
+        self.modes.extend(modes);
+        self.settled_at = now;
+    }
+
+    /// Check whether the snapshot has settled into something worth writing,
+    /// and write it if so. Called by the existing shell tick.
     pub fn service(&mut self, snapshot: Vec<WindowRecord>, now: Instant) {
         if self.note(snapshot, now) {
-            self.write_out();
+            self.write_out(now);
         }
     }
 
@@ -229,7 +288,7 @@ impl SessionLayout {
     /// identical `Vec<WindowRecord>` first.
     pub fn service_current(&mut self, now: Instant) {
         if self.ready(now) {
-            self.write_out();
+            self.write_out(now);
         }
     }
 
@@ -274,13 +333,16 @@ impl SessionLayout {
         if !self.pending.is_empty() {
             return false;
         }
-        if self.persisted.as_ref() == Some(&self.last_snapshot) {
+        if self.persisted.as_ref() == Some(&self.last_snapshot)
+            && self.persisted_modes == self.modes
+        {
             return false;
         }
         if now < self.settled_at + DEBOUNCE {
             return false;
         }
         self.persisted = Some(self.last_snapshot.clone());
+        self.persisted_modes.clone_from(&self.modes);
         true
     }
 
@@ -303,25 +365,40 @@ impl SessionLayout {
     /// restore is still pending, for the same partial-layout reason
     /// `note` suppresses ordinary persists then.
     pub fn flush(&mut self) {
-        if !self.pending.is_empty() || self.persisted.as_ref() == Some(&self.last_snapshot) {
+        if !self.pending.is_empty()
+            || (self.persisted.as_ref() == Some(&self.last_snapshot)
+                && self.persisted_modes == self.modes)
+        {
             return;
         }
         self.persisted = Some(self.last_snapshot.clone());
-        self.write_out();
+        self.persisted_modes.clone_from(&self.modes);
+        self.write_out(Instant::now());
     }
 
     /// The I/O half of a persist: serialize `last_snapshot` and write
     /// it atomically. A failure warns and leaves the previous file
     /// intact — the next settled change tries again.
-    fn write_out(&mut self) {
+    fn write_out(&mut self, now: Instant) {
         let Some(path) = self.path.as_deref() else {
             return;
         };
-        if let Err(error) = write_atomic(path, &serialize(&self.last_snapshot)) {
+        let mut text = serialize(&self.last_snapshot);
+        for (index, mode) in self.modes.iter().enumerate() {
+            text.push_str(&format!(
+                "@workspace\t{index}\t{}\n",
+                mode.compatible_name()
+            ));
+        }
+        if let Err(error) = write_atomic(path, &text) {
             tracing::warn!(?error, path = %path.display(), "could not persist the session layout");
             // Disk truth is now unknown; clearing the cache makes the
             // next settle retry rather than believe this write landed.
             self.persisted = None;
+            // A read-only/full filesystem must not turn every compositor
+            // wakeup into another write attempt and warning. Reuse the settle
+            // interval for a bounded retry without requiring another edit.
+            self.settled_at = now;
         }
     }
 }
@@ -350,11 +427,14 @@ fn relaunch_plan(record: &WindowRecord, apps: &[AppEntry]) -> Option<RelaunchPla
 /// theme/wallpaper/dock files beside it:
 ///
 /// ```text
-/// class \t app-or-'-' \t x \t y \t w \t h \t workspace \t flags-or-'-' \t monitor-or-'-'
+/// @window \t class-json \t app-json \t x \t y \t w \t h \t workspace \t flags-or-'-' \t monitor-json \t spatial-json
 /// ```
 ///
-/// Tabs because a class is free text that may contain spaces; flags
-/// are a comma-joined subset of `maximized,shaded,miniaturized`. A
+/// Text fields are JSON strings (or null), so client-controlled newlines and
+/// tabs cannot create records or workspace directives. The explicit prefix
+/// distinguishes escaped fields from legacy literal classes, including quotes
+/// and backslashes. Eight-, nine- and ten-column legacy records remain readable.
+/// Flags are a comma-joined subset of `maximized,shaded,miniaturized`. A
 /// line that does not parse is skipped with a warning — one corrupted
 /// record must cost that record, never the layout.
 fn serialize(records: &[WindowRecord]) -> String {
@@ -372,64 +452,141 @@ fn serialize(records: &[WindowRecord]) -> String {
         }
         let flags = if flags.is_empty() { "-".to_string() } else { flags.join(",") };
         text.push_str(&format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
-            record.class,
-            record.app.as_deref().unwrap_or("-"),
+            "@window\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            serde_json::to_string(&record.class).expect("string serialization is infallible"),
+            serde_json::to_string(&record.app).expect("string serialization is infallible"),
             record.geometry.pos.x,
             record.geometry.pos.y,
             record.geometry.size.w,
             record.geometry.size.h,
             record.workspace,
             flags,
-            record.monitor_identity.as_deref().unwrap_or("-"),
+            serde_json::to_string(&record.monitor_identity).expect("string serialization is infallible"),
+            record
+                .spatial
+                .as_ref()
+                .and_then(|s| serde_json::to_string(s).ok())
+                .unwrap_or_else(|| "-".into()),
         ));
     }
     text
 }
 
 fn parse(text: &str) -> Vec<WindowRecord> {
-    text.lines().filter(|line| !line.trim().is_empty()).filter_map(parse_line).collect()
+    let mut rejected = 0usize;
+    let records = text.lines()
+        .filter(|line| !line.trim().is_empty()
+            && !(line.starts_with("@workspace\t") && line.split('\t').count() == 3))
+        .filter_map(|line| {
+            let record = parse_line(line);
+            rejected += usize::from(record.is_none());
+            record
+        })
+        .take(MAX_RECORDS)
+        .collect();
+    if rejected != 0 {
+        tracing::warn!(rejected, "skipping unparsable session-layout records");
+    }
+    records
+}
+
+fn parse_modes(text: &str) -> Vec<LayoutMode> {
+    let mut modes = Vec::new();
+    for line in text.lines().filter_map(|s| s.strip_prefix("@workspace\t")) {
+        if line.split('\t').count() != 2 { continue; }
+        let Some((index, mode)) = line.split_once('\t') else {
+            continue;
+        };
+        let Some(index) = index
+            .parse::<usize>()
+            .ok()
+            .filter(|&i| i < wm_core::MAX_WORKSPACES)
+        else {
+            continue;
+        };
+        modes.resize((index + 1).max(modes.len()), LayoutMode::Freeform);
+        modes[index] = LayoutMode::parse(mode).unwrap_or_default();
+    }
+    modes
 }
 
 fn parse_line(line: &str) -> Option<WindowRecord> {
-    let fields: Vec<&str> = line.split('\t').collect();
-    let parsed = (|| -> Option<WindowRecord> {
-        let [class, app, x, y, w, h, workspace, flags, monitor @ ..] = fields.as_slice() else {
-            return None;
-        };
-        if monitor.len() > 1 {
-            return None;
-        }
-        if class.is_empty() {
-            return None;
-        }
-        // Zero-sized windows can't have been recorded by `snapshot`;
-        // a record claiming one is corruption, and restoring it would
-        // hand the client a degenerate configure.
-        let (w, h) = (w.parse::<u32>().ok()?, h.parse::<u32>().ok()?);
-        if w == 0 || h == 0 {
-            return None;
-        }
-        Some(WindowRecord {
-            class: class.to_string(),
-            app: (*app != "-" && !app.is_empty()).then(|| app.to_string()),
-            geometry: Rect {
-                pos: Point::new(x.parse().ok()?, y.parse().ok()?),
-                size: Size::new(w, h),
-            },
-            monitor_identity: monitor
-                .first()
-                .and_then(|identity| (!identity.is_empty() && *identity != "-").then(|| (*identity).to_string())),
-            workspace: workspace.parse().ok()?,
-            maximized: flags.split(',').any(|f| f == "maximized"),
-            shaded: flags.split(',').any(|f| f == "shaded"),
-            miniaturized: flags.split(',').any(|f| f == "miniaturized"),
-        })
-    })();
-    if parsed.is_none() {
-        tracing::warn!(line, "skipping an unparsable session-layout record");
+    if line.len() > MAX_RECORD_BYTES {
+        return None;
     }
-    parsed
+    // Eleven fields identify the versioned format unambiguously. A legacy
+    // client named @window still has at most ten fields.
+    let escaped = line.starts_with("@window\t") && line.split('\t').count() == 11;
+    let line = if escaped {
+        line.strip_prefix("@window\t")?
+    } else {
+        line
+    };
+    let fields: Vec<&str> = line.splitn(11, '\t').collect();
+    let [class, app, x, y, w, h, workspace, flags, monitor @ ..] = fields.as_slice() else {
+        return None;
+    };
+    if monitor.len() > 2 {
+        return None;
+    }
+    let class: String = if escaped {
+        serde_json::from_str(class).ok()?
+    } else {
+        class.to_string()
+    };
+    if class.is_empty() {
+        return None;
+    }
+    // Zero-sized windows can't have been recorded by `snapshot`;
+    // a record claiming one is corruption, and restoring it would
+    // hand the client a degenerate configure.
+    let (w, h) = (w.parse::<u32>().ok()?, h.parse::<u32>().ok()?);
+    if w == 0 || h == 0 {
+        return None;
+    }
+    let spatial = monitor
+        .get(1)
+        .and_then(|text| serde_json::from_str::<SpatialRecord>(text).ok())
+        .filter(|s| {
+            s.order < 10000
+                && s.flow_width <= 65536
+                && s.mosaic_weight.iter().all(|&v| v <= 1_000_000)
+                && s.floating_geometry.is_none_or(|r| {
+                    r[0].unsigned_abs() <= i32::MAX as u64
+                        && r[1].unsigned_abs() <= i32::MAX as u64
+                        && r[2] > 0
+                        && r[2] <= 65536
+                        && r[3] > 0
+                        && r[3] <= 65536
+                })
+        });
+    Some(WindowRecord {
+        spatial,
+        class,
+        app: if escaped {
+            serde_json::from_str(app).ok()?
+        } else {
+            (*app != "-" && !app.is_empty()).then(|| app.to_string())
+        },
+        geometry: Rect {
+            pos: Point::new(x.parse().ok()?, y.parse().ok()?),
+            size: Size::new(w, h),
+        },
+        monitor_identity: if escaped {
+            serde_json::from_str(monitor.first()?).ok()?
+        } else {
+            monitor.first().and_then(|identity| {
+                (!identity.is_empty() && *identity != "-").then(|| (*identity).to_string())
+            })
+        },
+        workspace: workspace
+            .parse::<usize>()
+            .ok()
+            .filter(|&w| w < wm_core::MAX_WORKSPACES)?,
+        maximized: flags.split(',').any(|f| f == "maximized"),
+        shaded: flags.split(',').any(|f| f == "shaded"),
+        miniaturized: flags.split(',').any(|f| f == "miniaturized"),
+    })
 }
 
 /// Temp-and-rename write: the layout file is always either the old
@@ -437,12 +594,31 @@ fn parse_line(line: &str) -> Option<WindowRecord> {
 /// whole point of persisting is surviving a crash, and a crash is
 /// allowed to happen mid-write.
 fn write_atomic(path: &Path, text: &str) -> std::io::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+    let parent = path.parent().filter(|p| !p.as_os_str().is_empty()).unwrap_or(Path::new("."));
+    std::fs::create_dir_all(parent)?;
+    // A unique, owner-only file avoids following a stale .tmp symlink and
+    // cleans up on failure. Rename gives process-crash atomicity; no claim
+    // of power-loss durability (which would require file/directory fsync).
+    let mut tmp = tempfile::Builder::new().prefix(".session-layout-").tempfile_in(parent)?;
+    tmp.write_all(text.as_bytes())?;
+    tmp.persist(path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+fn read_session(path: &Path) -> std::io::Result<String> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NONBLOCK | libc::O_NOFOLLOW)
+        .open(path)?;
+    if !file.metadata()?.is_file() {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "session state is not a regular file"));
     }
-    let tmp = path.with_extension("tmp");
-    std::fs::write(&tmp, text)?;
-    std::fs::rename(&tmp, path)
+    let mut text = String::new();
+    file.take(MAX_SESSION_BYTES + 1).read_to_string(&mut text)?;
+    if text.len() as u64 > MAX_SESSION_BYTES {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "session state exceeds size limit"));
+    }
+    Ok(text)
 }
 
 #[cfg(test)]
@@ -452,6 +628,7 @@ mod tests {
 
     fn record(class: &str, x: i32) -> WindowRecord {
         WindowRecord {
+            spatial: None,
             class: class.to_string(),
             app: None,
             geometry: Rect { pos: Point::new(x, 40), size: Size::new(500, 400) },
@@ -482,6 +659,7 @@ mod tests {
     fn the_wire_format_round_trips_every_field() {
         let records = vec![
             WindowRecord {
+                spatial: None,
                 class: "Navigator".to_string(),
                 app: Some("org.mozilla.firefox".to_string()),
                 geometry: Rect { pos: Point::new(-40, 12), size: Size::new(1280, 900) },
@@ -494,6 +672,81 @@ mod tests {
             record("foot", 100),
         ];
         assert_eq!(parse(&serialize(&records)), records);
+    }
+
+    #[test]
+    fn client_text_cannot_inject_records_or_workspace_modes() {
+        let mut item = record("bad\n@workspace\t0\tflow\nfoot\t-\t0\t0\t500\t400\t0\t-", 100);
+        item.app = Some("app\twith\nseparators\\and\"quotes".into());
+        item.monitor_identity = Some("monitor\r\nwith\ttabs".into());
+        let encoded = serialize(std::slice::from_ref(&item));
+        assert_eq!(encoded.lines().count(), 1);
+        assert!(parse_modes(&encoded).is_empty());
+        assert_eq!(parse(&encoded), vec![item]);
+        for class in ["@workspace", "@window", "-", "\"quoted\"", "日本語", "literal\\n"] {
+            let item = record(class, 10);
+            assert_eq!(parse(&serialize(std::slice::from_ref(&item))), vec![item]);
+        }
+        for class in ["@window", "@workspace", "\"quoted\"", "literal\\n"] {
+            let legacy = format!("{class}\t-\t10\t40\t500\t400\t0\t-\n");
+            assert_eq!(parse(&legacy), vec![record(class, 10)]);
+            assert!(parse_modes(&legacy).is_empty());
+        }
+    }
+
+    #[test]
+    fn corrupt_restore_files_have_bounded_reads_records_and_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session");
+        let file = std::fs::File::create(&path).unwrap();
+        file.set_len(MAX_SESSION_BYTES + 1).unwrap();
+        assert!(read_session(&path).is_err());
+        assert!(read_session(dir.path()).is_err());
+        let (layout, plans) = SessionLayout::start_at(Some(path), true, &[], Instant::now());
+        assert!(!layout.restoring());
+        assert!(plans.is_empty());
+        let one = serialize(&[record("foot", 10)]);
+        assert_eq!(parse(&one.repeat(MAX_RECORDS + 5)).len(), MAX_RECORDS);
+        assert!(parse_line(&"x".repeat(MAX_RECORD_BYTES + 1)).is_none());
+    }
+
+    #[test]
+    fn atomic_write_is_private_and_does_not_follow_a_stale_temporary_symlink() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("session");
+        let other = dir.path().join("unrelated");
+        std::fs::write(&other, "keep").unwrap();
+        symlink(&other, path.with_extension("tmp")).unwrap();
+        write_atomic(&path, "new session").unwrap();
+        assert_eq!(std::fs::read_to_string(&other).unwrap(), "keep");
+        assert_eq!(read_session(&path).unwrap(), "new session");
+        assert_eq!(std::fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        assert!(read_session(&path.with_extension("tmp")).is_err());
+        // Failed replacement removes its unique temporary file and leaves the
+        // previous state alone, including when the destination is a directory.
+        let entries = std::fs::read_dir(dir.path()).unwrap().count();
+        assert!(write_atomic(dir.path(), "cannot replace a directory").is_err());
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), entries);
+        assert_eq!(read_session(&path).unwrap(), "new session");
+    }
+
+    #[test]
+    fn failed_persistence_retries_without_a_new_user_action() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().join("blocked");
+        std::fs::write(&parent, "not a directory").unwrap();
+        let path = parent.join("session");
+        let start = Instant::now();
+        let (mut store, _) = SessionLayout::start_at(Some(path.clone()), false, &[], start);
+        store.service(vec![record("foot", 10)], start);
+        store.service_current(start + DEBOUNCE);
+        assert!(store.persisted.is_none());
+        std::fs::remove_file(parent).unwrap();
+        store.service_current(start + DEBOUNCE + DEBOUNCE / 2);
+        assert!(!path.exists(), "a failed write retries at the settle interval");
+        store.service_current(start + DEBOUNCE * 2);
+        assert_eq!(parse(&read_session(&path).unwrap()), vec![record("foot", 10)]);
     }
 
     #[test]
@@ -732,5 +985,69 @@ mod tests {
         layout.flush();
         assert_eq!(parse(&std::fs::read_to_string(&path).unwrap()), vec![record("foot", 700)]);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+    #[test]
+    fn spatial_metadata_roundtrips_order_membership_width_and_empty_workspace_modes() {
+        let mut item = record("foot", 80);
+        item.spatial = Some(SpatialRecord {
+            floating: true,
+            order: 3,
+            flow_width: 780,
+            mosaic_weight: [600, 400],
+            output: Some("Dell monitor serial".into()),
+            focused: true,
+            floating_geometry: Some([40, 50, 700, 600]),
+            floating_monitor: Some("Other monitor serial".into()),
+        });
+        let text = format!(
+            "{}@workspace\t0\tdwindle\n@workspace\t4\tscrolling\n",
+            serialize(&[item.clone()])
+        );
+        assert_eq!(parse(&text), vec![item]);
+        assert_eq!(
+            parse_modes(&text),
+            vec![
+                LayoutMode::Mosaic,
+                LayoutMode::Freeform,
+                LayoutMode::Freeform,
+                LayoutMode::Freeform,
+                LayoutMode::Flow
+            ]
+        );
+        let now = Instant::now();
+        let mut store = fresh(now);
+        store.note_modes([LayoutMode::Flow].into_iter(), now);
+        assert!(!store.note(Vec::new(), now));
+        assert!(store.ready(now + DEBOUNCE));
+        assert!(!store.ready(now + DEBOUNCE * 2));
+    }
+
+    #[test]
+    fn malformed_spatial_metadata_never_discards_a_usable_legacy_window() {
+        let base = "foot\t-\t80\t40\t500\t400\t0\t-";
+        assert_eq!(parse(base), vec![record("foot", 80)]);
+        assert!(parse_modes(base).is_empty());
+        for metadata in [
+            "-",
+            "not json",
+            r#"{"order":10000}"#,
+            r#"{"flow_width":-1}"#,
+            r#"{"flow_width":4294967295}"#,
+            r#"{"mosaic_weight":[4000000000,0]}"#,
+            r#"{"floating_geometry":[-9223372036854775808,0,10,10]}"#,
+            r#"{"floating_geometry":[0,0,0,10]}"#,
+        ] {
+            assert_eq!(
+                parse(&format!("{base}\t-\t{metadata}")),
+                vec![record("foot", 80)],
+                "{metadata}"
+            );
+        }
+        assert_eq!(
+            parse_modes(
+                "@workspace\t0\tunknown\n@workspace\t9999999999999\tflow\n@workspace\t-1\tmosaic"
+            ),
+            vec![LayoutMode::Freeform]
+        );
     }
 }

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -30,7 +30,10 @@ use crate::desktop::{
 use crate::dockapp::Farewell;
 use crate::launchdock::{LaunchDock, LaunchDockAction};
 use crate::overview::{OverviewHit, OverviewItem, OverviewRelease};
-use crate::session_layout::{relative_to_monitor, restored_geometry, RelaunchPlan, SessionLayout, WindowRecord};
+use crate::session_layout::{
+    relative_to_monitor, restored_geometry, restored_on_monitor, RelaunchPlan, SessionLayout,
+    SpatialRecord, WindowRecord,
+};
 use crate::startup::SessionState;
 use crate::widgets::DockInput;
 use crate::{spawn, theme_select, wallpaper};
@@ -842,11 +845,41 @@ fn running_matches_clients<B: Backend>(wm: &WindowManager<B>, running: &[(String
 fn layout_snapshot<B: Backend>(wm: &WindowManager<B>, apps: &[AppEntry]) -> Vec<WindowRecord> {
     wm.iter_clients()
         .filter(|(_, client)| !client.class.is_empty())
-        .map(|(_, client)| {
-            let maximized = client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
-            let root_geometry = if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry };
+        .map(|(id, client)| {
+            let maximized = client
+                .flags
+                .intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
+            let root_geometry = client.placement.freeform.unwrap_or_else(|| {
+                if maximized {
+                    client.restore_geometry.unwrap_or(client.geometry)
+                } else {
+                    client.geometry
+                }
+            });
             let (geometry, monitor_identity) = layout_record_geometry(wm, root_geometry);
+            let floating = floating_record_geometry(wm, id);
             WindowRecord {
+                spatial: Some(SpatialRecord {
+                    floating: client.placement.floating,
+                    order: wm
+                        .layout_order(client.workspace)
+                        .iter()
+                        .position(|&i| i == id)
+                        .unwrap_or(0),
+                    flow_width: client.placement.flow_width,
+                    mosaic_weight: client.placement.mosaic_weight,
+                    output: client.placement.output.clone(),
+                    focused: wm.focused_client() == Some(id),
+                    floating_geometry: floating.map(|(rect, _)| {
+                        [
+                            rect.pos.x as i64,
+                            rect.pos.y as i64,
+                            rect.size.w as i64,
+                            rect.size.h as i64,
+                        ]
+                    }),
+                    floating_monitor: floating.and_then(|(_, monitor)| monitor.map(str::to_owned)),
+                }),
                 class: client.class.clone(),
                 app: apps::match_window_class(apps, &client.class).map(|index| apps[index].id.clone()),
                 geometry,
@@ -871,6 +904,15 @@ fn layout_record_geometry<B: Backend>(wm: &WindowManager<B>, geometry: Rect) -> 
     relative_to_monitor(monitor, geometry)
 }
 
+fn floating_record_geometry<B: Backend>(
+    wm: &WindowManager<B>,
+    id: ClientId,
+) -> Option<(Rect, Option<&str>)> {
+    let client = wm.client(id)?;
+    (client.placement.floating && client.placement.freeform.is_some())
+        .then(|| layout_record_geometry(wm, client.geometry))
+}
+
 /// Whether `records` still describe the live client set exactly,
 /// without cloning a class name or consulting the application index.
 ///
@@ -887,13 +929,47 @@ fn layout_record_geometry<B: Backend>(wm: &WindowManager<B>, geometry: Rect) -> 
 fn layout_matches_clients<B: Backend>(wm: &WindowManager<B>, records: &[WindowRecord]) -> bool {
     let mut clients = wm.iter_clients().filter(|(_, client)| !client.class.is_empty());
     for record in records {
-        let Some((_, client)) = clients.next() else {
+        let Some((id, client)) = clients.next() else {
             return false;
         };
-        let maximized = client.flags.intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
-        let root_geometry = if maximized { client.restore_geometry.unwrap_or(client.geometry) } else { client.geometry };
+        let maximized = client
+            .flags
+            .intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
+        let root_geometry = client.placement.freeform.unwrap_or_else(|| {
+            if maximized {
+                client.restore_geometry.unwrap_or(client.geometry)
+            } else {
+                client.geometry
+            }
+        });
         let (geometry, monitor_identity) = layout_record_geometry(wm, root_geometry);
-        if record.class != client.class
+        let placement = &client.placement;
+        let floating = floating_record_geometry(wm, id);
+        let spatial_matches = record.spatial.as_ref().is_some_and(|r| {
+            r.floating == placement.floating
+                && r.flow_width == placement.flow_width
+                && r.mosaic_weight == placement.mosaic_weight
+                && r.output == placement.output
+                && r.focused == (wm.focused_client() == Some(id))
+                && r.order
+                    == wm
+                        .layout_order(client.workspace)
+                        .iter()
+                        .position(|&i| i == id)
+                        .unwrap_or(0)
+                && r.floating_geometry
+                    == floating.map(|(rect, _)| {
+                        [
+                            rect.pos.x as i64,
+                            rect.pos.y as i64,
+                            rect.size.w as i64,
+                            rect.size.h as i64,
+                        ]
+                    })
+                && r.floating_monitor.as_deref() == floating.and_then(|(_, monitor)| monitor)
+        });
+        if !spatial_matches
+            || record.class != client.class
             || record.geometry != geometry
             || record.monitor_identity.as_deref() != monitor_identity
             || record.workspace != client.workspace
@@ -1005,6 +1081,7 @@ pub struct Shell<B: Backend + PopupHost<PopupId = B::ShellId>> {
     /// records while a restore is matching mapped windows against
     /// them. See `crate::session_layout` for all the rules.
     layout: SessionLayout,
+    restore_focus: Option<ClientId>,
     /// Owned identities last reconciled into the launcher strip's
     /// running lamps. Most ticks prove these still match through
     /// borrowed comparisons and avoid allocating/cloning them again.
@@ -1284,6 +1361,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             overview_close_pressed: None,
             grabbed: to_grab,
             layout,
+            restore_focus: None,
             running_clients: Vec::new(),
             terminals,
             state: state.clone(),
@@ -1863,6 +1941,36 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             // same `WindowMenuRequested` notification a titlebar
             // right-click raises, so the menu, its items and its
             // dispatch are shared verbatim.
+            Action::Layout(mode) => wm.set_workspace_layout(wm.current_workspace(), *mode),
+            Action::ToggleLayout => wm.toggle_workspace_layout(),
+            Action::Floating(value) => {
+                if let Some(id) = wm.focused_client() {
+                    if let Some(value) = value {
+                        wm.set_floating(id, *value);
+                    } else {
+                        wm.toggle_floating(id);
+                    }
+                }
+            }
+            Action::Move(direction) => {
+                if let Some(id) = wm.focused_client() {
+                    wm.move_layout_window(id, *direction);
+                }
+            }
+            Action::Resize(delta) => {
+                if let Some(id) = wm.focused_client() {
+                    if !wm.resize_layout_window(id, *delta) {
+                        if let Some(c) = wm.client(id) {
+                            let size = wm_core::Size::new(
+                                (c.geometry.size.w as i64 + delta.x as i64).clamp(1, 65536) as u32,
+                                (c.geometry.size.h as i64 + delta.y as i64).clamp(1, 65536) as u32,
+                            );
+                            wm.resize_client_content(id, size);
+                        }
+                    }
+                }
+            }
+            Action::LayoutNoop => {}
             Action::WindowMenu => wm.request_window_menu_for_focused(),
             Action::RootMenu => {
                 let at = wm
@@ -2055,7 +2163,15 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                 c.geometry.pos.y - c.layout.client_offset.y), c.layout.frame_size)
         } else { c.geometry }).collect();
         let sizes: Vec<_> = sources.iter().map(|r| r.size).collect();
-        let layout = live::layout(geometry.size, tile, &sizes, wm.workspace_count().max(workspace + 1));
+        let mut layout = live::layout(
+            geometry.size,
+            tile,
+            &sizes,
+            wm.workspace_count().max(workspace + 1),
+        );
+        if wm.workspace_layout(workspace) != wm_core::LayoutMode::Freeform {
+            live::preserve_arrangement(&mut layout, &sources);
+        }
         let (mut fonts, mut swash) = (self.fonts.system(), self.fonts.swash());
         let label_h = (tile / 2).max(16);
         let mut label = |text: &str, width| live::label(&self.theme, &mut fonts, &mut swash, text, width, label_h);
@@ -2170,6 +2286,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             })
             .map(|(id, client)| OverviewItem {
                 client: id,
+                managed: wm.is_layout_managed(id),
                 window: client.window,
                 title: client.title.clone(),
                 preview: None,
@@ -2902,6 +3019,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                     | Notification::Deminiaturized(_)
                     | Notification::Removed(_)
                     | Notification::Mapped(_)
+                    | Notification::LayoutChanged(_)
             );
         match notification {
             Notification::Miniaturized(id, preview) => {
@@ -2932,6 +3050,8 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                         workspace = record.workspace,
                         "restoring a recorded window"
                     );
+                    let initially_floating = wm.client(id).is_some_and(|c| c.placement.floating);
+                    wm.set_floating(id, true);
                     wm.set_client_content_geometry(id, geometry);
                     if record.workspace != wm.current_workspace() {
                         wm.move_client_to_workspace(id, record.workspace);
@@ -2949,7 +3069,51 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
                     if record.miniaturized {
                         wm.miniaturize(id);
                     }
+                    if let Some(spatial) = record.spatial {
+                        if let Some(r) = spatial.floating_geometry {
+                            let rect = restored_on_monitor(
+                                wm.monitors_ref(),
+                                Rect::new(
+                                    Point::new(r[0] as i32, r[1] as i32),
+                                    wm_core::Size::new(r[2] as u32, r[3] as u32),
+                                ),
+                                spatial.floating_monitor.as_deref(),
+                            );
+                            wm.set_client_content_geometry(id, rect);
+                        }
+                        let freeform = (wm.workspace_layout(record.workspace)
+                            != wm_core::LayoutMode::Freeform)
+                            .then_some(geometry);
+                        wm.restore_window_placement(
+                            id,
+                            wm_core::WindowPlacement {
+                                freeform,
+                                floating: spatial.floating,
+                                output: spatial.output,
+                                flow_width: spatial.flow_width,
+                                mosaic_weight: spatial.mosaic_weight,
+                            },
+                            spatial.order,
+                        );
+                        if spatial.focused {
+                            self.restore_focus = Some(id);
+                        }
+                    } else {
+                        wm.set_floating(id, initially_floating);
+                    }
                 }
+            }
+            Notification::LayoutChanged(mode) => {
+                let (mut fonts, mut swash) = (self.fonts.system(), self.fonts.swash());
+                let label = wm_theme::overview::live::label(
+                    &self.theme,
+                    &mut fonts,
+                    &mut swash,
+                    mode.name(),
+                    (180.0 * self.state.scale) as u32,
+                    (36.0 * self.state.scale) as u32,
+                );
+                wm.backend_mut().show_layout_mode(mode, label);
             }
             Notification::CycleUpdated => {
                 if let Some((candidates, selected)) = wm.cycle_state() {
@@ -3014,6 +3178,20 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
     /// this routine therefore does not approximate state change with an
     /// action-shaped boolean.
     pub fn tick(&mut self, wm: &mut WindowManager<B>) {
+        if let Some(modes) = self.layout.take_restored_modes() {
+            for (workspace, mode) in modes.into_iter().enumerate() {
+                wm.set_workspace_layout(workspace, mode);
+            }
+        }
+        if !self.layout.restoring() {
+            if let Some(id) = self.restore_focus.take() {
+                if let Some(c) = wm.client(id) {
+                    let (workspace, window) = (c.workspace, c.window);
+                    wm.switch_workspace(workspace);
+                    wm.dispatch(BackendEvent::ActivateRequested(window));
+                }
+            }
+        }
         let now = Instant::now();
         // The appearance-request file, consumed the way the binaries
         // consume reload/restart markers: one cached path at a bounded
@@ -3122,6 +3300,10 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
         // debounce without allocating, cloning every class, or
         // rescanning the application index. A real change still builds
         // the full owned snapshot once and resets the settle clock.
+        self.layout.note_modes(
+            (0..wm.workspace_count()).map(|i| wm.workspace_layout(i)),
+            now,
+        );
         if layout_matches_clients(wm, self.layout.current()) {
             self.layout.service_current(now);
         } else {

--- a/crates/chonk-testkit/Cargo.toml
+++ b/crates/chonk-testkit/Cargo.toml
@@ -16,6 +16,7 @@ wm-theme-api = { path = "../wm-theme-api" }
 # PNG decode for screenshot assertions — already in the workspace's
 # dependency graph (winit pulls it), so this adds no new code to vet.
 png = "0.17"
+tempfile = "3"
 # The instrument-panel e2e drives a real dockapp against the nested
 # shell: `src/bin/chonk-panel-probe.rs` is that dockapp, speaking the
 # wire protocol directly through the reference crate rather than
@@ -68,7 +69,6 @@ rustix = { version = "1.1", features = ["event", "fs", "net"] }
 
 [dev-dependencies]
 chonk-test-support = { path = "../chonk-test-support" }
-tempfile = "3"
 # Observe the real browser's DOM via its private loopback DevTools socket.
 # Input still enters through the compositor; no CDP input injection. Reuse a
 # maintained WebSocket client instead of implementing framing in the harness.

--- a/crates/chonk-testkit/src/bin/chonk-fullscreen-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-fullscreen-probe.rs
@@ -77,6 +77,9 @@ use std::io::Write;
 use std::os::fd::AsFd;
 use std::time::Duration;
 
+#[path = "chonk-fullscreen-probe/popup.rs"]
+mod popup;
+
 use wayland_client::protocol::{
     wl_buffer::WlBuffer, wl_callback, wl_compositor::WlCompositor, wl_keyboard, wl_registry,
     wl_seat, wl_shm, wl_shm_pool, wl_surface::WlSurface,
@@ -159,6 +162,9 @@ struct Probe {
     text_input_manager: Option<ZwpTextInputManagerV3>,
     input_method_manager: Option<ZwpInputMethodManagerV2>,
     surface: Option<WlSurface>,
+    xdg_surface: Option<XdgSurface>,
+    popup: Option<popup::Popup>,
+    large_minimum: bool,
     toplevel: Option<XdgToplevel>,
     /// The size the compositor's latest configure asked for, or
     /// [`WINDOWED`] until one names a size.
@@ -362,6 +368,10 @@ impl Dispatch<XdgToplevel, ()> for Probe {
                         Ok(xdg_toplevel::State::Activated) => names.push("activated"),
                         Ok(xdg_toplevel::State::Resizing) => names.push("resizing"),
                         Ok(xdg_toplevel::State::Suspended) => names.push("suspended"),
+                        Ok(xdg_toplevel::State::TiledLeft) => names.push("tiled-left"),
+                        Ok(xdg_toplevel::State::TiledRight) => names.push("tiled-right"),
+                        Ok(xdg_toplevel::State::TiledTop) => names.push("tiled-top"),
+                        Ok(xdg_toplevel::State::TiledBottom) => names.push("tiled-bottom"),
                         _ => names.push("other"),
                     }
                 }
@@ -413,6 +423,13 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for Probe {
             match key {
                 KEY_F => probe.control(Want::Fullscreen, qh),
                 KEY_M => probe.control(Want::Maximized, qh),
+                25 => popup::toggle(probe, qh), // P: a native application menu.
+                49 => {
+                    probe.large_minimum = !probe.large_minimum;
+                    let (w, h) = if probe.large_minimum { (2000, 1200) } else { (0, 0) };
+                    probe.toplevel.as_ref().unwrap().set_min_size(w, h);
+                    probe.surface.as_ref().unwrap().commit();
+                }
                 _ => {}
             }
         }
@@ -602,6 +619,7 @@ fn main() {
 
     let surface = compositor.create_surface(&qh, ());
     let xdg_surface = wm_base.get_xdg_surface(&surface, &qh, ());
+    probe.xdg_surface = Some(xdg_surface.clone());
     let toplevel = xdg_surface.get_toplevel(&qh, ());
     toplevel.set_title(title.clone());
     toplevel.set_app_id(app_id);
@@ -642,6 +660,10 @@ fn main() {
                 &qh,
                 (),
             );
+            // The buffer owns its pool storage. Retaining the protocol pool
+            // and every replaced buffer leaks one frame per configure during
+            // repeated layout/focus operations.
+            pool.destroy();
             surface.attach(Some(&buffer), 0, 0);
             surface.damage(0, 0, width.max(1), height.max(1));
             if frame_driven && !probe.frame_pending {
@@ -649,7 +671,9 @@ fn main() {
                 probe.frame_pending = true;
             }
             surface.commit();
-            attached_buffer = Some(buffer);
+            if let Some(previous) = attached_buffer.replace(buffer) {
+                previous.destroy();
+            }
             if inhibit_idle && probe.idle_inhibitor.is_none() {
                 let manager = probe
                     .idle_inhibit_manager
@@ -668,7 +692,6 @@ fn main() {
                 probe.idle_notification = Some(notifier.get_idle_notification(250, seat, &qh, ()));
                 say("idle inhibition armed");
             }
-            pool.destroy();
             attached = probe.size;
             probe.dirty = false;
         }

--- a/crates/chonk-testkit/src/bin/chonk-fullscreen-probe/popup.rs
+++ b/crates/chonk-testkit/src/bin/chonk-fullscreen-probe/popup.rs
@@ -1,0 +1,140 @@
+//! A colored native application menu for pixel/input tests in every layout.
+use super::*;
+use wayland_client::protocol::wl_pointer::{self, WlPointer};
+use wayland_protocols::xdg::shell::client::{xdg_popup, xdg_positioner};
+
+pub(super) struct Events;
+
+pub(super) struct Popup {
+    role: xdg_popup::XdgPopup,
+    xdg: XdgSurface,
+    surface: WlSurface,
+    buffer: Option<WlBuffer>,
+    pointer: WlPointer,
+    entered: bool,
+}
+
+impl Drop for Popup {
+    fn drop(&mut self) {
+        self.role.destroy();
+        self.xdg.destroy();
+        self.surface.destroy();
+        self.pointer.release();
+        if let Some(buffer) = self.buffer.take() {
+            buffer.destroy();
+        }
+    }
+}
+
+pub(super) fn toggle(probe: &mut Probe, qh: &QueueHandle<Probe>) {
+    if probe.popup.take().is_some() {
+        say("popup closed");
+        return;
+    }
+    let base = probe.wm_base.as_ref().unwrap();
+    let positioner = base.create_positioner(qh, ());
+    positioner.set_size(120, 80);
+    positioner.set_anchor_rect(50, 50, 1, 1);
+    positioner.set_anchor(xdg_positioner::Anchor::TopLeft);
+    positioner.set_gravity(xdg_positioner::Gravity::BottomRight);
+    let surface = probe.compositor.as_ref().unwrap().create_surface(qh, ());
+    let xdg = base.get_xdg_surface(&surface, qh, Events);
+    let role = xdg.get_popup(probe.xdg_surface.as_ref(), &positioner, qh, Events);
+    positioner.destroy();
+    let pointer = probe.seat.as_ref().unwrap().get_pointer(qh, Events);
+    surface.commit();
+    probe.popup = Some(Popup {
+        role,
+        xdg,
+        surface,
+        buffer: None,
+        pointer,
+        entered: false,
+    });
+}
+
+impl Dispatch<XdgSurface, Events> for Probe {
+    fn event(
+        probe: &mut Self,
+        xdg: &XdgSurface,
+        event: xdg_surface::Event,
+        _: &Events,
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let xdg_surface::Event::Configure { serial } = event {
+            xdg.ack_configure(serial);
+            let Some(popup) = probe.popup.as_mut().filter(|p| p.xdg == *xdg) else {
+                return;
+            };
+            let mut file = tempfile::tempfile().unwrap();
+            let pixels = [0xff19e63au32.to_ne_bytes(); 120 * 80];
+            file.write_all(pixels.as_flattened()).unwrap();
+            let pool = probe
+                .shm
+                .as_ref()
+                .unwrap()
+                .create_pool(file.as_fd(), 120 * 80 * 4, qh, ());
+            let buffer = pool.create_buffer(0, 120, 80, 120 * 4, wl_shm::Format::Argb8888, qh, ());
+            pool.destroy();
+            popup.surface.attach(Some(&buffer), 0, 0);
+            popup.surface.damage(0, 0, 120, 80);
+            popup.surface.commit();
+            if let Some(previous) = popup.buffer.replace(buffer) {
+                previous.destroy();
+            }
+            say("popup painted");
+        }
+    }
+}
+
+impl Dispatch<xdg_popup::XdgPopup, Events> for Probe {
+    fn event(
+        probe: &mut Self,
+        _: &xdg_popup::XdgPopup,
+        event: xdg_popup::Event,
+        _: &Events,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let xdg_popup::Event::PopupDone = event {
+            probe.popup = None;
+        }
+    }
+}
+
+impl Dispatch<xdg_positioner::XdgPositioner, ()> for Probe {
+    fn event(
+        _: &mut Self,
+        _: &xdg_positioner::XdgPositioner,
+        _: xdg_positioner::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<WlPointer, Events> for Probe {
+    fn event(
+        probe: &mut Self,
+        _: &WlPointer,
+        event: wl_pointer::Event,
+        _: &Events,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        let Some(popup) = probe.popup.as_mut() else {
+            return;
+        };
+        match event {
+            wl_pointer::Event::Enter { surface, .. } => popup.entered = surface == popup.surface,
+            wl_pointer::Event::Leave { .. } => popup.entered = false,
+            wl_pointer::Event::Button {
+                state: WEnum::Value(wl_pointer::ButtonState::Pressed),
+                ..
+            } if popup.entered => say("popup clicked"),
+            _ => {}
+        }
+    }
+}

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1096,6 +1096,7 @@ pub struct ThemeInfo {
 /// One `windows` reply: the compositor's whole idea of the screen.
 #[derive(Clone, Debug, Default)]
 pub struct World {
+    pub spatial: SpatialInfo,
     pub scale: f32,
     pub current_workspace: usize,
     pub workspace_count: usize,
@@ -1111,6 +1112,22 @@ pub struct World {
     pub gesture: Option<GestureInfo>,
     pub logical_focus: Option<u64>,
     pub seat_focus: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SpatialInfo {
+    pub mode: String,
+    pub moving: bool,
+    pub calculations: u64,
+    pub calculation_us: u128,
+    pub managed: usize,
+    pub changes: u64,
+    pub setups: u64,
+    pub setup_us: u128,
+    pub configures: u64,
+    pub builds: u64,
+    pub build_us: u128,
+    pub culled: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -1772,6 +1789,21 @@ impl Door {
                 if let Some(shell) = parse_shell_line(&line) {
                     world.shells.push(shell);
                 }
+            } else if line.starts_with("spatial ") {
+                world.spatial = SpatialInfo {
+                    mode: field::<String>(&line, "mode=").unwrap_or_default(),
+                    moving: field(&line, "moving=").unwrap_or_default(),
+                    calculations: field(&line, "calculations=").unwrap_or_default(),
+                    calculation_us: field(&line, "calculation_us=").unwrap_or_default(),
+                    managed: field(&line, "managed=").unwrap_or_default(),
+                    changes: field(&line, "changes=").unwrap_or_default(),
+                    setups: field(&line, "setups=").unwrap_or_default(),
+                    setup_us: field(&line, "setup_us=").unwrap_or_default(),
+                    configures: field(&line, "configures=").unwrap_or_default(),
+                    builds: field(&line, "builds=").unwrap_or_default(),
+                    build_us: field(&line, "build_us=").unwrap_or_default(),
+                    culled: field(&line, "culled=").unwrap_or_default(),
+                };
             } else if line.starts_with("workspaces ") {
                 world.current_workspace = field(&line, "current=").unwrap_or_default();
                 world.workspace_count = field(&line, "count=").unwrap_or_default();

--- a/crates/chonk-testkit/tests/hyprland_ipc.rs
+++ b/crates/chonk-testkit/tests/hyprland_ipc.rs
@@ -609,7 +609,7 @@ fn foreign_toplevel_mapping_returns_the_same_live_ipc_address() {
     // unchanged client commit sends nothing, while a real WM mutation
     // closes one new atomic foreign-toplevel batch with `done`.
     let done_before = session.client_log("chonk-toplevel-mapping-probe").matches("**foreign done**").count();
-    assert_eq!(request(&dir, "dispatch fullscreen 1").trim(), "ok");
+    assert_eq!(request(&dir, "dispatch fullscreen 0").trim(), "ok");
     poll_until(EVENT, "the foreign-toplevel handle to publish fullscreen", || {
         (session.client_log("chonk-toplevel-mapping-probe").matches("**foreign done**").count() > done_before)
             .then_some(())
@@ -910,17 +910,17 @@ fn native_control_mutations_reach_the_hyprland_event_stream() {
 /// and is seen to change nothing.
 #[test]
 #[ignore = "needs a Wayland session to nest inside"]
-fn tiling_verbs_fail_honestly_against_a_live_desktop() {
+fn inapplicable_layout_messages_are_quiet_and_unavailable_groups_still_fail() {
     let session = boot("hypr-ipc-refusal");
     let dir = socket_dir(&session);
 
     let before = json(&dir, "j/activeworkspace");
 
-    for verb in ["togglesplit", "layoutmsg orientationtop", "pseudo", "togglegroup"] {
-        let response = request(&dir, &format!("/dispatch {verb}"));
-        assert_ne!(response.trim(), "ok", "{verb} must not claim success");
-        assert!(response.starts_with("Invalid dispatcher"), "{verb} must fail the way Hyprland does, got {response:?}");
+    for verb in ["togglesplit", "layoutmsg orientationtop", "pseudo"] {
+        assert_eq!(request(&dir, &format!("/dispatch {verb}")).trim(), "ok");
     }
+    let response = request(&dir, "/dispatch togglegroup");
+    assert!(response.starts_with("Invalid dispatcher"), "groups remain unsupported: {response:?}");
 
     assert_eq!(json(&dir, "j/activeworkspace"), before, "a refused verb changes nothing");
 

--- a/crates/chonk-testkit/tests/session_restore.rs
+++ b/crates/chonk-testkit/tests/session_restore.rs
@@ -27,14 +27,28 @@ fn foot_record(x: i32, y: i32, w: u32, h: u32) -> String {
 /// if the file exists and holds one.
 fn recorded_foot(session: &Session) -> Option<(i32, i32, u32, u32)> {
     let text = std::fs::read_to_string(session.state_file("session")).ok()?;
-    let line = text.lines().find(|line| line.starts_with("foot\t"))?;
-    let fields: Vec<&str> = line.split('\t').collect();
-    Some((
-        fields.get(2)?.parse().ok()?,
-        fields.get(3)?.parse().ok()?,
-        fields.get(4)?.parse().ok()?,
-        fields.get(5)?.parse().ok()?,
-    ))
+    text.lines().find_map(|line| {
+        let (line, escaped) = line
+            .strip_prefix("@window\t")
+            .map_or((line, false), |record| (record, true));
+        let mut fields = line.split('\t');
+        let class = fields.next()?;
+        let is_foot = if escaped {
+            serde_json::from_str::<String>(class).ok()? == "foot"
+        } else {
+            class == "foot"
+        };
+        if !is_foot {
+            return None;
+        }
+        fields.next()?; // application identity
+        Some((
+            fields.next()?.parse().ok()?,
+            fields.next()?.parse().ok()?,
+            fields.next()?.parse().ok()?,
+            fields.next()?.parse().ok()?,
+        ))
+    })
 }
 
 /// Pillar 1, the recording half: arrange a window, and the arrangement

--- a/crates/chonk-testkit/tests/spatial_layout.rs
+++ b/crates/chonk-testkit/tests/spatial_layout.rs
@@ -1,0 +1,688 @@
+//! Product path: real native clients, compatibility IPC, input, live scenes,
+//! persistence, and the existing finger-following Overview/workspace routes.
+use chonk_testkit::{keys, poll_until, profile_binary, Session, SessionOptions, World};
+use std::io::{Read, Write};
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+fn request(session: &Session, message: &str) -> String {
+    let path = std::path::PathBuf::from(std::env::var("XDG_RUNTIME_DIR").unwrap())
+        .join("hypr")
+        .join(session.hyprland_signature().unwrap())
+        .join(".socket.sock");
+    let mut socket = UnixStream::connect(path).unwrap();
+    socket
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .unwrap();
+    socket.write_all(message.as_bytes()).unwrap();
+    let mut reply = String::new();
+    socket.read_to_string(&mut reply).unwrap();
+    reply
+}
+
+fn dispatch(session: &mut Session, command: &str) {
+    assert_eq!(
+        request(session, &format!("/dispatch {command}")),
+        "ok",
+        "{command}"
+    );
+    session.door().barrier().unwrap();
+}
+
+fn settled(session: &mut Session) -> World {
+    poll_until(
+        Duration::from_secs(5),
+        "layout and gesture settlement",
+        || {
+            let world = session.world().ok()?;
+            (!world.spatial.moving && world.gesture.is_none()).then_some(world)
+        },
+    )
+    .unwrap()
+}
+
+fn mode(session: &mut Session, mode: &str) -> World {
+    dispatch(session, &format!("layout {mode}"));
+    settled(session)
+}
+
+fn geometry(world: &World, class: &str) -> (i32, i32, u32, u32) {
+    let w = world.window_matching(class).unwrap();
+    (w.x, w.y, w.w, w.h)
+}
+
+fn overview_roundtrip(session: &mut Session) {
+    session.door().chord(keys::LEFTMETA, keys::UP).unwrap();
+    assert!(session.world().unwrap().overview.is_some());
+    session.screenshot("overview").unwrap();
+    session.door().tap_key(keys::ESC).unwrap();
+    assert!(session.world().unwrap().overview.is_none());
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn application_popups_are_visible_and_receive_input_in_every_style() {
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(
+            &format!("spatial-popup-{scale}"),
+            SessionOptions {
+                scale: Some(scale),
+                config_extra: "show_dock = false\n".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+        session
+            .launch(probe.to_str().unwrap(), &["Popup", "spatial-popup"])
+            .unwrap();
+        session.wait_for_window("spatial-popup").unwrap();
+        for style in ["freeform", "mosaic", "flow"] {
+            let world = mode(&mut session, style);
+            poll_until(
+                Duration::from_secs(5),
+                "client-visible layout state",
+                || {
+                    let log = session.client_log("chonk-fullscreen-probe");
+                    let configure = log
+                        .lines()
+                        .rev()
+                        .find(|line| line.starts_with("configure "))?;
+                    (configure.contains("tiled-left") == (style != "freeform")).then_some(())
+                },
+            )
+            .unwrap();
+            let window = world.window_matching("spatial-popup").unwrap();
+            // This probe deliberately keeps 1x buffers even on scaled outputs;
+            // its surface-local popup anchor follows that declared scale.
+            let x = window.x + 80;
+            let y = window.y + 80;
+            session.door().tap_key(25).unwrap();
+            poll_until(Duration::from_secs(5), "native popup map", || {
+                (session.door().hit(x, y).ok()?.as_str() == "popup").then_some(())
+            })
+            .unwrap();
+            let shot = session.screenshot(&format!("{style}-popup")).unwrap();
+            let [r, g, b, _] = shot.pixel(x as u32, y as u32);
+            assert!(
+                g > 190 && r < 70 && b < 100,
+                "{style} scale {scale}: popup input exists but pixels are {r},{g},{b}"
+            );
+            let before = session
+                .client_log("chonk-fullscreen-probe")
+                .matches("popup clicked")
+                .count();
+            session.door().click(x as f64, y as f64).unwrap();
+            poll_until(Duration::from_secs(5), "native popup click", || {
+                (session
+                    .client_log("chonk-fullscreen-probe")
+                    .matches("popup clicked")
+                    .count()
+                    > before)
+                    .then_some(())
+            })
+            .unwrap();
+            session.door().tap_key(25).unwrap();
+            session.door().barrier().unwrap();
+        }
+        let focus = session.world().unwrap().logical_focus;
+        session.door().tap_key(49).unwrap(); // N: commit an infeasible minimum.
+        poll_until(
+            Duration::from_secs(5),
+            "late constraints suspend participation",
+            || (session.world().ok()?.spatial.managed == 0).then_some(()),
+        )
+        .unwrap();
+        session.door().tap_key(49).unwrap();
+        poll_until(
+            Duration::from_secs(5),
+            "cleared constraints restore participation",
+            || (session.world().ok()?.spatial.managed == 1).then_some(()),
+        )
+        .unwrap();
+        assert_eq!(settled(&mut session).logical_focus, focus);
+    }
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn three_views_preserve_intent_with_native_input_and_live_surfaces_at_each_scale() {
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(
+            &format!("spatial-acceptance-{scale}"),
+            SessionOptions {
+                scale: Some(scale),
+                config_extra: "show_dock = false\n".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        for class in ["spatial-a", "spatial-b", "spatial-c"] {
+            let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+            session
+                .launch(probe.to_str().unwrap(), &[class, class])
+                .unwrap();
+            session.wait_for_window(class).unwrap();
+        }
+        for (class, x, y, w, h) in [
+            ("spatial-a", 80, 100, 700, 450),
+            ("spatial-b", 900, 120, 550, 600),
+            ("spatial-c", 600, 700, 600, 450),
+        ] {
+            dispatch(
+                &mut session,
+                &format!("resizewindowpixel exact {w} {h},class:{class}"),
+            );
+            dispatch(
+                &mut session,
+                &format!("movewindowpixel exact {x} {y},class:{class}"),
+            );
+        }
+        let original = session.world().unwrap();
+        let focus = original.logical_focus;
+        assert_eq!(original.spatial.mode, "Freeform");
+        overview_roundtrip(&mut session);
+        session.door().chord(keys::LEFTMETA, 38).unwrap(); // Super+L
+        let following = session.world().unwrap();
+        assert_eq!(following.spatial.mode, "Mosaic");
+        assert!(
+            following.spatial.moving,
+            "mode switch uses a live transition"
+        );
+        session.screenshot("mosaic-in-motion").unwrap();
+        let tiled = settled(&mut session);
+        assert_eq!(tiled.logical_focus, focus);
+        assert_eq!(tiled.spatial.managed, 3);
+        let windows: Vec<_> = tiled.frames.iter().filter(|f| f.mapped).collect();
+        for (i, a) in windows.iter().enumerate() {
+            for b in windows.iter().skip(i + 1) {
+                assert!(
+                    a.x + a.w as i32 <= b.x
+                        || b.x + b.w as i32 <= a.x
+                        || a.y + a.h as i32 <= b.y
+                        || b.y + b.h as i32 <= a.y
+                );
+            }
+        }
+        dispatch(&mut session, "focuswindow class:spatial-b");
+        session.door().chord(keys::LEFTMETA, 20).unwrap(); // Super+T
+        let floated = settled(&mut session);
+        assert_eq!(
+            geometry(&floated, "spatial-b"),
+            geometry(&original, "spatial-b")
+        );
+        dispatch(&mut session, "resizeactive 60 20");
+        dispatch(&mut session, "moveactive 80 30");
+        session.door().chord(keys::LEFTMETA, 20).unwrap();
+        let rejoined = settled(&mut session);
+        assert_eq!(
+            geometry(&rejoined, "spatial-b"),
+            geometry(&tiled, "spatial-b")
+        );
+        assert_eq!(rejoined.logical_focus, floated.logical_focus);
+        overview_roundtrip(&mut session);
+        session.door().chord(keys::LEFTMETA, 38).unwrap();
+        assert_eq!(settled(&mut session).spatial.mode, "Flow");
+        dispatch(&mut session, "movefocus r");
+        let flow = settled(&mut session);
+        let selected = flow.logical_focus;
+        dispatch(&mut session, "movefocus u");
+        assert_eq!(session.world().unwrap().logical_focus, selected);
+        dispatch(&mut session, "resizeactive 120 0");
+        assert_eq!(settled(&mut session).logical_focus, selected);
+        dispatch(&mut session, "movewindow l");
+        assert_eq!(settled(&mut session).logical_focus, selected);
+        dispatch(&mut session, "layoutmsg togglesplit");
+        overview_roundtrip(&mut session);
+        // Minimize/restore through ChonkStep's existing keyboard semantics.
+        session.door().key(keys::LEFTALT, true).unwrap();
+        session.door().key(keys::LEFTSHIFT, true).unwrap();
+        session.door().tap_key(50).unwrap(); // M
+        session.door().key(keys::LEFTSHIFT, false).unwrap();
+        session.door().key(keys::LEFTALT, false).unwrap();
+        assert_eq!(settled(&mut session).spatial.managed, 2);
+        dispatch(&mut session, "focuswindow class:spatial-c");
+        settled(&mut session);
+        mode(&mut session, "mosaic");
+        let restored = mode(&mut session, "freeform");
+        for class in ["spatial-a", "spatial-b", "spatial-c"] {
+            assert_eq!(geometry(&restored, class), geometry(&original, class));
+        }
+        mode(&mut session, "flow");
+        session.door().swipe_begin_at(3, 0).unwrap();
+        session.door().swipe_update_at(-120.0, 0.0, 200).unwrap();
+        assert_eq!(session.world().unwrap().current_workspace, 0);
+        session.door().swipe_end_at(false, 350).unwrap();
+        assert_eq!(settled(&mut session).current_workspace, 1);
+        dispatch(&mut session, "workspace 1");
+        assert_eq!(settled(&mut session).spatial.mode, "Flow");
+        let saved = poll_until(Duration::from_secs(6), "persisted workspace mode", || {
+            let text = std::fs::read_to_string(session.state_file("session")).ok()?;
+            text.contains("@workspace\t0\tscrolling").then_some(text)
+        })
+        .unwrap();
+        assert!(saved.contains("flow_width"));
+    }
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn reflow_stages_final_configures_once_and_has_no_animation_deadline_after_settlement() {
+    let mut session = Session::boot(
+        "spatial-live-configures",
+        SessionOptions {
+            config_extra: "show_dock = false\n".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let binary = profile_binary("chonk-input-probe").unwrap();
+    session
+        .launch(binary.to_str().unwrap(), &["1", "--interactive=resize"])
+        .unwrap();
+    session.wait_for_window("input-probe").unwrap();
+    session.door().barrier().unwrap();
+    let initial = session.world().unwrap();
+    dispatch(&mut session, "layout mosaic");
+    let moving = session.world().unwrap();
+    assert!(moving.spatial.moving);
+    let screenshot = session.screenshot("live-intermediate").unwrap();
+    assert!(screenshot.width > 0);
+    let final_state = settled(&mut session);
+    assert_eq!(final_state.logical_focus, initial.logical_focus);
+    assert!(
+        final_state.spatial.configures - initial.spatial.configures <= 2,
+        "one final resize, plus optional activation state"
+    );
+    let calculations = final_state.spatial.calculations;
+    session.door().frame_stats().unwrap();
+    // No synthetic frames or layout recalculation after settling, even with
+    // the caption visible. Its expiry is a single damage event.
+    std::thread::sleep(Duration::from_millis(120));
+    assert_eq!(session.door().frame_stats().unwrap().render_calls, 0);
+    assert_eq!(session.world().unwrap().spatial.calculations, calculations);
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn native_pointer_reorder_resize_cancel_and_modal_takeover_leave_no_transforms() {
+    let mut session = Session::boot(
+        "spatial-pointer",
+        SessionOptions {
+            config_extra: "show_dock = false\n".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let binary = profile_binary("chonk-fullscreen-probe").unwrap();
+    for class in ["pointer-a", "pointer-b", "pointer-c"] {
+        session
+            .launch(binary.to_str().unwrap(), &[class, class])
+            .unwrap();
+        session.wait_for_window(class).unwrap();
+    }
+    for style in ["mosaic", "flow"] {
+        let before = mode(&mut session, style);
+        let a = before.window_matching("pointer-a").unwrap();
+        dispatch(&mut session, "focuswindow class:pointer-a");
+        let before = settled(&mut session);
+        let source = before.frame_of(a.id).unwrap().clone();
+        let b = before.window_matching("pointer-b").unwrap();
+        let target = before.frame_of(b.id).unwrap();
+        let destination = (
+            (target.x + target.w as i32 / 2).clamp(15, before.output_w as i32 - 15) as f64,
+            (target.y + target.h as i32 / 2) as f64,
+        );
+        let grip = (
+            (source.x + source.w as i32 / 2) as f64,
+            (source.y + 8) as f64,
+        );
+        session.door().drag_to(grip, destination).unwrap();
+        session
+            .screenshot(&format!("{style}-drop-preview"))
+            .unwrap();
+        // The live drag is presentation only until release.
+        assert_eq!(
+            geometry(&session.world().unwrap(), "pointer-a"),
+            geometry(&before, "pointer-a")
+        );
+        session.door().tap_key(keys::ESC).unwrap();
+        session.door().button("left", false).unwrap();
+        session.door().barrier().unwrap();
+        assert_eq!(
+            geometry(&settled(&mut session), "pointer-a"),
+            geometry(&before, "pointer-a")
+        );
+        session.door().drag_to(grip, destination).unwrap();
+        session.door().button("left", false).unwrap();
+        session.door().barrier().unwrap();
+        assert_ne!(
+            geometry(&settled(&mut session), "pointer-a"),
+            geometry(&before, "pointer-a")
+        );
+        let initial = settled(&mut session);
+        let frame = initial.frame_of(a.id).unwrap();
+        let content = initial.window_matching("pointer-a").unwrap();
+        // Modifier resize uses the same shared-boundary path as native grips.
+        let corner = (
+            if frame.x > 5 {
+                (content.x + 20) as f64
+            } else {
+                (content.x + content.w as i32 - 20).min(initial.output_w as i32 - 20) as f64
+            },
+            (frame.y + frame.h as i32 / 2) as f64,
+        );
+        session.door().motion(corner.0, corner.1).unwrap();
+        session.door().barrier().unwrap();
+        session.door().key(keys::LEFTALT, true).unwrap();
+        session.door().button("right", true).unwrap();
+        session.door().barrier().unwrap();
+        session.door().motion(corner.0 - 70.0, corner.1).unwrap();
+        session.door().barrier().unwrap();
+        assert_ne!(
+            geometry(&session.world().unwrap(), "pointer-a"),
+            geometry(&initial, "pointer-a")
+        );
+        session.door().tap_key(keys::ESC).unwrap();
+        session.door().button("right", false).unwrap();
+        session.door().key(keys::LEFTALT, false).unwrap();
+        assert_eq!(
+            geometry(&settled(&mut session), "pointer-a"),
+            geometry(&initial, "pointer-a")
+        );
+    }
+    dispatch(&mut session, "layout mosaic");
+    dispatch(&mut session, "layout flow");
+    overview_roundtrip(&mut session);
+    assert!(!settled(&mut session).spatial.moving);
+    dispatch(&mut session, "layout freeform");
+    session.kill_clients();
+    poll_until(
+        Duration::from_secs(5),
+        "destroyed clients clear layout animations",
+        || {
+            let world = session.world().ok()?;
+            (world.windows.is_empty() && !world.spatial.moving).then_some(())
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn a_crashed_managed_desktop_restores_organization_and_original_freeform_geometry() {
+    let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+    let mut session = Session::boot(
+        "spatial-before-crash",
+        SessionOptions {
+            config_extra: "show_dock = false\n".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    for title in ["restore-a", "restore-b", "restore-c"] {
+        session
+            .launch(probe.to_str().unwrap(), &[title, "foot"])
+            .unwrap();
+        session.wait_for_window(title).unwrap();
+    }
+    for (title, x, y) in [
+        ("restore-a", 80, 100),
+        ("restore-b", 600, 120),
+        ("restore-c", 300, 380),
+    ] {
+        dispatch(
+            &mut session,
+            &format!("resizewindowpixel exact 430 280,title:{title}"),
+        );
+        dispatch(
+            &mut session,
+            &format!("movewindowpixel exact {x} {y},title:{title}"),
+        );
+    }
+    let mut originals: Vec<_> = session
+        .world()
+        .unwrap()
+        .windows
+        .iter()
+        .map(|w| (w.x, w.y, w.w, w.h))
+        .collect();
+    originals.sort();
+    mode(&mut session, "mosaic");
+    dispatch(&mut session, "focuswindow title:restore-a");
+    dispatch(&mut session, "resizeactive 80 0");
+    mode(&mut session, "flow");
+    dispatch(&mut session, "resizeactive -90 0");
+    dispatch(&mut session, "movewindow r");
+    dispatch(&mut session, "focuswindow title:restore-b");
+    dispatch(&mut session, "togglefloating");
+    dispatch(&mut session, "moveactive 40 20");
+    // An empty workspace's mode is part of the organization, too.
+    dispatch(&mut session, "workspace 3");
+    mode(&mut session, "mosaic");
+    dispatch(&mut session, "workspace 1");
+    settled(&mut session);
+    let saved = poll_until(
+        Duration::from_secs(8),
+        "complete spatial session persisted",
+        || {
+            let text = std::fs::read_to_string(session.state_file("session")).ok()?;
+            let records: Vec<_> = text
+                .lines()
+                .filter(|l| l.starts_with("foot\t") || l.starts_with("@window\t\"foot\"\t"))
+                .collect();
+            (records.len() == 3
+                && records.iter().any(|l| l.contains("\"floating\":true"))
+                && text.contains("@workspace\t2\tdwindle"))
+            .then_some(text)
+        },
+    )
+    .unwrap();
+    session.kill_compositor();
+    drop(session);
+    let config = format!("show_dock = false\nrestore_session = true\nterminal = [\"{}\", \"restored-foot\", \"foot\"]\n",probe.display());
+    let mut restored = Session::boot(
+        "spatial-after-crash",
+        SessionOptions {
+            config_extra: config,
+            state_files: vec![("session".into(), saved.clone())],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    poll_until(
+        Duration::from_secs(10),
+        "all three applications restored",
+        || {
+            let world = restored.world().ok()?;
+            (world.windows.len() == 3
+                && world.windows.iter().all(|w| w.mapped && w.w > 0)
+                && world.spatial.mode == "Flow"
+                && !world.spatial.moving)
+                .then_some(())
+        },
+    )
+    .unwrap();
+    let metadata = |text: &str| -> Vec<serde_json::Value> {
+        let mut records: Vec<_> = text
+            .lines()
+            .filter(|l| l.starts_with("foot\t") || l.starts_with("@window\t\"foot\"\t"))
+            .map(|l| {
+                let mut value: serde_json::Value = serde_json::from_str(
+                    l.split('\t')
+                        .nth(if l.starts_with("@window\t") { 10 } else { 9 })
+                        .unwrap(),
+                )
+                .unwrap();
+                value.as_object_mut().unwrap().remove("focused");
+                value
+            })
+            .collect();
+        records.sort_by_key(|v| v["order"].as_u64());
+        records
+    };
+    poll_until(
+        Duration::from_secs(8),
+        "restored organization written without drift",
+        || {
+            let text = std::fs::read_to_string(restored.state_file("session")).ok()?;
+            (metadata(&text) == metadata(&saved)).then_some(())
+        },
+    )
+    .unwrap();
+    dispatch(&mut restored, "workspace 3");
+    assert_eq!(settled(&mut restored).spatial.mode, "Mosaic");
+    dispatch(&mut restored, "workspace 1");
+    let freeform = mode(&mut restored, "freeform");
+    let mut geometry: Vec<_> = freeform
+        .windows
+        .iter()
+        .map(|w| (w.x, w.y, w.w, w.h))
+        .collect();
+    geometry.sort();
+    assert_eq!(geometry, originals);
+}
+
+#[test]
+#[ignore = "requires native nested Wayland"]
+fn benchmark_real_reflow_focus_and_reversible_membership() {
+    let mut session = Session::boot(
+        "spatial-benchmark",
+        SessionOptions {
+            config_extra: "show_dock = false\n".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+    for count in 1..=8 {
+        let class = format!("benchmark-{count}");
+        session
+            .launch(probe.to_str().unwrap(), &[&class, &class])
+            .unwrap();
+        session.wait_for_window(&class).unwrap();
+        if count != 4 && count != 8 {
+            continue;
+        }
+        for style in ["mosaic", "flow"] {
+            let before = session.world().unwrap().spatial;
+            session.door().frame_stats().unwrap();
+            mode(&mut session, style);
+            let after = session.world().unwrap().spatial;
+            let frames = session.door().frame_stats().unwrap();
+            eprintln!("{count}-window {style}: calculations={} reflow_us={} transitions={} setup_us={} configures={} renders={} render_us={} render_max_us={}",
+                after.calculations-before.calculations,after.calculation_us-before.calculation_us,after.setups-before.setups,after.setup_us-before.setup_us,
+                after.configures-before.configures,frames.render_calls,frames.render_us,frames.render_max_us);
+            assert_eq!(after.managed, count);
+            assert!(after.configures - before.configures <= count as u64 * 2);
+            eprintln!("layout scene: builds={} culled={} build_us={} (excludes GPU submission/presentation waits)",
+                after.builds - before.builds, after.culled - before.culled, after.build_us - before.build_us);
+            if count == 8 && style == "flow" {
+                assert!(
+                    after.culled > before.culled,
+                    "offscreen Flow cells must skip element construction"
+                );
+            }
+        }
+    }
+    if let Ok(before) = session.door().memory_statistics() {
+        dispatch(&mut session, "layout mosaic");
+        let during = session.door().memory_statistics().unwrap();
+        std::thread::sleep(Duration::from_millis(120));
+        let after = session.door().memory_statistics().unwrap();
+        eprintln!("allocation-profile animation interval (120ms, includes renderer/client commits/test IPC): operations={} allocated_bytes={}; transition setup operations={}",
+            after.get("rust_operations").unwrap()-during.get("rust_operations").unwrap(),
+            after.get("rust_allocated_bytes").unwrap()-during.get("rust_allocated_bytes").unwrap(),
+            during.get("rust_operations").unwrap()-before.get("rust_operations").unwrap());
+        mode(&mut session, "flow");
+    }
+    let memory_before = session.door().memory_statistics().ok();
+    let before = session.world().unwrap().spatial;
+    for _ in 0..8 {
+        for _ in 0..7 {
+            dispatch(&mut session, "movefocus l");
+        }
+        for _ in 0..7 {
+            dispatch(&mut session, "movefocus r");
+        }
+        dispatch(&mut session, "layout mosaic");
+        dispatch(&mut session, "layout flow");
+        dispatch(&mut session, "togglefloating");
+        dispatch(&mut session, "togglefloating");
+    }
+    let after = settled(&mut session).spatial;
+    eprintln!(
+        "rapid focus/reflow: calculations={} reflow_us={} transitions={} setup_us={} configures={}",
+        after.calculations - before.calculations,
+        after.calculation_us - before.calculation_us,
+        after.setups - before.setups,
+        after.setup_us - before.setup_us,
+        after.configures - before.configures
+    );
+    if let (Some(before), Ok(after)) = (memory_before, session.door().memory_statistics()) {
+        eprintln!("allocation-profile complete operations (includes clients, chrome and test IPC): allocations={} allocated_bytes={} retained_bytes_before={} retained_bytes_after={}",
+            after.get("rust_operations").unwrap()-before.get("rust_operations").unwrap(),after.get("rust_allocated_bytes").unwrap()-before.get("rust_allocated_bytes").unwrap(),
+            before.get("rust_live_bytes").unwrap(),after.get("rust_live_bytes").unwrap());
+    }
+    assert_eq!(after.managed, 8);
+    session.door().frame_stats().unwrap();
+    std::thread::sleep(Duration::from_millis(120));
+    assert_eq!(session.door().frame_stats().unwrap().render_calls, 0);
+}
+
+#[test]
+#[ignore = "requires native nested Wayland; use memory-profile binary for allocation counters"]
+fn steady_flow_rendering_profile_with_a_live_frame_paced_client() {
+    let mut session = Session::boot(
+        "spatial-steady-profile",
+        SessionOptions {
+            config_extra: "show_dock = false\n".into(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+    for i in 0..8 {
+        let class = format!("steady-{i}");
+        let animation = if i == 7 { "animate-frame" } else { "static" };
+        session
+            .launch(probe.to_str().unwrap(), &[&class, &class, animation])
+            .unwrap();
+        session.wait_for_window(&class).unwrap();
+    }
+    for style in ["mosaic", "flow", "mosaic", "flow"] {
+        mode(&mut session, style);
+        // Caption expiry is outside the measurement. The client, not test
+        // screenshots or injected motion, supplies every measured live frame.
+        std::thread::sleep(Duration::from_millis(1100));
+        let before = session.world().unwrap().spatial;
+        session.door().frame_stats().unwrap();
+        let memory_before = session.door().memory_statistics().ok();
+        std::thread::sleep(Duration::from_millis(500));
+        let memory_after = session.door().memory_statistics().ok();
+        let frames = session.door().frame_stats().unwrap();
+        let after = session.world().unwrap().spatial;
+        assert!(
+            frames.render_calls >= 5,
+            "the actual client must keep rendering"
+        );
+        assert_eq!(after.calculations, before.calculations);
+        assert_eq!(after.configures, before.configures);
+        eprintln!(
+            "steady {style}: renders={} builds={} culled={} build_us={}",
+            frames.render_calls,
+            after.builds - before.builds,
+            after.culled - before.culled,
+            after.build_us - before.build_us
+        );
+        if let (Some(before), Some(after)) = (memory_before, memory_after) {
+            let operations =
+                after.get("rust_operations").unwrap() - before.get("rust_operations").unwrap();
+            let bytes = after.get("rust_allocated_bytes").unwrap()
+                - before.get("rust_allocated_bytes").unwrap();
+            eprintln!("steady {style} allocator: operations={operations} bytes={bytes} operations_per_render={:.1} bytes_per_render={:.1} retained_before={} retained_after={}",
+                operations as f64 / frames.render_calls as f64, bytes as f64 / frames.render_calls as f64,
+                before.get("rust_live_bytes").unwrap(), after.get("rust_live_bytes").unwrap());
+        }
+    }
+}

--- a/crates/chonk-testkit/tests/supervisor.rs
+++ b/crates/chonk-testkit/tests/supervisor.rs
@@ -326,8 +326,10 @@ fn direct_session_owns_graphical_targets_and_publishes_only_curated_environment(
 
     let started = poll_until(Duration::from_secs(10), "the direct session to publish its X display", || {
         let text = std::fs::read_to_string(&calls).ok()?;
-        text.lines()
-            .any(|line| line.starts_with("dbus ") && line.contains("DISPLAY=:7"))
+        // Environment publication precedes starting the targets. Wait for
+        // both observable effects before inspecting the complete startup.
+        (text.lines().any(|line| line.starts_with("dbus ") && line.contains("DISPLAY=:7"))
+            && text.contains("--user start graphical-session.target xdg-desktop-autostart.target"))
             .then_some(text)
     })
     .expect("the activation environment must gain DISPLAY once XWayland is ready");

--- a/crates/wm-config/src/hyprland/dispatch.rs
+++ b/crates/wm-config/src/hyprland/dispatch.rs
@@ -15,14 +15,9 @@
 //!    declared under a name derived from the argv itself.
 //! 3. Everything else stays unbound and says why.
 //!
-//! The rule that makes the third answer worth having is the preset's,
-//! quoted because it is the thing most easily lost when a table becomes
-//! a parser: *an approximation is worse than a dead key.* `SUPER + J`
-//! toggles a split on Omarchy; on a stacking desk there is nothing to
-//! split, and binding it to the nearest-looking verb turns a key the
-//! user would look up in five seconds into a bug report. Every
-//! dispatcher below that has no true answer here is written down as
-//! having none.
+//! Workspace layout dispatchers select Mosaic/Flow and preserve floating
+//! membership. Tree-only messages deliberately succeed without changing the
+//! scene; unavailable grouping operations remain explicitly unbound.
 //!
 //! # Why this reads a table of dispatchers and not of chords
 //!
@@ -77,6 +72,11 @@ fn exec_verb(command: &str) -> Verb {
     let Some(program) = argv.first() else {
         return Verb::Unbound(Unbound::NoVerb);
     };
+    if argv.len() == 1
+        && program.rsplit('/').next() == Some("omarchy-hyprland-workspace-layout-toggle")
+    {
+        return Verb::Action(Action::ToggleLayout);
+    }
     if commands_hyprland(program) {
         return Verb::Unbound(Unbound::HyprlandOnly);
     }
@@ -160,11 +160,26 @@ fn compositor_verb(name: &str, arg: &str) -> Verb {
         },
         // `fullscreenstate` sets the *client's* idea and the
         // compositor's separately, which is how Omarchy builds "tiled
-        // fullscreen". There is no tiling here to be full inside of.
+        // fullscreen". Independent client/internal states are not modeled.
         "fullscreenstate" => Verb::Unbound(Unbound::TilingOnly),
-        "layoutmsg" | "pseudo" | "togglefloating" | "setfloating" | "settiled" | "swapwindow"
-        | "swapnext" | "resizeactive" | "moveactive" | "splitratio" | "pin" | "togglesplit"
-        | "movewindoworgroup" | "centerwindow" => Verb::Unbound(Unbound::TilingOnly),
+        "togglefloating" => Verb::Action(Action::Floating(None)),
+        "setfloating" => Verb::Action(Action::Floating(Some(true))),
+        "settiled" => Verb::Action(Action::Floating(Some(false))),
+        "layoutmsg" | "togglesplit" | "swapsplit" | "pseudo" | "splitratio" => {
+            Verb::Action(Action::LayoutNoop)
+        }
+        "resizeactive" => {
+            let values: Vec<_> = arg
+                .split_whitespace()
+                .filter_map(|s| s.parse::<i32>().ok())
+                .collect();
+            if let [x, y] = values.as_slice() {
+                Verb::Action(Action::Resize(wm_core::Point::new(*x, *y)))
+            } else {
+                Verb::Unbound(Unbound::NoVerb)
+            }
+        }
+        "swapnext" | "moveactive" | "pin" | "centerwindow" => Verb::Unbound(Unbound::TilingOnly),
         "togglegroup"
         | "changegroupactive"
         | "moveintogroup"
@@ -182,7 +197,12 @@ fn compositor_verb(name: &str, arg: &str) -> Verb {
             "d" | "down" => Verb::Action(Action::Focus(FocusDirection::Down)),
             _ => Verb::Unbound(Unbound::NoVerb),
         },
-        "movewindow" => Verb::Unbound(Unbound::TilingOnly),
+        "movewindow" | "swapwindow" | "movewindoworgroup" => {
+            match compositor_verb("movefocus", arg) {
+                Verb::Action(Action::Focus(direction)) => Verb::Action(Action::Move(direction)),
+                _ => Verb::Unbound(Unbound::NoVerb),
+            }
+        }
         // Workspaces. `e+1`/`e-1` are "the next/previous workspace that
         // exists", which is exactly what this desktop's two workspace
         // verbs do; a bare number is a workspace by index, and

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -485,11 +485,18 @@ pub fn apply(config: &mut crate::Config, reading: Option<&Reading>) {
             "hyprland-config: no bindings came out of the read; keeping the built-in keymap"
         );
     } else {
-        let captures: Vec<_> = config.keybindings.iter()
-            .filter(|(key, action)| matches!(action, Action::Capture(_))
-                && !reading.explicit_keys.contains(key)
-                && !reading.keybindings.iter().any(|(other, _)| other == key))
-            .cloned().collect();
+        let captures: Vec<_> = config
+            .keybindings
+            .iter()
+            .filter(|(key, action)| {
+                matches!(
+                    action,
+                    Action::Capture(_) | Action::Layout(wm_core::LayoutMode::Freeform)
+                ) && !reading.explicit_keys.contains(key)
+                    && !reading.keybindings.iter().any(|(other, _)| other == key)
+            })
+            .cloned()
+            .collect();
         config.keybindings = reading.keybindings.clone();
         config.keybindings.extend(captures);
     }

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -184,12 +184,12 @@ fn the_three_answers_each_land_on_a_real_chord() {
     // 3. A tiling verb, deliberately unbound with a reason.
     assert_eq!(
         action_for(&reading, "super+j"),
-        None,
-        "toggle split must not be approximated"
+        Some(Action::LayoutNoop),
+        "inapplicable split messages are deliberately quiet"
     );
     assert_eq!(
         skipped_why(&reading, "SUPER + J"),
-        Some(crate::preset::Unbound::TilingOnly.reason().to_string()),
+        None,
         "and the reason has to be recorded, not implied"
     );
 }
@@ -1136,8 +1136,8 @@ fn the_live_read_replaces_the_baked_preset() {
     apply(&mut config, Some(&reading));
     assert_eq!(
         config.keybindings.len(),
-        reading.keybindings.len() + 4,
-        "only four native capture shortcuts augment the live read, not all {baked} entries"
+        reading.keybindings.len() + 5,
+        "four native capture shortcuts and Freeform augment the live read, not all {baked} entries"
     );
     assert!(config.float_policy.is_some());
     assert!(!config.session_env.is_empty());
@@ -2070,7 +2070,7 @@ fn the_numbers_the_documents_quote_are_the_numbers_this_machine_produces() {
     let reading = read(&machine());
     assert_eq!(
         reading.keybindings.len(),
-        153,
+        161,
         "bindings read from the captured machine"
     );
     assert_eq!(
@@ -2089,17 +2089,17 @@ fn the_numbers_the_documents_quote_are_the_numbers_this_machine_produces() {
     // number there is the normal case rather than a fault.
     assert_eq!(
         reading.skipped.len(),
-        173,
+        165,
         "directives this desktop has its own answer for"
     );
     const GUIDE: &str = include_str!("../../../../docs/hyprland-config.md");
     assert!(
-        MODE.contains("153\nbindings over 113 commands") || MODE.contains("153 bindings over 113 commands"),
-        "docs/omarchy-mode.md no longer quotes the 153 bindings over 113 commands this machine produces"
+        MODE.contains("161\nbindings over 113 commands") || MODE.contains("161 bindings over 113 commands"),
+        "docs/omarchy-mode.md no longer quotes the 161 bindings over 113 commands this machine produces"
     );
     assert!(
-        GUIDE.contains("files=42 bindings=153 commands=113 env=8 autostart=4")
-            && GUIDE.contains("float_rules=45 monitors=1 skipped=173"),
+        GUIDE.contains("files=42 bindings=161 commands=113 env=8 autostart=4")
+            && GUIDE.contains("float_rules=45 monitors=1 skipped=165"),
         "the guide's sample log line no longer matches what this machine reports"
     );
 }

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -112,9 +112,14 @@ pub enum Action {
     ToggleShade,
     Miniaturize,
     ToggleFullscreen,
+    Layout(wm_core::LayoutMode),
+    ToggleLayout,
+    Floating(Option<bool>),
+    Move(FocusDirection),
+    Resize(wm_core::Point),
+    LayoutNoop,
     /// Focus the nearest visible window in this root-coordinate
-    /// direction. This is spatial navigation over floating frames, not
-    /// a tiling-tree approximation.
+    /// direction, using the workspace style's spatial navigation policy.
     Focus(FocusDirection),
     WorkspaceNext,
     WorkspacePrev,
@@ -285,6 +290,20 @@ fn action_from_name(name: &str) -> Option<Action> {
     match normalized.as_str() {
         "spawn-terminal" => Some(Action::SpawnTerminal),
         "close" => Some(Action::Close),
+        "layout-freeform" => Some(Action::Layout(wm_core::LayoutMode::Freeform)),
+        "layout-mosaic" => Some(Action::Layout(wm_core::LayoutMode::Mosaic)),
+        "layout-flow" => Some(Action::Layout(wm_core::LayoutMode::Flow)),
+        "toggle-layout" => Some(Action::ToggleLayout),
+        "grow-width" => Some(Action::Resize(wm_core::Point::new(25, 0))),
+        "shrink-width" => Some(Action::Resize(wm_core::Point::new(-25, 0))),
+        "grow-height" => Some(Action::Resize(wm_core::Point::new(0, 25))),
+        "shrink-height" => Some(Action::Resize(wm_core::Point::new(0, -25))),
+        "layout-noop" => Some(Action::LayoutNoop),
+        "toggle-floating" => Some(Action::Floating(None)),
+        "move-left" => Some(Action::Move(FocusDirection::Left)),
+        "move-right" => Some(Action::Move(FocusDirection::Right)),
+        "move-up" => Some(Action::Move(FocusDirection::Up)),
+        "move-down" => Some(Action::Move(FocusDirection::Down)),
         "toggle-maximize" => Some(Action::ToggleMaximize),
         "toggle-shade" => Some(Action::ToggleShade),
         "miniaturize" => Some(Action::Miniaturize),
@@ -678,6 +697,30 @@ impl Config {
             bindings: Vec::new(),
             layer_bindings: BTreeMap::new(),
             keybindings: vec![
+                bind("super+t", Action::Floating(None)),
+                bind("super+l", Action::ToggleLayout),
+                bind(
+                    "super+shift+l",
+                    Action::Layout(wm_core::LayoutMode::Freeform),
+                ),
+                bind("super+ctrl+left", Action::Focus(FocusDirection::Left)),
+                bind("super+ctrl+right", Action::Focus(FocusDirection::Right)),
+                bind("super+ctrl+up", Action::Focus(FocusDirection::Up)),
+                bind("super+ctrl+down", Action::Focus(FocusDirection::Down)),
+                bind("super+shift+left", Action::Move(FocusDirection::Left)),
+                bind("super+shift+right", Action::Move(FocusDirection::Right)),
+                bind("super+shift+up", Action::Move(FocusDirection::Up)),
+                bind("super+shift+down", Action::Move(FocusDirection::Down)),
+                bind("super+equal", Action::Resize(wm_core::Point::new(25, 0))),
+                bind("super+minus", Action::Resize(wm_core::Point::new(-25, 0))),
+                bind(
+                    "super+shift+equal",
+                    Action::Resize(wm_core::Point::new(0, 25)),
+                ),
+                bind(
+                    "super+shift+minus",
+                    Action::Resize(wm_core::Point::new(0, -25)),
+                ),
                 bind("alt+shift+return", Action::SpawnTerminal),
                 bind("alt+shift+q", Action::Close),
                 bind("alt+shift+x", Action::ToggleMaximize),
@@ -689,7 +732,7 @@ impl Config {
                 bind("alt+shift+right", Action::WorkspaceCarryNext),
                 bind("alt+shift+left", Action::WorkspaceCarryPrev),
                 // Super+Up "steps back" from the desk for the modal
-                // Overview: the whole super row is otherwise free, and
+                // Overview: keep the established chord, while Ctrl+arrows focus, and
                 // the arrow pairs with the arrows that then drive the
                 // selection inside it.
                 bind("super+up", Action::Overview),
@@ -2009,6 +2052,60 @@ mod tests {
         // Expected combos written out with literal keysyms (not via
         // parse_key) so this test cannot be fooled by a parser bug.
         let expected = vec![
+            (combo(0x74, Modifiers::SUPER), Action::Floating(None)),
+            (combo(0x6c, Modifiers::SUPER), Action::ToggleLayout),
+            (
+                combo(0x6c, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Layout(wm_core::LayoutMode::Freeform),
+            ),
+            (
+                combo(0xff51, Modifiers::SUPER | Modifiers::CONTROL),
+                Action::Focus(FocusDirection::Left),
+            ),
+            (
+                combo(0xff53, Modifiers::SUPER | Modifiers::CONTROL),
+                Action::Focus(FocusDirection::Right),
+            ),
+            (
+                combo(0xff52, Modifiers::SUPER | Modifiers::CONTROL),
+                Action::Focus(FocusDirection::Up),
+            ),
+            (
+                combo(0xff54, Modifiers::SUPER | Modifiers::CONTROL),
+                Action::Focus(FocusDirection::Down),
+            ),
+            (
+                combo(0xff51, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Move(FocusDirection::Left),
+            ),
+            (
+                combo(0xff53, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Move(FocusDirection::Right),
+            ),
+            (
+                combo(0xff52, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Move(FocusDirection::Up),
+            ),
+            (
+                combo(0xff54, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Move(FocusDirection::Down),
+            ),
+            (
+                combo(0x3d, Modifiers::SUPER),
+                Action::Resize(wm_core::Point::new(25, 0)),
+            ),
+            (
+                combo(0x2d, Modifiers::SUPER),
+                Action::Resize(wm_core::Point::new(-25, 0)),
+            ),
+            (
+                combo(0x3d, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Resize(wm_core::Point::new(0, 25)),
+            ),
+            (
+                combo(0x2d, Modifiers::SUPER | Modifiers::SHIFT),
+                Action::Resize(wm_core::Point::new(0, -25)),
+            ),
             (combo(0xff0d, alt_shift), Action::SpawnTerminal),
             (combo(0x71, alt_shift), Action::Close),
             (combo(0x78, alt_shift), Action::ToggleMaximize),
@@ -2267,7 +2364,10 @@ scroll_factor = 0.4
             action_for(&config, "alt+shift+left"),
             Some(Action::WorkspaceCarryPrev)
         );
-        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len() + 1);
+        assert_eq!(
+            config.keybindings.len(),
+            Config::default_config().keybindings.len()
+        );
     }
 
     /// The one conversion between the two workspace vocabularies, in
@@ -2482,7 +2582,10 @@ scroll_factor = 0.4
         assert_eq!(config.diagnostics, vec!["bind: SUPER J — tiling-only"]);
         let report = effective_config_report(&config);
         assert!(report.contains("focus_follows_mouse = true\t# config file"));
-        assert!(report.contains("keybindings = 16\t# live Hyprland config"));
+        assert!(report.contains(&format!(
+            "keybindings = {}\t# live Hyprland config",
+            Config::default_config().keybindings.len()
+        )));
     }
 
     #[test]
@@ -2585,7 +2688,10 @@ scroll_factor = 0.4
         assert_eq!(action_for(&config, "super+u"), None);
         assert_eq!(action_for(&config, "super+v"), None);
         // ...and the untouched defaults survived: one removed, one added.
-        assert_eq!(config.keybindings.len(), Config::default_config().keybindings.len());
+        assert_eq!(
+            config.keybindings.len(),
+            Config::default_config().keybindings.len() - 1
+        );
         assert_eq!(
             action_for(&config, "alt+shift+x"),
             Some(Action::ToggleMaximize)

--- a/crates/wm-config/src/preset.rs
+++ b/crates/wm-config/src/preset.rs
@@ -66,20 +66,10 @@
 //!    "install chonkstep, keep your Omarchy" claim made literal:
 //!    `SUPER + SPACE` opens Omarchy's menu because it runs Omarchy's
 //!    `omarchy-menu`, not an imitation of it.
-//! 3. **Everything else stays unbound**, and says why in
-//!    [`OMARCHY_UNBOUND`]. A tiling desktop's vocabulary is full of
-//!    verbs that have no meaning on a stacking desk — split ratios,
-//!    gaps, layout cycling, "toggle floating" on a desk where
-//!    everything floats already — and the temptation is to map each one
-//!    to whatever is nearest. An approximation is worse than a dead
-//!    key: a dead key is discovered in five seconds and looked up,
-//!    while `SUPER + J` that does something *else* is a bug report.
-//!
-//! The same filter the Omarchy menu already applies applies here: an
-//! action that invokes `hyprctl` or an `omarchy-hyprland-*` script
-//! commands a compositor that is not running, so it is left unbound
-//! rather than bound to a command that will fail
-//! (`chonk_shell::omarchy_menu`, `Skip::HyprlandOnly`).
+//! 3. **Workspace styles** map to the native Mosaic and Flow layouts.
+//!    Super+T floats/rejoins, Super+L switches managed styles, and
+//!    Super+Shift+L returns to Freeform. Tree-only messages are quiet
+//!    no-ops; grouping and unavailable system operations stay unbound.
 
 use std::collections::BTreeMap;
 
@@ -400,6 +390,20 @@ pub const OMARCHY_BINDINGS: &[(&str, &str)] = &[
     // These select the closest focusable frame in the requested
     // direction, which preserves Omarchy's intent without inventing a
     // tiling tree.
+    ("super+j", "layout-noop"),
+    ("super+p", "layout-noop"),
+    ("super+ctrl+f", "toggle-maximize"),
+    ("super+equal", "grow-width"),
+    ("super+minus", "shrink-width"),
+    ("super+shift+equal", "grow-height"),
+    ("super+shift+minus", "shrink-height"),
+    ("super+t", "toggle-floating"),
+    ("super+l", "toggle-layout"),
+    ("super+shift+l", "layout-freeform"),
+    ("super+shift+left", "move-left"),
+    ("super+shift+right", "move-right"),
+    ("super+shift+up", "move-up"),
+    ("super+shift+down", "move-down"),
     ("super+left", "focus-left"),
     ("super+right", "focus-right"),
     ("super+up", "focus-up"),
@@ -571,9 +575,7 @@ pub const OMARCHY_BINDINGS: &[(&str, &str)] = &[
 /// place and forgotten in the other is how a table starts lying.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Unbound {
-    /// Names a tiling-layout action — split direction, gaps, ratios,
-    /// grouping, layout cycling — that has no meaning on a stacking
-    /// desktop where every window already floats at its own size.
+    /// A grouping or layout-specific operation outside the three styles.
     TilingOnly,
     /// Commands Hyprland itself (`hyprctl`, an `omarchy-hyprland-*`
     /// script, or a `hl.config` write from Lua). The compositor it
@@ -602,7 +604,7 @@ impl Unbound {
     /// The one-line reason, as the docs table prints it.
     pub fn reason(self) -> &'static str {
         match self {
-            Self::TilingOnly => "tiling-only: no meaning on a stacking desk",
+            Self::TilingOnly => "requires window groups or a feature ChonkStep does not provide",
             Self::HyprlandOnly => "commands Hyprland, which is not running",
             Self::NoVerb => "chonkstep has no verb for it, and no command can stand in",
             Self::NotAKey => "not a key chord this config format can express",
@@ -633,24 +635,14 @@ pub const OMARCHY_UNBOUND: &[(&str, &str, Unbound)] = &[
         Unbound::NoVerb,
     ),
     // tiling.lua
-    ("super+j", "toggle window split", Unbound::TilingOnly),
-    ("super+p", "pseudo-tile the window", Unbound::TilingOnly),
-    ("super+t", "toggle floating / tiling", Unbound::TilingOnly),
-    ("super+ctrl+f", "tiled fullscreen", Unbound::TilingOnly),
     ("super+o", "pop the window out, floating and pinned", Unbound::TilingOnly),
     ("super+home / super+alt+home", "restore / save window width", Unbound::HyprlandOnly),
-    ("super+l", "cycle the workspace layout", Unbound::HyprlandOnly),
     ("super+g / super+alt+g", "toggle grouping / move out of group", Unbound::TilingOnly),
     ("super+alt+left/right/up/down", "move the window into the group in that direction", Unbound::TilingOnly),
     ("super+alt+tab / super+alt+shift+tab", "next / previous window in the group", Unbound::TilingOnly),
     ("super+ctrl+left / super+ctrl+right", "move the grouped-window focus", Unbound::TilingOnly),
     ("super+alt+1..5", "focus the nth window of the group", Unbound::TilingOnly),
-    ("super+shift+left/right/up/down", "swap the window with its neighbour", Unbound::TilingOnly),
-    (
-        "super+minus / super+equal, +shift/alt/ctrl variants",
-        "grow and shrink the window by 25 / 100 / 300 px",
-        Unbound::TilingOnly,
-    ),
+    ("super+alt/ctrl+minus/equal", "large resize increments", Unbound::NoVerb),
     ("super+s", "toggle the scratchpad workspace", Unbound::NoVerb),
     ("super+ctrl+tab", "the workspace before this one", Unbound::NoVerb),
     ("super+shift+alt+left/right/up/down", "move the workspace to the monitor in that direction", Unbound::NoVerb),
@@ -834,6 +826,8 @@ mod tests {
 
         // The intended aliases, as (action, how many chords reach it).
         let expected: BTreeMap<&str, usize> = [
+            ("layout-noop", 2),
+            ("toggle-maximize", 2),
             ("run omarchy-browser", 2),
             ("run omarchy-menu", 2),
             ("run omarchy-menu-system", 2),
@@ -871,26 +865,15 @@ mod tests {
         // checked mechanically; the rest describe a family (`super+1..0`)
         // and are expanded here by hand where a family is checkable.
         let literal = [
-            "super+j",
-            "super+p",
-            "super+t",
-            "super+ctrl+f",
             "super+o",
             "super+home",
             "super+alt+home",
-            "super+l",
             "super+g",
             "super+alt+g",
             "super+alt+tab",
             "super+alt+shift+tab",
             "super+ctrl+left",
             "super+ctrl+right",
-            "super+shift+left",
-            "super+shift+right",
-            "super+shift+up",
-            "super+shift+down",
-            "super+minus",
-            "super+equal",
             "super+s",
             "super+ctrl+tab",
             "ctrl+alt+tab",

--- a/crates/wm-core/src/backend.rs
+++ b/crates/wm-core/src/backend.rs
@@ -46,6 +46,15 @@ pub struct OverviewDrag {
     pub workspace: Option<usize>,
 }
 
+/// Presentation of a managed drag; policy and membership stay in WindowManager.
+#[derive(Clone, Copy, Debug)]
+pub struct LayoutDrag<Window, Frame> {
+    pub window: Window,
+    pub frame: Option<Frame>,
+    pub source: Rect,
+    pub destination: Rect,
+}
+
 /// Everything the protocol-agnostic core needs from a windowing backend
 /// (X11 today via `wm-x11`, a future Wayland/Smithay backend later).
 /// Deliberately scoped to what a *window manager* needs, not a
@@ -60,6 +69,32 @@ pub struct OverviewDrag {
 pub trait Backend {
     type WindowId: Copy + Eq + std::hash::Hash + std::fmt::Debug;
     type FrameId: Copy + Eq + std::hash::Hash + std::fmt::Debug;
+
+    /// Establish output clipping before staging final geometry, then animate
+    /// live surfaces from the old frame without intermediate configures.
+    /// `clip` confines managed windows to their output workarea. Backends without native transforms settle
+    /// immediately. This carries presentation only, never layout policy.
+    fn present_layout(
+        &mut self,
+        _window: Self::WindowId,
+        _frame: Option<Self::FrameId>,
+        _source: Rect,
+        _destination: Rect,
+        _clip: Option<Rect>,
+        _animate: bool,
+    ) {
+    }
+
+    /// Input-transparent transient mode caption, rendered by the compositor.
+    fn show_layout_mode(&mut self, _mode: crate::LayoutMode, _label: DecorationBuffer) {}
+
+    /// Whole-cell managed drag target. None is the idempotent cleanup path.
+    fn preview_layout_drop(
+        &mut self,
+        _drag: Option<LayoutDrag<Self::WindowId, Self::FrameId>>,
+        _target: Option<Rect>,
+    ) {
+    }
 
     // -- lifecycle --------------------------------------------------------
     fn scan_existing_windows(&mut self) -> Vec<Self::WindowId>;

--- a/crates/wm-core/src/client.rs
+++ b/crates/wm-core/src/client.rs
@@ -137,6 +137,9 @@ pub struct Client<B: Backend> {
     pub class: String,
     /// Root-relative content geometry (standard X11 convention).
     pub geometry: Rect,
+    pub placement: crate::WindowPlacement,
+    pub(crate) layout_excluded: bool,
+    pub(crate) layout_restore_order: Option<usize>,
     /// Who drew this window's chrome. `ClientDrawn` means `frame` stays
     /// `None` for the window's whole life (or until the client changes
     /// its mind — see `WindowManager::refresh_client_chrome`) while
@@ -186,6 +189,9 @@ impl<B: Backend> Client<B> {
             title,
             class: String::new(),
             geometry: Rect::default(),
+            placement: crate::WindowPlacement::default(),
+            layout_excluded: false,
+            layout_restore_order: None,
             // Overwritten at map time from the backend's answer; the
             // default is what keeps a client that says nothing framed.
             chrome: ClientChrome::ServerDrawn,

--- a/crates/wm-core/src/fake_backend.rs
+++ b/crates/wm-core/src/fake_backend.rs
@@ -28,6 +28,7 @@ pub struct FakeBackend {
     geometries: HashMap<FakeWindowId, Rect>,
     hints: HashMap<FakeWindowId, SizeHints>,
     monitors: Vec<MonitorInfo>,
+    monitor_scales: Vec<f32>,
     /// Per-window `_NET_WM_WINDOW_TYPE` the fake reports — absent means
     /// `WindowType::Normal`, matching both the trait default and the
     /// EWMH fallback for windows that declare no type.
@@ -257,6 +258,11 @@ impl FakeBackend {
         self.monitors = monitors;
     }
 
+    /// Per-output scales for logical-coordinate layout and cross-output tests.
+    pub fn set_monitor_scales(&mut self, scales: Vec<f32>) {
+        self.monitor_scales = scales;
+    }
+
     /// Sets the `_NET_WM_WINDOW_TYPE` this fake reports for `window` —
     /// windows never set report `WindowType::Normal`, same as the trait
     /// default. Lets tests exercise the `Unmanaged` map path.
@@ -362,6 +368,19 @@ impl Backend for FakeBackend {
 
     fn monitors(&self) -> Vec<MonitorInfo> {
         self.monitors.clone()
+    }
+
+    fn decoration_scale(&self, frame: Rect) -> f32 {
+        let center = Point::new(
+            frame.pos.x + frame.size.w as i32 / 2,
+            frame.pos.y + frame.size.h as i32 / 2,
+        );
+        let index = self
+            .monitors
+            .iter()
+            .position(|m| m.geometry.contains(center))
+            .unwrap_or(0);
+        self.monitor_scales.get(index).copied().unwrap_or(1.0)
     }
 
     fn monitors_ref(&self) -> &[MonitorInfo] {

--- a/crates/wm-core/src/lib.rs
+++ b/crates/wm-core/src/lib.rs
@@ -16,6 +16,7 @@ mod motif;
 mod placement;
 mod resize;
 mod snap;
+mod spatial;
 mod types;
 
 // The in-memory `Backend` double is compiled for this crate's own
@@ -29,7 +30,7 @@ mod types;
 #[cfg(any(test, feature = "test-support"))]
 pub mod fake_backend;
 
-pub use backend::{Backend, OverviewDrag, OverviewScene, OverviewWindow, OverviewWorkspace};
+pub use backend::{Backend, LayoutDrag, OverviewDrag, OverviewScene, OverviewWindow, OverviewWorkspace};
 pub use client::{
     Client, ClientFlags, ClientId, Lifecycle, MaximizeDirections, MonitorId, MonitorInfo,
 };
@@ -45,6 +46,7 @@ pub use placement::{place_frame, FloatDecision, FloatPolicy, PlacementPolicy, Wi
 // geometry is part of this crate's own published interface the moment
 // one of its public types contains it.
 pub use snap::snap_position;
+pub use spatial::{LayoutMode, LayoutStatistics, WindowPlacement};
 pub use types::{
     BackendEvent, ClientChrome, DecorationRules, DragHandle, KeyCombo, KeyboardConfig, Modifiers, MouseButton, NetState,
     PointerConfig,

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
+mod spatial_layout;
+
 use slotmap::SlotMap;
 use wm_theme_api::{
     clamp_client_size, ButtonKind, ButtonRuntimeState, DecorationBuffer, DecorationLayout,
@@ -23,6 +25,8 @@ use crate::types::{
 /// X server "double-click time" setting yet — a reasonable fixed
 /// default, in the same ballpark as the classic desktop's.
 const DOUBLE_CLICK_MS: u32 = 400;
+/// Maximum travel between titlebar clicks, in logical pixels.
+const DOUBLE_CLICK_DISTANCE: f32 = 4.0;
 
 /// How close (in pixels) a dragged frame edge must come to a screen edge
 /// or another window's edge before it snaps flush — the classic "edge
@@ -110,6 +114,7 @@ struct ActiveButtonPress {
 /// since `Miniaturized` carries an owned pixel buffer.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Notification {
+    LayoutChanged(crate::LayoutMode),
     /// A client was iconified — the shell should show an icon tile for
     /// it (clicking the tile should call `WindowManager::deminiaturize`).
     /// The `Option<DecorationBuffer>` is a snapshot of the window's
@@ -200,8 +205,8 @@ pub struct WindowManager<B: Backend> {
     active_button_press: Option<ActiveButtonPress>,
     /// The most recent press on a titlebar drag region, for double-click
     /// detection — a second press on the *same* client's titlebar within
-    /// `DOUBLE_CLICK_MS` toggles maximize instead of starting a move.
-    last_titlebar_press: Option<(ClientId, u32)>,
+    /// `DOUBLE_CLICK_MS` and the movement tolerance trigger a titlebar action.
+    last_titlebar_press: Option<(ClientId, u32, Point)>,
     /// Per-monitor screen area windows should maximize into,
     /// reserved-space-aware — e.g. `chonkstep`'s desktop shell excludes
     /// its dock strip from the entry for the monitor the dock hangs on,
@@ -294,6 +299,10 @@ pub struct WindowManager<B: Backend> {
     /// workspace compacts memberships and retains at least one desktop.
     current_workspace: usize,
     workspace_count: usize,
+    layouts: Vec<crate::spatial::WorkspaceLayout>,
+    layout_drop: Option<(ClientId, ClientId)>,
+    layout_resize_snapshot: Option<crate::spatial::ResizeSnapshot>,
+    layout_statistics: crate::LayoutStatistics,
     /// An in-progress Alt-Tab switcher session: the snapshot of cycle
     /// candidates and which one is currently selected. Selection moves
     /// on every Tab press while Alt stays held; releasing Alt commits
@@ -379,6 +388,10 @@ impl<B: Backend> WindowManager<B> {
             raise_on_focus: true,
             current_workspace: 0,
             workspace_count: 1,
+            layouts: vec![crate::spatial::WorkspaceLayout::default()],
+            layout_drop: None,
+            layout_resize_snapshot: None,
+            layout_statistics: crate::LayoutStatistics::default(),
             cycle: None,
             managed_order: Vec::new(),
             focus_history: Vec::new(),
@@ -539,6 +552,7 @@ impl<B: Backend> WindowManager<B> {
             // bypasses the theme entirely and is correct unchanged.
             self.reflow_frame(id);
         }
+        self.reflow_layouts();
     }
 
     /// Reserves screen space windows should not maximize into (e.g. a
@@ -572,6 +586,7 @@ impl<B: Backend> WindowManager<B> {
         self.publish_workarea_union();
         if self.effective_workareas() != before {
             self.refit_maximized();
+            self.reflow_layouts();
             // A bar can map after ordinary windows, including windows on
             // inactive desktops. Only reflow frames actually inside its strip.
             let displaced: Vec<_> = self
@@ -742,6 +757,7 @@ impl<B: Backend> WindowManager<B> {
     /// geometry obey the same rules if the X backend grows RandR
     /// hotplug later.
     pub fn rescue_clients_from_removed_monitor(&mut self, departed: Rect) {
+        self.end_active_drag();
         let monitors = self.backend.monitors();
         if monitors.is_empty() {
             return;
@@ -795,6 +811,7 @@ impl<B: Backend> WindowManager<B> {
             self.reflow_frame(id);
             tracing::info!(?id, ?departed, ?target, "rescued window from a removed monitor");
         }
+        self.reflow_layouts();
     }
 
     /// That monitor's workarea: the shell-reserved area if one was set
@@ -911,16 +928,24 @@ impl<B: Backend> WindowManager<B> {
     /// Pin/unpin a window. Pinned windows are visible on every
     /// workspace and are kept above ordinary windows.
     pub fn set_client_pinned(&mut self, id: ClientId, pinned: bool) -> bool {
+        self.cancel_client_layout_interaction(id);
+        if pinned && self.is_layout_managed(id) {
+            if let Some(saved) = self.clients[id].placement.freeform {
+                self.restore_freeform_geometry(id, saved);
+            }
+        }
         let Some(client) = self.clients.get_mut(id) else { return false };
         if client.flags.contains(ClientFlags::STICKY) == pinned {
             return true;
         }
         client.flags.set(ClientFlags::STICKY, pinned);
+        self.reflow_client_workspace(id);
         self.bump_protocol_state_revision();
         if pinned {
             self.show_client_surface(id);
             self.raise_client(id);
         } else if self.clients.get(id).is_some_and(|client| client.workspace != self.current_workspace) {
+            self.focus_successor_of(id);
             self.hide_client_surface(id);
         }
         true
@@ -1135,6 +1160,16 @@ impl<B: Backend> WindowManager<B> {
     /// Miniaturized, hidden-workspace and `NO_FOCUS` clients cannot be
     /// destinations, exactly as for immediate focus cycling.
     pub fn focus_direction(&mut self, direction: FocusDirection) -> bool {
+        if let Some(id) = self.focused.filter(|&id| self.is_layout_managed(id)) {
+            let Some(target) = self
+                .layout_neighbor(id, direction)
+                .or_else(|| self.layout_neighbor_across_outputs(id, direction))
+            else {
+                return false;
+            };
+            self.focus_client(target);
+            return true;
+        }
         let Some(source) = self.focused.and_then(|id| self.clients.get(id)).map(client_frame_rect) else {
             return false;
         };
@@ -1171,6 +1206,12 @@ impl<B: Backend> WindowManager<B> {
         if self.workspace_count <= 1 || workspace >= self.workspace_count {
             return false;
         }
+        self.end_active_drag();
+        let removed = self.layouts.remove(workspace);
+        let target = workspace.saturating_sub(1).min(self.layouts.len() - 1);
+        self.layouts[target]
+            .order
+            .extend(removed.order.iter().copied());
         let remap = |index: usize| {
             if index == workspace {
                 workspace.saturating_sub(1)
@@ -1199,6 +1240,12 @@ impl<B: Backend> WindowManager<B> {
                 revealed.push(id);
             }
         }
+        if self.workspace_layout(target) == crate::LayoutMode::Freeform {
+            for id in removed.order {
+                self.restore_freeform_view(id);
+            }
+        }
+        self.reflow_layouts();
         self.bump_protocol_state_revision();
         self.backend.publish_workspaces(self.workspace_count, self.current_workspace);
         self.publish_workarea_union();
@@ -1232,6 +1279,10 @@ impl<B: Backend> WindowManager<B> {
             return;
         }
         self.workspace_count = self.workspace_count.max(workspace + 1);
+        self.layouts.resize_with(
+            self.workspace_count,
+            crate::spatial::WorkspaceLayout::default,
+        );
         self.current_workspace = workspace;
         self.bump_protocol_state_revision();
         self.backend.publish_workspaces(self.workspace_count, self.current_workspace);
@@ -1291,6 +1342,7 @@ impl<B: Backend> WindowManager<B> {
     /// next/previous workspace" window actions. A no-op if `id` is
     /// already on `workspace` or if the index is out of range.
     pub fn move_client_to_workspace(&mut self, id: ClientId, workspace: usize) {
+        self.cancel_client_layout_interaction(id);
         for member in self.transient_family(id) {
             self.move_one_client_to_workspace(member, workspace);
         }
@@ -1331,6 +1383,7 @@ impl<B: Backend> WindowManager<B> {
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
+        let old_workspace = client.workspace;
         client.workspace = workspace;
         let window = client.window;
         let should_hide = workspace != self.current_workspace && !client.flags.contains(ClientFlags::STICKY);
@@ -1339,6 +1392,15 @@ impl<B: Backend> WindowManager<B> {
         // changes — pagers track membership from this property, not by
         // guessing from map/unmap traffic.
         self.backend.publish_window_desktop(window, workspace);
+        self.layouts[old_workspace]
+            .order
+            .retain(|&other| other != id);
+        self.register_layout_client(id);
+        if self.workspace_layout(workspace) == crate::LayoutMode::Freeform {
+            self.restore_freeform_view(id);
+        }
+        self.reflow_workspace(old_workspace);
+        self.reflow_workspace(workspace);
         if should_hide {
             self.hide_client_surface(id);
             if self.focused == Some(id) {
@@ -1471,12 +1533,19 @@ impl<B: Backend> WindowManager<B> {
             }
             BackendEvent::TitleChanged(window) => self.handle_title_changed(window),
             BackendEvent::ChromeChanged(window) => self.handle_chrome_changed(window),
+            BackendEvent::SizeHintsChanged(window) => {
+                if let Some(id) = self.client_for_window(window) {
+                    self.cancel_client_layout_interaction(id);
+                    self.reflow_client_workspace(id);
+                }
+            }
             BackendEvent::ParentChanged(window) => self.handle_parent_changed(window),
             BackendEvent::ModalChanged { window, modal } => {
                 self.handle_modal_changed(window, modal)
             }
             BackendEvent::MoveRequest(window) => self.handle_move_request(window),
-            BackendEvent::DragEnded => self.end_active_drag(),
+            BackendEvent::DragEnded => self.commit_active_drag(),
+            BackendEvent::DragCancelled => self.end_active_drag(),
             BackendEvent::ResizeRequest { window, edge } => self.handle_resize_request(window, edge),
             // Routed through the very same miniaturize the titlebar
             // button runs, so the client's own button and ours are one
@@ -1768,6 +1837,14 @@ impl<B: Backend> WindowManager<B> {
 
         client.frame = frame;
         client.layout = layout;
+        let hints = self.backend.size_hints(window);
+        client.placement.floating = floated.is_some()
+            || window_type == WindowType::Dialog
+            || client.parent.is_some()
+            || hints
+                .min_size
+                .zip(hints.max_size)
+                .is_some_and(|(min, max)| min == max);
 
         let id = self.clients.insert(client);
         self.bump_protocol_state_revision();
@@ -1807,6 +1884,8 @@ impl<B: Backend> WindowManager<B> {
         }
 
         self.publish_frame_extents(id);
+        self.register_layout_client(id);
+        self.reflow_client_workspace(id);
         self.notifications.push_back(Notification::Mapped(id));
         // Maximize first so a simultaneous fullscreen rule preserves
         // the maximized geometry/state underneath fullscreen.
@@ -1829,6 +1908,17 @@ impl<B: Backend> WindowManager<B> {
     /// (`handle_configure_request`), so both end up equally "real" as
     /// far as layout/repaint are concerned.
     pub fn resize_client_content(&mut self, id: ClientId, size: Size) {
+        if self.is_layout_managed(id) {
+            let current = self.clients[id].geometry.size;
+            self.resize_layout_window(
+                id,
+                Point::new(
+                    size.w as i32 - current.w as i32,
+                    size.h as i32 - current.h as i32,
+                ),
+            );
+            return;
+        }
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -1852,6 +1942,10 @@ impl<B: Backend> WindowManager<B> {
     /// for this itself). A no-op for an unknown `id`, like every other
     /// stale-id path here.
     pub fn set_client_content_geometry(&mut self, id: ClientId, geometry: Rect) {
+        if self.is_layout_managed(id) {
+            self.resize_client_content(id, geometry.size);
+            return;
+        }
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -1887,11 +1981,16 @@ impl<B: Backend> WindowManager<B> {
         self.focus_history.retain(|&other| other != id);
         if self.active_move.as_ref().is_some_and(|m| m.client == id)
             || self.active_resize.as_ref().is_some_and(|r| r.client == id)
+            || self.layout_drop.is_some_and(|(_, target)| target == id)
         {
             // The window being dragged has gone. Ending the drag here
             // is what stops the grab outliving it — a pointer grab with
             // nothing left to move is a frozen desktop.
             self.end_active_drag();
+        }
+        let workspace = self.clients.get(id).map(|c| c.workspace);
+        for layout in &mut self.layouts {
+            layout.order.retain(|&other| other != id);
         }
         self.fullscreen_restore.remove(&id);
         self.idle_inhibit_clients.remove(&id);
@@ -1932,6 +2031,9 @@ impl<B: Backend> WindowManager<B> {
                 session.selected = session.selected.min(session.order.len() - 1);
                 self.notifications.push_back(Notification::CycleUpdated);
             }
+        }
+        if let Some(workspace) = workspace {
+            self.reflow_workspace(workspace);
         }
         self.notifications.push_back(Notification::Removed(id));
         self.bump_protocol_state_revision();
@@ -1976,9 +2078,13 @@ impl<B: Backend> WindowManager<B> {
         {
             return;
         }
+        if parent.is_some() && self.is_layout_managed(id) {
+            self.set_floating(id, true);
+        }
         if let Some(client) = self.clients.get_mut(id) {
             client.parent = parent;
         }
+        self.reflow_client_workspace(id);
         let Some(parent) = parent else {
             return;
         };
@@ -2011,12 +2117,16 @@ impl<B: Backend> WindowManager<B> {
             self.reflow_frame(id);
         }
         self.raise_client(parent);
+        self.reflow_client_workspace(id);
     }
 
     fn handle_modal_changed(&mut self, window: B::WindowId, modal: bool) {
         let Some(&id) = self.window_index.get(&window) else {
             return;
         };
+        if modal && self.is_layout_managed(id) {
+            self.set_floating(id, true);
+        }
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2026,6 +2136,7 @@ impl<B: Backend> WindowManager<B> {
         client.flags.set(ClientFlags::MODAL, modal);
         self.bump_protocol_state_revision();
         self.publish_client_net_state(id);
+        self.reflow_client_workspace(id);
         if modal {
             self.focus_client(id);
         }
@@ -2040,6 +2151,9 @@ impl<B: Backend> WindowManager<B> {
             return;
         };
 
+        if self.is_layout_managed(id) {
+            return;
+        }
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2114,7 +2228,7 @@ impl<B: Backend> WindowManager<B> {
         // of them means the same thing, and treating only one of them
         // as the end is what left the window stuck to the cursor.
         if !pressed && button == MouseButton::Left && (self.active_move.is_some() || self.active_resize.is_some()) {
-            self.end_active_drag();
+            self.commit_active_drag();
         }
         match surface {
             SurfaceRef::Frame(frame) => self.handle_frame_button(frame, local, button, pressed, time_ms, mods),
@@ -2255,10 +2369,17 @@ impl<B: Backend> WindowManager<B> {
                 // flagship default.) No X server gives double-click
                 // detection for free; this is why
                 // `BackendEvent::PointerButton` carries a timestamp.
+                let at = Point::new(
+                    client.geometry.pos.x - client.layout.client_offset.x + local.x,
+                    client.geometry.pos.y - client.layout.client_offset.y + local.y,
+                );
+                let tolerance = (DOUBLE_CLICK_DISTANCE * self.client_decoration_scale(id)).ceil() as i64;
                 let is_double_click = self
                     .last_titlebar_press
-                    .take_if(|(prev_id, prev_time)| {
-                        *prev_id == id && time_ms.saturating_sub(*prev_time) <= DOUBLE_CLICK_MS
+                    .take_if(|(prev_id, prev_time, prev_at)| {
+                        *prev_id == id && time_ms.wrapping_sub(*prev_time) <= DOUBLE_CLICK_MS
+                            && (at.x as i64 - prev_at.x as i64).abs() <= tolerance
+                            && (at.y as i64 - prev_at.y as i64).abs() <= tolerance
                     })
                     .is_some();
                 if is_double_click {
@@ -2271,7 +2392,7 @@ impl<B: Backend> WindowManager<B> {
                         (false, false) => self.toggle_shade(id),
                     }
                 } else {
-                    self.last_titlebar_press = Some((id, time_ms));
+                    self.last_titlebar_press = Some((id, time_ms, at));
                     // Dragging a maximized window is the gesture that
                     // un-maximizes it. Without this the window travels
                     // under the pointer still flagged maximized: the
@@ -2311,7 +2432,7 @@ impl<B: Backend> WindowManager<B> {
         if self.active_move.as_ref().is_some_and(|m| m.client == id)
             || self.active_resize.as_ref().is_some_and(|r| r.client == id)
         {
-            self.end_active_drag();
+            self.commit_active_drag();
         }
 
         let Some(active) = self.active_button_press.take_if(|p| p.client == id) else {
@@ -2380,6 +2501,19 @@ impl<B: Backend> WindowManager<B> {
             return;
         };
         let (client_id, grab_offset) = (active.client, active.grab_offset);
+        let tolerance = (DOUBLE_CLICK_DISTANCE * self.client_decoration_scale(client_id)).ceil() as i64;
+        if self.last_titlebar_press.is_some_and(|(id, _, at)| {
+            id == client_id && ((root.x as i64 - at.x as i64).abs() > tolerance
+                || (root.y as i64 - at.y as i64).abs() > tolerance)
+        }) {
+            // A drag is not the first click of a double-click, even if it is
+            // cancelled and the user immediately grabs the same titlebar.
+            self.last_titlebar_press = None;
+        }
+        if self.is_layout_managed(client_id) {
+            self.preview_managed_move(client_id, root);
+            return;
+        }
 
         let Some(client) = self.clients.get(client_id) else {
             self.end_active_drag();
@@ -2524,6 +2658,33 @@ impl<B: Backend> WindowManager<B> {
 
         let raw_content =
             Size::new((raw_frame_w as u32).saturating_sub(overhead_w), (raw_frame_h as u32).saturating_sub(overhead_h));
+        if self.is_layout_managed(client_id) {
+            if self.layout_resize_snapshot.is_none() {
+                let workspace = self.clients[client_id].workspace;
+                self.layout_resize_snapshot = Some(crate::spatial::ResizeSnapshot {
+                    workspace,
+                    viewports: self.layouts[workspace].viewports.clone(),
+                    placements: self
+                        .layout_order(workspace)
+                        .iter()
+                        .map(|&id| {
+                            let p = &self.clients[id].placement;
+                            (id, p.mosaic_weight, p.flow_width)
+                        })
+                        .collect(),
+                });
+            }
+            let current = self.clients[client_id].geometry.size;
+            self.resize_managed(
+                client_id,
+                Point::new(
+                    raw_content.w as i32 - current.w as i32,
+                    raw_content.h as i32 - current.h as i32,
+                ),
+                Some(edge),
+            );
+            return;
+        }
         let hints = self.backend.size_hints(client.window);
         let content = resize::constrain_size(raw_content, hints);
 
@@ -2667,8 +2828,7 @@ impl<B: Backend> WindowManager<B> {
             return;
         }
         let request = Self::decoration_request(client, None);
-        let current_frame = client_frame_rect(client);
-        let scale = self.backend.decoration_scale(current_frame);
+        let scale = self.client_decoration_scale(id);
         let layout = self.theme.layout_at(&request, scale);
         // Shaded windows show only the titlebar — the frame's *visible*
         // height is overridden to `shaded_frame_height`, but the client's
@@ -2724,7 +2884,9 @@ impl<B: Backend> WindowManager<B> {
     /// in either axis) so `unmaximize` can restore it. No titlebar button
     /// triggers this — see `MaximizeDirections`'s doc comment.
     pub fn maximize(&mut self, id: ClientId, directions: MaximizeDirections) {
+        self.cancel_client_layout_interaction(id);
         self.fit_maximized(id, directions);
+        self.reflow_client_workspace(id);
         tracing::info!(?id, ?directions, "maximized");
     }
 
@@ -2732,16 +2894,37 @@ impl<B: Backend> WindowManager<B> {
     /// refit, where one bar coming up would otherwise log a maximize
     /// per window as if the user had asked for each.
     fn fit_maximized(&mut self, id: ClientId, directions: MaximizeDirections) {
+        if self.clients.get(id).is_some_and(|c| c.flags.contains(ClientFlags::FULLSCREEN)) {
+            // Maximize changes the state underneath fullscreen. Derive its
+            // chrome and workarea geometry from that state, then keep the
+            // visible presentation fullscreen. The backend coalesces these
+            // staged sizes into the operation's final configure.
+            let client = &mut self.clients[id];
+            client.flags.remove(ClientFlags::FULLSCREEN);
+            if let Some(saved) = self.fullscreen_restore.get(&id) {
+                client.geometry = *saved;
+            }
+            self.reflow_frame(id);
+            self.fit_maximized(id, directions);
+            self.fullscreen_restore.insert(id, self.clients[id].geometry);
+            self.clients[id].flags.insert(ClientFlags::FULLSCREEN);
+            self.reflow_frame(id);
+            self.publish_client_net_state(id);
+            return;
+        }
         // The window's *own* monitor, not the primary: a window dragged
         // onto the second head must maximize there. Same frame-center
         // rule fullscreen picks its monitor by (`client_frame_center`),
         // but through that monitor's workarea rather than its raw rect
         // — maximize respects the shell's reserved strip, fullscreen
         // deliberately does not.
-        let usable = match self.client_frame_center(id) {
-            Some(center) => self.usable_area_at(center),
-            None => self.usable_area(),
-        };
+        let index = self.client_output_index(id);
+        let usable = self
+            .workareas
+            .get(index)
+            .copied()
+            .or_else(|| self.backend.monitors_ref().get(index).map(|m| m.geometry))
+            .unwrap_or(NO_MONITOR_FALLBACK);
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2781,17 +2964,23 @@ impl<B: Backend> WindowManager<B> {
     /// Restores the geometry saved by the most recent `maximize` call, if
     /// any (a no-op on an already-unmaximized client).
     pub fn unmaximize(&mut self, id: ClientId) {
+        self.cancel_client_layout_interaction(id);
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
         let Some(restore) = client.restore_geometry.take() else {
             return;
         };
-        client.geometry = restore;
+        if client.flags.contains(ClientFlags::FULLSCREEN) {
+            self.fullscreen_restore.insert(id, restore);
+        } else {
+            client.geometry = restore;
+        }
         client.flags.remove(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
         self.bump_protocol_state_revision();
         self.reflow_frame(id);
         self.publish_client_net_state(id);
+        self.reflow_client_workspace(id);
         tracing::info!(?id, "unmaximized");
     }
 
@@ -2844,6 +3033,10 @@ impl<B: Backend> WindowManager<B> {
     /// untouched, so `unshade` restores exactly. A no-op if already
     /// shaded.
     pub fn shade(&mut self, id: ClientId) {
+        self.cancel_client_layout_interaction(id);
+        if self.is_layout_managed(id) && self.clients[id].chrome == ClientChrome::ServerDrawn {
+            self.set_floating(id, true);
+        }
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2937,15 +3130,10 @@ impl<B: Backend> WindowManager<B> {
     /// `usable_area_at`: fullscreen covers the dock strip too — that's
     /// the whole point of the state.
     fn fullscreen_monitor_rect(&self, id: ClientId) -> Rect {
-        match self.client_frame_center(id) {
-            Some(center) => self.monitor_rect_at(center),
-            None => self
-                .backend
-                .monitors()
-                .get(self.primary_monitor_index())
-                .map(|m| m.geometry)
-                .unwrap_or(NO_MONITOR_FALLBACK),
-        }
+        self.backend
+            .monitors_ref()
+            .get(self.client_output_index(id))
+            .map_or(NO_MONITOR_FALLBACK, |m| m.geometry)
     }
 
     /// Enters EWMH fullscreen: the frame becomes exactly the client's
@@ -2957,6 +3145,7 @@ impl<B: Backend> WindowManager<B> {
     /// still finds its own pre-maximize snapshot intact. A no-op if
     /// already fullscreen.
     pub fn fullscreen(&mut self, id: ClientId) {
+        self.cancel_client_layout_interaction(id);
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -2991,6 +3180,7 @@ impl<B: Backend> WindowManager<B> {
         // windows would be useless.
         self.raise_client(id);
         self.publish_client_net_state(id);
+        self.reflow_client_workspace(id);
         tracing::info!(?id, "entered fullscreen");
     }
 
@@ -2998,6 +3188,7 @@ impl<B: Backend> WindowManager<B> {
     /// on entry through the normal reflow path (theme layout recomputed,
     /// chrome repainted). A no-op if not currently fullscreen.
     pub fn unfullscreen(&mut self, id: ClientId) {
+        self.cancel_client_layout_interaction(id);
         let Some(client) = self.clients.get_mut(id) else {
             return;
         };
@@ -3013,6 +3204,7 @@ impl<B: Backend> WindowManager<B> {
         self.bump_protocol_state_revision();
         self.reflow_frame(id);
         self.publish_client_net_state(id);
+        self.reflow_client_workspace(id);
         tracing::info!(?id, "left fullscreen");
     }
 
@@ -3035,6 +3227,7 @@ impl<B: Backend> WindowManager<B> {
     /// once unmapped, there's nothing left to capture (see
     /// `Backend::capture_window_image`).
     pub fn miniaturize(&mut self, id: ClientId) {
+        self.cancel_client_layout_interaction(id);
         for member in self.transient_family(id) {
             self.miniaturize_one(member);
         }
@@ -3063,6 +3256,7 @@ impl<B: Backend> WindowManager<B> {
         self.focus_successor_of(id);
         self.notifications.push_back(Notification::Miniaturized(id, preview));
         self.publish_client_net_state(id);
+        self.reflow_client_workspace(id);
         tracing::info!(?id, "miniaturized");
     }
 
@@ -3108,6 +3302,7 @@ impl<B: Backend> WindowManager<B> {
         // Painting it ourselves right here removes that dependency on
         // Expose timing entirely instead of hoping one arrives.
         self.repaint_decoration(id);
+        self.reflow_client_workspace(id);
         self.notifications.push_back(Notification::Deminiaturized(id));
         self.publish_client_net_state(id);
         self.focus_client(id);
@@ -3323,6 +3518,7 @@ impl<B: Backend> WindowManager<B> {
                     self.cycle_step(1);
                 }
             }
+            XK_ESCAPE if self.interactive_drag_active() => self.end_active_drag(),
             XK_ESCAPE if self.cycle.is_some() => self.cycle_end(false),
             // Any other key without Alt held means the Alt release was
             // lost (it can slip into the gap before the modal keyboard
@@ -3599,6 +3795,11 @@ impl<B: Backend> WindowManager<B> {
         // focus change pays only a flag comparison.
         self.set_urgent(id, false);
         self.repaint_decoration(id);
+        if self.is_layout_managed(id)
+            && self.workspace_layout(self.clients[id].workspace) == crate::LayoutMode::Flow
+        {
+            self.reflow_client_workspace(id);
+        }
     }
 
     /// Pushes a client's current `_NET_WM_STATE`-relevant flags to the
@@ -3784,6 +3985,7 @@ impl<B: Backend> WindowManager<B> {
         } else {
             self.hide_client_surface(id);
         }
+        self.reflow_client_workspace(id);
     }
 
     /// Publish `_NET_FRAME_EXTENTS` for `id` from whatever its layout
@@ -4016,10 +4218,30 @@ impl<B: Backend> WindowManager<B> {
     /// workspace switching out from under it — goes through here, so
     /// that "the drag is over" and "the pointer is free" cannot come
     /// apart. Safe to call when nothing is dragging.
+    fn commit_active_drag(&mut self) {
+        self.layout_resize_snapshot = None;
+        self.commit_layout_drop();
+        self.end_active_drag();
+    }
+
     fn end_active_drag(&mut self) {
+        self.layout_drop = None;
+        self.backend.preview_layout_drop(None, None);
         let client = self.interactive_drag_client();
         self.active_move = None;
         self.active_resize = None;
+        if let Some(snapshot) = self.layout_resize_snapshot.take() {
+            for (id, weight, width) in snapshot.placements {
+                if let Some(c) = self.clients.get_mut(id) {
+                    c.placement.mosaic_weight = weight;
+                    c.placement.flow_width = width;
+                }
+            }
+            if let Some(layout) = self.layouts.get_mut(snapshot.workspace) {
+                layout.viewports = snapshot.viewports;
+            }
+            self.reflow_workspace(snapshot.workspace);
+        }
         if let Some(handle) = self.drag_grab.take() {
             self.backend.ungrab_pointer(handle);
         }
@@ -4114,14 +4336,7 @@ impl<B: Backend> WindowManager<B> {
         } else {
             (request, client.layout.clone())
         };
-        let frame_rect = Rect {
-            pos: Point::new(
-                client.geometry.pos.x - client.layout.client_offset.x,
-                client.geometry.pos.y - client.layout.client_offset.y,
-            ),
-            size: paint_layout.frame_size,
-        };
-        let scale = self.backend.decoration_scale(frame_rect);
+        let scale = self.client_decoration_scale(id);
         if client.last_decoration_request.as_ref() == Some(&paint_request)
             && client.last_decoration_frame_size == paint_layout.frame_size
             && client.last_decoration_scale_bits == scale.to_bits()
@@ -4249,10 +4464,9 @@ fn union_rect(a: Rect, b: Rect) -> Rect {
 /// Squared distance from `point` to the nearest point of `rect`, `0`
 /// for a point inside it — the ordering `monitor_index_at` picks its
 /// nearest monitor by. Squared because only the ordering matters and a
-/// square root would cost precision for nothing; `i64` because a
-/// desktop spanning several 4K outputs has coordinates whose square
-/// overflows `i32`.
-fn squared_distance_to(rect: Rect, point: Point) -> i64 {
+/// square root would cost precision for nothing. The sum needs `u128`:
+/// restored coordinates can span the full signed range in both axes.
+fn squared_distance_to(rect: Rect, point: Point) -> u128 {
     // `Rect::contains` is half-open, so the last pixel actually inside
     // is one short of the far edge — measuring to the edge itself would
     // report a one-pixel gap as zero distance.
@@ -4260,7 +4474,7 @@ fn squared_distance_to(rect: Rect, point: Point) -> i64 {
     let last_y = rect.pos.y as i64 + rect.size.h as i64 - 1;
     let dx = (rect.pos.x as i64 - point.x as i64).max(point.x as i64 - last_x).max(0);
     let dy = (rect.pos.y as i64 - point.y as i64).max(point.y as i64 - last_y).max(0);
-    dx * dx + dy * dy
+    (dx as u128) * (dx as u128) + (dy as u128) * (dy as u128)
 }
 
 /// The root-coordinate rectangle of a managed client's outer frame.
@@ -9061,6 +9275,8 @@ mod tests {
             top_area,
             "a point nowhere near any output still has to resolve to one"
         );
+        assert_eq!(wm.usable_area_at(Point::new(i32::MIN, i32::MIN)), top_area);
+        assert_eq!(wm.usable_area_at(Point::new(i32::MAX, i32::MAX)), bottom_area);
     }
 
     #[test]
@@ -9098,4 +9314,5 @@ mod tests {
             "_NET_WORKAREA must span every monitor's workarea"
         );
     }
+    mod spatial;
 }

--- a/crates/wm-core/src/manager/spatial_layout.rs
+++ b/crates/wm-core/src/manager/spatial_layout.rs
@@ -1,0 +1,873 @@
+//! Workspace policy lives alongside the existing geometry/lifecycle owner.
+use super::*;
+use crate::spatial::{self, Item, WorkspaceLayout};
+use crate::{LayoutMode, WindowPlacement};
+
+impl<B: Backend> WindowManager<B> {
+    /// A membership/presentation change invalidates a managed drag's targets
+    /// and resize rollback. Finish cancellation before changing that model.
+    pub(super) fn cancel_client_layout_interaction(&mut self, id: ClientId) {
+        let Some(active) = self.interactive_drag_client() else {
+            return;
+        };
+        if active == id
+            || self
+                .clients
+                .get(id)
+                .zip(self.clients.get(active))
+                .is_some_and(|(c, a)| {
+                    c.workspace == a.workspace
+                        && self.workspace_layout(c.workspace) != LayoutMode::Freeform
+                })
+        {
+            self.end_active_drag();
+        }
+    }
+
+    pub fn layout_statistics(&self) -> crate::LayoutStatistics {
+        self.layout_statistics
+    }
+
+    pub fn workspace_layout(&self, workspace: usize) -> LayoutMode {
+        self.layouts
+            .get(workspace)
+            .map_or(LayoutMode::Freeform, |l| l.mode)
+    }
+
+    pub fn layout_order(&self, workspace: usize) -> &[ClientId] {
+        self.layouts
+            .get(workspace)
+            .map_or(&[], |l| l.order.as_slice())
+    }
+
+    pub fn set_workspace_layout(&mut self, workspace: usize, mode: LayoutMode) {
+        if workspace >= MAX_WORKSPACES
+            || (workspace < self.workspace_count && self.workspace_layout(workspace) == mode)
+        {
+            return;
+        }
+        self.end_active_drag();
+        self.workspace_count = self.workspace_count.max(workspace + 1);
+        self.layouts
+            .resize_with(self.workspace_count, WorkspaceLayout::default);
+        self.layouts[workspace].mode = mode;
+        if mode == LayoutMode::Freeform {
+            let order = self.layouts[workspace].order.clone();
+            for id in order {
+                self.restore_freeform_view(id);
+            }
+        } else {
+            self.reflow_workspace(workspace);
+        }
+        self.bump_protocol_state_revision();
+        self.backend
+            .publish_workspaces(self.workspace_count, self.current_workspace);
+        if workspace == self.current_workspace {
+            self.notifications
+                .push_back(Notification::LayoutChanged(mode));
+        }
+    }
+
+    pub(super) fn restore_freeform_view(&mut self, id: ClientId) {
+        let Some(c) = self.clients.get_mut(id) else {
+            return;
+        };
+        c.layout_excluded = false;
+        c.placement.output = None;
+        if let Some(saved) = c.placement.freeform.take() {
+            self.restore_freeform_geometry(id, saved);
+        }
+        self.clear_layout_clip(id);
+    }
+
+    /// Membership changes update the base of a special presentation's restore
+    /// chain. Fullscreen over maximize still restores through both states.
+    pub(super) fn restore_freeform_geometry(&mut self, id: ClientId, saved: Rect) {
+        let c = &mut self.clients[id];
+        if c.restore_geometry.is_some() {
+            c.restore_geometry = Some(saved);
+        }
+        let maximized = c
+            .flags
+            .intersects(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V);
+        if !maximized {
+            if let Some(restore) = self.fullscreen_restore.get_mut(&id) {
+                *restore = saved;
+            }
+        }
+        if !maximized && !c.flags.contains(ClientFlags::FULLSCREEN) {
+            self.apply_layout_geometry(id, saved, None);
+        }
+    }
+
+    pub fn toggle_workspace_layout(&mut self) {
+        let mode = match self.workspace_layout(self.current_workspace) {
+            LayoutMode::Mosaic => LayoutMode::Flow,
+            LayoutMode::Freeform | LayoutMode::Flow => LayoutMode::Mosaic,
+        };
+        self.set_workspace_layout(self.current_workspace, mode);
+    }
+
+    pub(super) fn layout_candidate(&self, id: ClientId) -> bool {
+        self.clients.get(id).is_some_and(|c| {
+            self.workspace_layout(c.workspace) != LayoutMode::Freeform
+                && !c.placement.floating
+                && c.parent.is_none()
+                && c.lifecycle == Lifecycle::Normal
+                && !c.flags.intersects(
+                    ClientFlags::STICKY
+                        | ClientFlags::MODAL
+                        | ClientFlags::NO_FOCUS
+                        | ClientFlags::SHADED
+                        | ClientFlags::FULLSCREEN
+                        | ClientFlags::MAXIMIZED_H
+                        | ClientFlags::MAXIMIZED_V,
+                )
+        })
+    }
+
+    pub fn is_layout_managed(&self, id: ClientId) -> bool {
+        self.layout_candidate(id) && !self.clients[id].layout_excluded
+    }
+
+    pub fn toggle_floating(&mut self, id: ClientId) {
+        let Some(c) = self.clients.get(id) else {
+            return;
+        };
+        // Every window already floats in Freeform. Do not invisibly change
+        // its membership in a future style when this shortcut has no effect.
+        if self.workspace_layout(c.workspace) == LayoutMode::Freeform {
+            return;
+        }
+        self.set_floating(id, !c.placement.floating);
+    }
+
+    pub fn set_floating(&mut self, id: ClientId, floating: bool) {
+        let Some(c) = self.clients.get(id) else {
+            return;
+        };
+        if c.placement.floating == floating {
+            return;
+        }
+        if self.interactive_drag_active() {
+            self.end_active_drag();
+        }
+        let c = &mut self.clients[id];
+        c.placement.floating = floating;
+        let workspace = c.workspace;
+        let saved = c.placement.freeform;
+        if floating {
+            if let Some(saved) = saved {
+                self.restore_freeform_geometry(id, saved);
+            }
+            self.clear_layout_clip(id);
+        } else {
+            self.unshade(id);
+        }
+        self.reflow_workspace(workspace);
+        self.bump_protocol_state_revision();
+    }
+
+    /// Restored indices may arrive out of order. The shell supplies the saved
+    /// ordering after it matches an application; no stale runtime IDs persist.
+    pub fn restore_window_placement(
+        &mut self,
+        id: ClientId,
+        placement: WindowPlacement,
+        index: usize,
+    ) {
+        let Some(c) = self.clients.get_mut(id) else {
+            return;
+        };
+        c.placement = placement;
+        c.layout_restore_order = Some(index);
+        let workspace = c.workspace;
+        self.layouts
+            .resize_with(self.workspace_count, WorkspaceLayout::default);
+        let order = &mut self.layouts[workspace].order;
+        order.retain(|&other| other != id);
+        order.push(id);
+        order.sort_by_key(|&id| self.clients[id].layout_restore_order.unwrap_or(usize::MAX));
+        self.reflow_workspace(workspace);
+        self.bump_protocol_state_revision();
+    }
+
+    pub(super) fn register_layout_client(&mut self, id: ClientId) {
+        let workspace = self.clients[id].workspace;
+        self.layouts
+            .resize_with(self.workspace_count, WorkspaceLayout::default);
+        let order = &mut self.layouts[workspace].order;
+        if order.contains(&id) {
+            return;
+        }
+        let index = self
+            .focused
+            .and_then(|focused| order.iter().position(|&c| c == focused))
+            .map_or(order.len(), |i| i + 1);
+        order.insert(index, id);
+    }
+
+    pub(super) fn layout_output_key(monitor: &MonitorInfo) -> &str {
+        monitor.identity.as_deref().unwrap_or(&monitor.name)
+    }
+
+    /// Flow positions may be outside every output: never infer ownership from
+    /// its current frame center once an output affinity has been recorded.
+    pub fn client_output_index(&self, id: ClientId) -> usize {
+        let Some(c) = self.clients.get(id) else {
+            return self.primary_monitor_index();
+        };
+        if self.workspace_layout(c.workspace) != LayoutMode::Freeform
+            && !c.placement.floating
+            && !c.flags.contains(ClientFlags::STICKY)
+        {
+            if let Some(key) = c.placement.output.as_deref() {
+                return self
+                    .backend
+                    .monitors_ref()
+                    .iter()
+                    .position(|m| Self::layout_output_key(m) == key)
+                    .unwrap_or_else(|| self.primary_monitor_index());
+            }
+        }
+        self.monitor_index_at(self.client_frame_center(id).unwrap_or(c.geometry.pos))
+    }
+
+    pub(super) fn client_decoration_scale(&self, id: ClientId) -> f32 {
+        let c = &self.clients[id];
+        let rect = if self.workspace_layout(c.workspace) != LayoutMode::Freeform
+            && !c.placement.floating
+        {
+            self.backend
+                .monitors_ref()
+                .get(self.client_output_index(id))
+                .map_or(client_frame_rect(c), |m| m.geometry)
+        } else {
+            client_frame_rect(c)
+        };
+        self.backend.decoration_scale(rect)
+    }
+
+    pub fn move_client_to_output(&mut self, id: ClientId, index: usize) -> bool {
+        self.cancel_client_layout_interaction(id);
+        self.place_client_on_output(id, index)
+    }
+
+    fn place_client_on_output(&mut self, id: ClientId, index: usize) -> bool {
+        let Some(monitor) = self.backend.monitors_ref().get(index) else {
+            return false;
+        };
+        let key = Self::layout_output_key(monitor).to_string();
+        let area = self
+            .workareas
+            .get(index)
+            .copied()
+            .unwrap_or(monitor.geometry);
+        let Some(c) = self.clients.get_mut(id) else {
+            return false;
+        };
+        c.placement.output = Some(key);
+        let workspace = c.workspace;
+        let fullscreen = c.flags.contains(ClientFlags::FULLSCREEN);
+        let mut maximized = MaximizeDirections::empty();
+        maximized.set(
+            MaximizeDirections::HORIZONTAL,
+            c.flags.contains(ClientFlags::MAXIMIZED_H),
+        );
+        maximized.set(
+            MaximizeDirections::VERTICAL,
+            c.flags.contains(ClientFlags::MAXIMIZED_V),
+        );
+        if self.workspace_layout(workspace) == LayoutMode::Freeform
+            || self.clients[id].placement.floating
+        {
+            let c = &self.clients[id];
+            let mut rect = c.geometry;
+            rect.pos = Point::new(
+                area.pos.x + c.layout.client_offset.x,
+                area.pos.y + c.layout.client_offset.y,
+            );
+            self.set_client_content_geometry(id, rect);
+        } else {
+            if fullscreen {
+                self.reflow_frame(id);
+            } else if !maximized.is_empty() {
+                self.fit_maximized(id, maximized);
+            }
+            self.reflow_workspace(workspace);
+        }
+        self.bump_protocol_state_revision();
+        true
+    }
+
+    pub(super) fn remember_freeform(&mut self, id: ClientId) {
+        let index = self.client_output_index(id);
+        let output = self
+            .backend
+            .monitors_ref()
+            .get(index)
+            .map(|m| Self::layout_output_key(m).to_string());
+        let c = &mut self.clients[id];
+        if c.placement.freeform.is_none() {
+            c.placement.freeform = Some(
+                c.restore_geometry
+                    .or_else(|| self.fullscreen_restore.get(&id).copied())
+                    .unwrap_or(c.geometry),
+            );
+        }
+        if c.placement.output.is_none() {
+            c.placement.output = output;
+        }
+    }
+
+    pub(super) fn clear_layout_clip(&mut self, id: ClientId) {
+        if let Some(c) = self.clients.get(id) {
+            let rect = client_frame_rect(c);
+            self.backend
+                .present_layout(c.window, c.frame, rect, rect, None, false);
+        }
+    }
+
+    fn reachable_freeform(&self, id: ClientId, mut geometry: Rect) -> Rect {
+        let Some(c) = self.clients.get(id) else {
+            return geometry;
+        };
+        let pos = Point::new(
+            geometry.pos.x.saturating_sub(c.layout.client_offset.x),
+            geometry.pos.y.saturating_sub(c.layout.client_offset.y),
+        );
+        let size = Size::new(
+            geometry
+                .size
+                .w
+                .saturating_add(c.layout.frame_size.w.saturating_sub(c.geometry.size.w)),
+            geometry
+                .size
+                .h
+                .saturating_add(c.layout.frame_size.h.saturating_sub(c.geometry.size.h)),
+        );
+        let reachable = self.backend.monitors_ref().iter().any(|m| {
+            pos.x as i64 + size.w as i64 > m.geometry.pos.x as i64 + 32
+                && (pos.x as i64) < m.geometry.pos.x as i64 + m.geometry.size.w as i64 - 32
+                && pos.y >= m.geometry.pos.y
+                && (pos.y as i64) < m.geometry.pos.y as i64 + m.geometry.size.h as i64 - 16
+        });
+        if !reachable {
+            let target = self.usable_area_at(pos);
+            let pos = placement::clamp_to(target, size, pos);
+            geometry.pos = Point::new(
+                pos.x.saturating_add(c.layout.client_offset.x),
+                pos.y.saturating_add(c.layout.client_offset.y),
+            );
+        }
+        geometry
+    }
+
+    pub(super) fn apply_layout_geometry(
+        &mut self,
+        id: ClientId,
+        geometry: Rect,
+        clip: Option<Rect>,
+    ) {
+        let geometry = if clip.is_none() {
+            self.reachable_freeform(id, geometry)
+        } else {
+            geometry
+        };
+        let Some(c) = self.clients.get_mut(id) else {
+            return;
+        };
+        let source = client_frame_rect(c);
+        // Establish output presentation before staging the configure: Flow
+        // may put the final frame outside the owning monitor entirely.
+        self.backend
+            .present_layout(c.window, c.frame, source, source, clip, false);
+        if c.geometry != geometry {
+            self.layout_statistics.geometry_changes += 1;
+            c.geometry = geometry;
+            self.reflow_frame(id);
+        }
+        let c = &self.clients[id];
+        self.backend.present_layout(
+            c.window,
+            c.frame,
+            source,
+            client_frame_rect(c),
+            clip,
+            self.active_resize.is_none(),
+        );
+    }
+
+    pub(super) fn reflow_client_workspace(&mut self, id: ClientId) {
+        if let Some(workspace) = self.clients.get(id).map(|c| c.workspace) {
+            self.reflow_workspace(workspace);
+        }
+    }
+
+    pub(super) fn reflow_layouts(&mut self) {
+        for workspace in 0..self.workspace_count {
+            self.reflow_workspace(workspace);
+        }
+    }
+
+    pub(super) fn reflow_workspace(&mut self, workspace: usize) {
+        let mode = self.workspace_layout(workspace);
+        if mode == LayoutMode::Freeform {
+            return;
+        }
+        let started = std::time::Instant::now();
+        let order = self.layouts[workspace].order.clone();
+        for &id in &order {
+            if self.layout_candidate(id) {
+                self.remember_freeform(id);
+            } else {
+                self.clear_layout_clip(id);
+            }
+        }
+        let monitors = self.backend.monitors();
+        for (index, monitor) in monitors.iter().enumerate() {
+            let area = self
+                .workareas
+                .get(index)
+                .copied()
+                .unwrap_or(monitor.geometry);
+            let scale = (self.backend.decoration_scale(monitor.geometry) as f64).clamp(0.25, 8.0);
+            let logical = Size::new(
+                (area.size.w as f64 / scale).floor() as u32,
+                (area.size.h as f64 / scale).floor() as u32,
+            );
+            let ids: Vec<_> = order
+                .iter()
+                .copied()
+                .filter(|&id| self.layout_candidate(id) && self.client_output_index(id) == index)
+                .collect();
+            let decorations: Vec<_> = ids
+                .iter()
+                .map(|&id| {
+                    let c = &self.clients[id];
+                    if c.chrome == ClientChrome::ClientDrawn {
+                        frameless_layout(c.geometry.size)
+                    } else {
+                        self.theme
+                            .layout_at(&Self::decoration_request(c, None), scale as f32)
+                    }
+                })
+                .collect();
+            let items: Vec<_> = ids
+                .iter()
+                .zip(&decorations)
+                .map(|(&id, layout)| {
+                    let c = &self.clients[id];
+                    let min = self
+                        .backend
+                        .size_hints(c.window)
+                        .min_size
+                        .unwrap_or(Size::new(1, 1));
+                    Item {
+                        min: Size::new(
+                            ((min.w.saturating_add(
+                                layout.frame_size.w.saturating_sub(c.geometry.size.w),
+                            )) as f64
+                                / scale)
+                                .ceil() as u32,
+                            ((min.h.saturating_add(
+                                layout.frame_size.h.saturating_sub(c.geometry.size.h),
+                            )) as f64
+                                / scale)
+                                .ceil() as u32,
+                        ),
+                        weight: c.placement.mosaic_weight,
+                        width: c.placement.flow_width,
+                    }
+                })
+                .collect();
+            let focused = self
+                .focused
+                .and_then(|id| ids.iter().position(|&i| i == id));
+            let rects = match mode {
+                LayoutMode::Mosaic => spatial::mosaic(logical, &items),
+                LayoutMode::Flow => {
+                    let viewport = self.layouts[workspace]
+                        .viewports
+                        .entry(Self::layout_output_key(monitor).to_string())
+                        .or_default();
+                    spatial::flow(logical, &items, focused, viewport)
+                }
+                LayoutMode::Freeform => unreachable!(),
+            };
+            for ((id, rect), layout) in ids.into_iter().zip(rects).zip(decorations) {
+                self.clients[id].layout_excluded = rect.is_none();
+                let Some(rect) = rect else {
+                    if let Some(saved) = self.clients[id].placement.freeform {
+                        self.apply_layout_geometry(id, saved, None);
+                    }
+                    continue;
+                };
+                let c = &self.clients[id];
+                // Convert both edges, so fractional-scale rounding cannot
+                // create overlapping neighboring frames.
+                let edge = |v: i64| (v as f64 * scale).round() as i32;
+                let frame = Rect {
+                    pos: Point::new(
+                        area.pos.x.saturating_add(edge(rect.pos.x as i64)),
+                        area.pos.y.saturating_add(edge(rect.pos.y as i64)),
+                    ),
+                    size: Size::new(
+                        (edge(rect.pos.x as i64 + rect.size.w as i64) - edge(rect.pos.x as i64))
+                            .max(1) as u32,
+                        (edge(rect.pos.y as i64 + rect.size.h as i64) - edge(rect.pos.y as i64))
+                            .max(1) as u32,
+                    ),
+                };
+                let candidate = Size::new(
+                    frame
+                        .size
+                        .w
+                        .saturating_sub(layout.frame_size.w.saturating_sub(c.geometry.size.w))
+                        .max(1),
+                    frame
+                        .size
+                        .h
+                        .saturating_sub(layout.frame_size.h.saturating_sub(c.geometry.size.h))
+                        .max(1),
+                );
+                let constrained =
+                    resize::constrain_size(candidate, self.backend.size_hints(c.window));
+                let size = Size::new(
+                    constrained.w.min(candidate.w),
+                    constrained.h.min(candidate.h),
+                );
+                let geometry = Rect {
+                    pos: Point::new(
+                        frame.pos.x + layout.client_offset.x,
+                        frame.pos.y + layout.client_offset.y,
+                    ),
+                    size,
+                };
+                if mode == LayoutMode::Flow && c.placement.flow_width == 0 {
+                    self.clients[id].placement.flow_width = rect.size.w;
+                }
+                self.apply_layout_geometry(id, geometry, Some(area));
+            }
+        }
+        self.bump_protocol_state_revision();
+        self.layout_statistics.calculations += 1;
+        self.layout_statistics.calculation_us += started.elapsed().as_micros();
+        self.layout_statistics.managed_windows = order
+            .iter()
+            .filter(|&&id| self.is_layout_managed(id))
+            .count();
+    }
+
+    pub(super) fn layout_neighbor(
+        &self,
+        id: ClientId,
+        direction: FocusDirection,
+    ) -> Option<ClientId> {
+        let c = self.clients.get(id)?;
+        if self.workspace_layout(c.workspace) == LayoutMode::Flow
+            && matches!(direction, FocusDirection::Up | FocusDirection::Down)
+        {
+            return None;
+        }
+        let source = client_frame_rect(c);
+        self.layout_order(c.workspace)
+            .iter()
+            .copied()
+            .filter(|&other| {
+                other != id
+                    && self.is_layout_managed(other)
+                    && self.client_output_index(other) == self.client_output_index(id)
+            })
+            .filter_map(|other| {
+                directional_score(source, client_frame_rect(&self.clients[other]), direction)
+                    .map(|score| (other, score))
+            })
+            .min_by_key(|(_, score)| *score)
+            .map(|(id, _)| id)
+    }
+
+    pub(super) fn layout_neighbor_across_outputs(
+        &self,
+        id: ClientId,
+        direction: FocusDirection,
+    ) -> Option<ClientId> {
+        let c = &self.clients[id];
+        if self.workspace_layout(c.workspace) == LayoutMode::Flow
+            && matches!(direction, FocusDirection::Up | FocusDirection::Down)
+        {
+            return None;
+        }
+        let output = self.client_output_index(id);
+        self.layout_order(c.workspace)
+            .iter()
+            .copied()
+            .filter(|&other| {
+                self.is_layout_managed(other) && self.client_output_index(other) != output
+            })
+            .filter_map(|other| {
+                let rect = client_frame_rect(&self.clients[other]);
+                let monitor = self
+                    .backend
+                    .monitors_ref()
+                    .get(self.client_output_index(other))?;
+                let center = Point::new(
+                    rect.pos.x + rect.size.w as i32 / 2,
+                    rect.pos.y + rect.size.h as i32 / 2,
+                );
+                if !monitor.geometry.contains(center) {
+                    return None;
+                }
+                directional_score(client_frame_rect(c), rect, direction).map(|score| (other, score))
+            })
+            .min_by_key(|(_, score)| *score)
+            .map(|(id, _)| id)
+    }
+
+    pub fn move_layout_window(&mut self, id: ClientId, direction: FocusDirection) -> bool {
+        if !self.is_layout_managed(id) {
+            return false;
+        }
+        if self.interactive_drag_active() {
+            self.end_active_drag();
+        }
+        if self.workspace_layout(self.clients[id].workspace) == LayoutMode::Flow
+            && matches!(direction, FocusDirection::Up | FocusDirection::Down)
+        {
+            return false;
+        }
+        if let Some(target) = self.layout_neighbor(id, direction) {
+            self.reorder_layout_window(id, target);
+            return true;
+        }
+        let output = self.client_output_index(id);
+        let Some(source) = self.backend.monitors_ref().get(output).map(|m| m.geometry) else {
+            return false;
+        };
+        let next = self
+            .backend
+            .monitors_ref()
+            .iter()
+            .enumerate()
+            .filter(|(index, _)| *index != output)
+            .filter_map(|(index, m)| {
+                directional_score(source, m.geometry, direction).map(|score| (index, score))
+            })
+            .min_by_key(|(_, score)| *score)
+            .map(|(index, _)| index);
+        next.is_some_and(|index| self.move_client_to_output(id, index))
+    }
+
+    pub(super) fn reorder_layout_window(&mut self, id: ClientId, target: ClientId) {
+        let Some(c) = self.clients.get(id) else {
+            return;
+        };
+        let workspace = c.workspace;
+        let order = &mut self.layouts[workspace].order;
+        let (Some(from), Some(to)) = (
+            order.iter().position(|&i| i == id),
+            order.iter().position(|&i| i == target),
+        ) else {
+            return;
+        };
+        order.remove(from);
+        order.insert(to, id);
+        self.reflow_workspace(workspace);
+    }
+
+    /// Keyboard and pointer resizing share this boundary policy. Mosaic
+    /// changes the nearest shared boundary; Flow changes only this width.
+    pub fn resize_layout_window(&mut self, id: ClientId, delta: Point) -> bool {
+        if self.interactive_drag_active() && self.is_layout_managed(id) {
+            self.end_active_drag();
+        }
+        self.resize_managed(id, delta, None)
+    }
+
+    pub(super) fn resize_managed(
+        &mut self,
+        id: ClientId,
+        delta: Point,
+        edge: Option<ResizeEdge>,
+    ) -> bool {
+        if !self.is_layout_managed(id) {
+            return false;
+        }
+        let c = &self.clients[id];
+        let workspace = c.workspace;
+        let mode = self.workspace_layout(workspace);
+        let source = client_frame_rect(c);
+        let scale = self
+            .backend
+            .monitors_ref()
+            .get(self.client_output_index(id))
+            .map_or(1.0, |m| self.backend.decoration_scale(m.geometry) as f64);
+        if mode == LayoutMode::Flow {
+            let output = self.client_output_index(id);
+            let area = self
+                .workareas
+                .get(output)
+                .copied()
+                .or_else(|| self.backend.monitors_ref().get(output).map(|m| m.geometry))
+                .unwrap_or(NO_MONITOR_FALLBACK);
+            // Start from the visible width, so reversing at a size limit
+            // responds immediately instead of undoing invisible overshoot.
+            let width = ((source.size.w as i64 + delta.x as i64) as f64 / scale).round();
+            let limit = (area.size.w as f64 / scale).floor().clamp(1.0, 65536.0);
+            let c = &mut self.clients[id];
+            c.placement.flow_width = width.clamp(1.0, limit) as u32;
+        } else {
+            for (axis, amount, forward, backward) in [
+                (0, delta.x, FocusDirection::Right, FocusDirection::Left),
+                (1, delta.y, FocusDirection::Down, FocusDirection::Up),
+            ] {
+                if amount == 0 {
+                    continue;
+                }
+                let output = self.client_output_index(id);
+                let area = self
+                    .workareas
+                    .get(output)
+                    .copied()
+                    .or_else(|| self.backend.monitors_ref().get(output).map(|m| m.geometry))
+                    .unwrap_or(NO_MONITOR_FALLBACK);
+                let portrait = area.size.h > area.size.w;
+                let neighbor = |direction| {
+                    self.layout_order(workspace)
+                        .iter()
+                        .copied()
+                        .filter(|&other| {
+                            other != id
+                                && self.is_layout_managed(other)
+                                && self.client_output_index(other) == output
+                        })
+                        .filter_map(|other| {
+                            let rect = client_frame_rect(&self.clients[other]);
+                            // Inside a column (or portrait row), only its own
+                            // shared boundary can resize these two cells.
+                            if axis == 1 && !portrait && rect.pos.x != source.pos.x {
+                                return None;
+                            }
+                            if axis == 0 && portrait && rect.pos.y != source.pos.y {
+                                return None;
+                            }
+                            directional_score(source, rect, direction).map(|score| (other, score))
+                        })
+                        .min_by_key(|(_, score)| *score)
+                        .map(|(id, _)| id)
+                };
+                let other = match edge {
+                    Some(edge) => {
+                        let reverse = if axis == 0 {
+                            matches!(
+                                edge,
+                                ResizeEdge::West | ResizeEdge::NorthWest | ResizeEdge::SouthWest
+                            )
+                        } else {
+                            matches!(
+                                edge,
+                                ResizeEdge::North | ResizeEdge::NorthEast | ResizeEdge::NorthWest
+                            )
+                        };
+                        neighbor(if reverse { backward } else { forward })
+                    }
+                    None => neighbor(forward).or_else(|| neighbor(backward)),
+                };
+                let Some(other) = other else {
+                    continue;
+                };
+                let neighbor = client_frame_rect(&self.clients[other]);
+                let (a, b) = if axis == 0 {
+                    (source.size.w, neighbor.size.w)
+                } else {
+                    (source.size.h, neighbor.size.h)
+                };
+                let changed = (a as i64 + amount as i64).clamp(1, a as i64 + b as i64 - 1) as u32;
+                // All cells sharing this boundary carry the same width
+                // proportion, so resizing a column never tears its edges.
+                let ids = self.layouts[workspace].order.clone();
+                for &candidate in &ids {
+                    if self.is_layout_managed(candidate) {
+                        let frame = client_frame_rect(&self.clients[candidate]);
+                        self.clients[candidate].placement.mosaic_weight[axis] = if axis == 0 {
+                            frame.size.w
+                        } else {
+                            frame.size.h
+                        };
+                    }
+                }
+                for candidate in ids {
+                    if !self.is_layout_managed(candidate)
+                        || self.client_output_index(candidate) != self.client_output_index(id)
+                    {
+                        continue;
+                    }
+                    let rect = client_frame_rect(&self.clients[candidate]);
+                    let aligned = if axis == 0 && !portrait {
+                        (rect.pos.x == source.pos.x, rect.pos.x == neighbor.pos.x)
+                    } else if axis == 1 && portrait {
+                        (rect.pos.y == source.pos.y, rect.pos.y == neighbor.pos.y)
+                    } else {
+                        (candidate == id, candidate == other)
+                    };
+                    let value = if aligned.0 {
+                        Some(changed)
+                    } else if aligned.1 {
+                        Some(a + b - changed)
+                    } else {
+                        None
+                    };
+                    if let Some(value) = value {
+                        self.clients[candidate].placement.mosaic_weight[axis] = value;
+                    }
+                }
+            }
+        }
+        self.reflow_workspace(workspace);
+        true
+    }
+
+    pub(super) fn preview_managed_move(&mut self, id: ClientId, root: Point) {
+        let workspace = self.clients[id].workspace;
+        let target = self
+            .layout_order(workspace)
+            .iter()
+            .copied()
+            .filter(|&other| other != id && self.is_layout_managed(other))
+            .find(|&other| client_frame_rect(&self.clients[other]).contains(root));
+        let next = target.map(|target| (id, target));
+        self.layout_drop = next;
+        let c = &self.clients[id];
+        let source = client_frame_rect(c);
+        let offset = self
+            .active_move
+            .as_ref()
+            .map_or(Point::new(0, 0), |m| m.grab_offset);
+        let destination = Rect::new(
+            Point::new(root.x - offset.x, root.y - offset.y),
+            source.size,
+        );
+        self.backend.preview_layout_drop(
+            Some(crate::LayoutDrag {
+                window: c.window,
+                frame: c.frame,
+                source,
+                destination,
+            }),
+            target.map(|target| client_frame_rect(&self.clients[target])),
+        );
+    }
+
+    pub(super) fn commit_layout_drop(&mut self) {
+        if let Some((id, target)) = self.layout_drop.take() {
+            if self.is_layout_managed(id) && self.is_layout_managed(target) {
+                let output = self.client_output_index(target);
+                if self.client_output_index(id) != output {
+                    self.place_client_on_output(id, output);
+                }
+                self.reorder_layout_window(id, target);
+            }
+        }
+        self.backend.preview_layout_drop(None, None);
+    }
+}

--- a/crates/wm-core/src/manager/tests/spatial.rs
+++ b/crates/wm-core/src/manager/tests/spatial.rs
@@ -1,0 +1,767 @@
+//! Behavior of the three workspace styles through the real WindowManager.
+use super::*;
+
+#[test]
+fn spatial_extreme_restored_positions_are_rescued_when_leaving_a_layout() {
+    for pos in [
+        Point::new(i32::MIN, i32::MIN),
+        Point::new(i32::MAX, i32::MAX),
+    ] {
+        for float_first in [false, true] {
+            let (mut wm, ids) = spatial_desktop(1);
+            let id = ids[0];
+            wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+            let mut placement = wm.clients[id].placement.clone();
+            placement.freeform = Some(Rect::new(pos, Size::new(500, 400)));
+            wm.restore_window_placement(id, placement, 0);
+            if float_first {
+                wm.toggle_floating(id);
+            }
+            wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+            let frame = client_frame_rect(&wm.clients[id]);
+            assert!(wm
+                .backend
+                .monitors_ref()
+                .iter()
+                .any(|m| m.geometry.contains(frame.pos)));
+            assert_eq!(wm.clients[id].geometry.size, Size::new(500, 400));
+            assert_eq!(wm.focused_client(), Some(id));
+        }
+    }
+}
+
+#[test]
+fn spatial_late_size_constraints_reflow_and_recover_without_losing_placement() {
+    let (mut wm, ids) = spatial_desktop(3);
+    let id = ids[1];
+    let window = wm.clients[id].window;
+    let base = wm.clients[id].geometry;
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    let order = wm.layout_order(0).to_vec();
+    wm.backend_mut().set_size_hints(
+        window,
+        SizeHints {
+            min_size: Some(Size::new(1200, 1000)),
+            ..Default::default()
+        },
+    );
+    wm.dispatch(BackendEvent::SizeHintsChanged(window));
+    assert!(wm.is_layout_managed(id));
+    assert!(wm.clients[id].geometry.size.w >= 1200 && wm.clients[id].geometry.size.h >= 1000);
+    wm.backend_mut().set_size_hints(
+        window,
+        SizeHints {
+            min_size: Some(Size::new(10_000, 10_000)),
+            ..Default::default()
+        },
+    );
+    wm.dispatch(BackendEvent::SizeHintsChanged(window));
+    assert!(!wm.is_layout_managed(id));
+    assert_eq!(wm.clients[id].geometry, base);
+    wm.backend_mut()
+        .set_size_hints(window, SizeHints::default());
+    wm.dispatch(BackendEvent::SizeHintsChanged(window));
+    assert!(wm.is_layout_managed(id));
+    assert_eq!(wm.layout_order(0), order);
+    wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+    assert_eq!(wm.clients[id].geometry, base);
+}
+
+#[test]
+fn spatial_a_quick_second_drag_never_shades_or_floats_the_window() {
+    for mode in [
+        crate::LayoutMode::Freeform,
+        crate::LayoutMode::Mosaic,
+        crate::LayoutMode::Flow,
+    ] {
+        let (mut wm, ids) = spatial_desktop(3);
+        let id = ids[0];
+        wm.set_workspace_layout(0, mode);
+        let frame = wm.clients[id].frame.unwrap();
+        let local = Point::new(30, 2);
+        wm.dispatch(titlebar_press(frame, local, 0, Modifiers::empty()));
+        let geometry = client_frame_rect(&wm.clients[id]);
+        wm.handle_pointer_motion(Point::new(geometry.pos.x + 200, geometry.pos.y + 100));
+        wm.dispatch(BackendEvent::DragCancelled);
+        wm.dispatch(titlebar_press(frame, local, 150, Modifiers::empty()));
+        assert!(wm.interactive_drag_active());
+        assert!(!wm.clients[id].flags.contains(ClientFlags::SHADED));
+        assert!(!wm.clients[id].placement.floating);
+    }
+}
+
+#[test]
+fn spatial_maximize_can_change_under_fullscreen_without_losing_the_base_geometry() {
+    for mode in [
+        crate::LayoutMode::Freeform,
+        crate::LayoutMode::Mosaic,
+        crate::LayoutMode::Flow,
+    ] {
+        let (mut wm, ids) = spatial_desktop(3);
+        let id = ids[1];
+        let base = wm.clients[id].geometry;
+        wm.set_workspace_layout(0, mode);
+        wm.maximize(id, MaximizeDirections::FULL);
+        wm.fullscreen(id);
+        let full = wm.clients[id].geometry;
+        wm.unmaximize(id);
+        assert_eq!(wm.clients[id].geometry, full);
+        wm.maximize(id, MaximizeDirections::FULL);
+        assert_eq!(wm.clients[id].geometry, full);
+        wm.unfullscreen(id);
+        assert!(wm.clients[id]
+            .flags
+            .contains(ClientFlags::MAXIMIZED_H | ClientFlags::MAXIMIZED_V));
+        wm.unmaximize(id);
+        wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+        assert_eq!(wm.clients[id].geometry, base);
+    }
+}
+
+#[test]
+fn spatial_generated_lifecycle_sequences_preserve_membership_focus_and_freeform_intent() {
+    use crate::LayoutMode::*;
+    for seed in 1..=32u64 {
+        let (mut wm, ids) = spatial_desktop(4);
+        let originals: Vec<_> = ids.iter().map(|&id| wm.clients[id].geometry).collect();
+        let mut random = seed;
+        for step in 0..120 {
+            random = random.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let id = ids[(random >> 32) as usize % ids.len()];
+            let workspace = wm.clients[id].workspace;
+            match (random >> 40) % 12 {
+                0 => wm.set_workspace_layout(workspace, Mosaic),
+                1 => wm.set_workspace_layout(workspace, Flow),
+                2 => wm.set_workspace_layout(workspace, Freeform),
+                3 => wm.toggle_floating(id),
+                4 => wm.toggle_fullscreen(id),
+                5 => wm.toggle_maximize(id, MaximizeDirections::FULL),
+                6 => wm.miniaturize(id),
+                7 => wm.deminiaturize(id),
+                8 => {
+                    wm.set_client_pinned(id, !wm.clients[id].flags.contains(ClientFlags::STICKY));
+                }
+                9 => wm.move_client_to_workspace(id, 1 - workspace),
+                10 => {
+                    wm.resize_layout_window(id, Point::new((random % 201) as i32 - 100, 0));
+                }
+                _ => wm.switch_workspace(1 - wm.current_workspace),
+            }
+            let ordered: Vec<_> = wm
+                .layouts
+                .iter()
+                .flat_map(|l| l.order.iter().copied())
+                .collect();
+            assert_eq!(ordered.len(), ids.len(), "seed {seed}, step {step}");
+            for &id in &ids {
+                assert_eq!(ordered.iter().filter(|&&other| other == id).count(), 1);
+                assert!(wm.layout_order(wm.clients[id].workspace).contains(&id));
+                if let Some(saved) = wm.clients[id].placement.freeform {
+                    assert_eq!(
+                        saved,
+                        originals[ids.iter().position(|&other| other == id).unwrap()],
+                        "seed {seed}, step {step}"
+                    );
+                }
+            }
+            let flagged: Vec<_> = wm
+                .clients
+                .iter()
+                .filter(|(_, c)| c.flags.contains(ClientFlags::FOCUSED))
+                .map(|(id, _)| id)
+                .collect();
+            assert_eq!(
+                flagged,
+                wm.focused_client().into_iter().collect::<Vec<_>>(),
+                "seed {seed}, step {step}"
+            );
+            if let Some(focused) = wm.focused_client() {
+                assert!(wm.is_focusable(focused), "seed {seed}, step {step}");
+            }
+        }
+        for &id in &ids {
+            wm.unfullscreen(id);
+            wm.unmaximize(id);
+            wm.deminiaturize(id);
+            wm.set_client_pinned(id, false);
+        }
+        for workspace in 0..wm.workspace_count() {
+            wm.set_workspace_layout(workspace, Freeform);
+        }
+        for (&id, original) in ids.iter().zip(originals) {
+            assert_eq!(wm.clients[id].geometry, original, "seed {seed}");
+        }
+    }
+}
+
+#[test]
+fn spatial_pinning_an_offscreen_flow_window_makes_it_reachable_and_rejoining_is_reversible() {
+    let (mut wm, ids) = spatial_desktop(8);
+    let id = ids[0];
+    let original = wm.clients[id].geometry;
+    let focus = wm.focused_client();
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    assert!(wm.clients[id].geometry.pos.x < 0);
+    let order = wm.layout_order(0).to_vec();
+    assert!(wm.set_client_pinned(id, true));
+    assert_eq!(wm.clients[id].geometry, original);
+    assert_eq!(wm.focused_client(), focus);
+    assert!(wm.set_client_pinned(id, false));
+    assert!(wm.is_layout_managed(id));
+    assert_eq!(wm.layout_order(0), order);
+    wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+    assert_eq!(wm.clients[id].geometry, original);
+}
+
+#[test]
+fn spatial_moving_a_special_window_to_an_output_refits_its_presentation() {
+    for fullscreen in [false, true] {
+        let (mut wm, ids) = spatial_desktop(2);
+        wm.backend_mut().set_monitors(dual_monitors());
+        wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+        let id = ids[0];
+        if fullscreen {
+            wm.fullscreen(id);
+        } else {
+            wm.maximize(id, MaximizeDirections::FULL);
+        }
+        wm.move_client_to_output(id, 1);
+        assert_eq!(wm.client_output_index(id), 1);
+        assert_eq!(client_frame_rect(&wm.clients[id]), RIGHT_HEAD);
+    }
+}
+
+#[test]
+fn spatial_floating_a_special_window_preserves_its_presentation_and_restore_chain() {
+    for fullscreen in [false, true] {
+        let (mut wm, ids) = spatial_desktop(3);
+        let id = ids[1];
+        let original = wm.clients[id].geometry;
+        wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+        if fullscreen {
+            wm.fullscreen(id);
+        } else {
+            wm.maximize(id, MaximizeDirections::FULL);
+        }
+        let special = wm.clients[id].geometry;
+        wm.toggle_floating(id);
+        assert_eq!(
+            wm.clients[id].geometry, special,
+            "membership must not undo presentation"
+        );
+        if fullscreen {
+            wm.unfullscreen(id);
+        } else {
+            wm.unmaximize(id);
+        }
+        assert_eq!(
+            wm.clients[id].geometry, original,
+            "floating restores the freeform view"
+        );
+        wm.toggle_floating(id);
+        assert!(wm.is_layout_managed(id));
+    }
+}
+
+#[test]
+fn spatial_lifecycle_changes_cancel_a_drag_before_mutating_membership() {
+    for operation in 0..5 {
+        let (mut wm, ids) = spatial_desktop(3);
+        let id = ids[0];
+        wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+        wm.focus_client(id);
+        wm.handle_pointer_motion(wm.clients[id].geometry.pos);
+        wm.handle_move_request(wm.clients[id].window);
+        let target = client_frame_rect(&wm.clients[ids[1]]);
+        wm.preview_managed_move(id, target.pos);
+        assert!(wm.interactive_drag_active());
+        match operation {
+            0 => wm.move_client_to_workspace(id, 1),
+            1 => wm.miniaturize(id),
+            2 => wm.fullscreen(id),
+            3 => wm.maximize(id, MaximizeDirections::FULL),
+            _ => wm.shade(id),
+        }
+        assert!(
+            !wm.interactive_drag_active(),
+            "operation {operation} left a grab"
+        );
+        assert!(wm.layout_drop.is_none());
+        assert_eq!(wm.backend().outstanding_pointer_grabs, 0);
+    }
+}
+
+fn spatial_desktop(n: usize) -> (WindowManager<FakeBackend>, Vec<ClientId>) {
+    let mut wm = wm(FakeBackend::new());
+    let mut ids = Vec::new();
+    for i in 0..n {
+        let window = wm.backend_mut().create_window();
+        wm.backend_mut().set_geometry(
+            window,
+            Rect::new(
+                Point::new(70 + i as i32 * 50, 90 + i as i32 * 30),
+                Size::new(300 + i as u32 * 20, 250),
+            ),
+        );
+        wm.dispatch(BackendEvent::MapRequest(window));
+        ids.push(wm.client_for_window(window).unwrap());
+    }
+    (wm, ids)
+}
+
+#[test]
+fn spatial_modes_preserve_freeform_and_focus_through_floating_edits() {
+    use crate::LayoutMode::*;
+    for intermediate in [Mosaic, Flow] {
+        let (mut wm, ids) = spatial_desktop(3);
+        let saved: Vec<_> = ids.iter().map(|id| wm.clients[*id].geometry).collect();
+        let focus = wm.focused_client();
+        let order = wm.layout_order(0).to_vec();
+        wm.set_workspace_layout(0, Mosaic);
+        assert!(ids.iter().all(|&id| wm.is_layout_managed(id)));
+        wm.toggle_floating(ids[1]);
+        assert_eq!(wm.clients[ids[1]].geometry, saved[1]);
+        wm.set_client_content_geometry(
+            ids[1],
+            Rect::new(Point::new(350, 200), Size::new(400, 350)),
+        );
+        wm.toggle_floating(ids[1]);
+        assert_eq!(wm.layout_order(0), order);
+        wm.set_workspace_layout(0, intermediate);
+        wm.set_workspace_layout(0, Freeform);
+        for (&id, geometry) in ids.iter().zip(saved) {
+            assert_eq!(wm.clients[id].geometry, geometry);
+        }
+        assert_eq!(wm.focused_client(), focus);
+    }
+}
+
+#[test]
+fn spatial_minimize_restore_removal_and_reordering_keep_membership_honest() {
+    use crate::LayoutMode::*;
+    let (mut wm, ids) = spatial_desktop(4);
+    wm.set_workspace_layout(0, Mosaic);
+    let order = wm.layout_order(0).to_vec();
+    wm.miniaturize(ids[1]);
+    assert_eq!(wm.layout_order(0), order);
+    assert!(!wm.is_layout_managed(ids[1]));
+    wm.deminiaturize(ids[1]);
+    assert_eq!(wm.layout_order(0), order);
+    assert_eq!(wm.focused_client(), Some(ids[1]));
+    wm.set_workspace_layout(0, Flow);
+    assert!(wm.move_layout_window(ids[1], FocusDirection::Right));
+    assert_eq!(wm.focused_client(), Some(ids[1]));
+    wm.resize_layout_window(ids[1], Point::new(100, 0));
+    assert_eq!(wm.focused_client(), Some(ids[1]));
+    let window = wm.clients[ids[2]].window;
+    wm.dispatch(BackendEvent::Destroyed(window));
+    assert!(!wm.layout_order(0).contains(&ids[2]));
+    assert_eq!(wm.layout_order(0).len(), 3);
+    wm.set_workspace_layout(0, Freeform);
+}
+
+#[test]
+fn spatial_focus_is_visual_and_flow_vertical_navigation_is_quiet() {
+    use crate::LayoutMode::*;
+    let (mut wm, ids) = spatial_desktop(3);
+    wm.set_workspace_layout(0, Mosaic);
+    wm.focus_client(ids[0]);
+    assert!(wm.focus_direction(FocusDirection::Right));
+    let right = wm.focused_client().unwrap();
+    assert!(wm.clients[right].geometry.pos.x > wm.clients[ids[0]].geometry.pos.x);
+    wm.set_workspace_layout(0, Flow);
+    wm.focus_client(ids[1]);
+    assert!(!wm.focus_direction(FocusDirection::Down));
+    assert_eq!(wm.focused_client(), Some(ids[1]));
+    assert!(wm.focus_direction(FocusDirection::Right));
+    assert_eq!(wm.focused_client(), Some(ids[2]));
+    let c = &wm.clients[ids[2]];
+    assert!(
+        c.geometry.pos.x >= 0
+            && c.geometry.pos.x as u32 + c.geometry.size.w <= wm.backend().screen_size().w
+    );
+}
+
+#[test]
+fn spatial_flow_resize_reverses_immediately_at_both_size_limits() {
+    let (mut wm, ids) = spatial_desktop(2);
+    let id = ids[1];
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    wm.resize_layout_window(id, Point::new(100_000, 0));
+    let widest = wm.clients[id].geometry.size.w;
+    wm.resize_layout_window(id, Point::new(-50, 0));
+    assert!(wm.clients[id].geometry.size.w < widest);
+    wm.resize_layout_window(id, Point::new(-100_000, 0));
+    let narrowest = wm.clients[id].geometry.size.w;
+    wm.resize_layout_window(id, Point::new(50, 0));
+    assert!(wm.clients[id].geometry.size.w > narrowest);
+    assert_eq!(wm.focused_client(), Some(id));
+}
+
+#[test]
+fn spatial_special_presentations_restore_layout_then_original_freeform() {
+    use crate::LayoutMode::*;
+    let (mut wm, ids) = spatial_desktop(3);
+    let original = wm.clients[ids[1]].geometry;
+    wm.set_workspace_layout(0, Mosaic);
+    let tiled = wm.clients[ids[1]].geometry;
+    wm.maximize(ids[1], MaximizeDirections::FULL);
+    assert!(!wm.is_layout_managed(ids[1]));
+    wm.unmaximize(ids[1]);
+    assert_eq!(wm.clients[ids[1]].geometry, tiled);
+    wm.fullscreen(ids[1]);
+    assert!(!wm.is_layout_managed(ids[1]));
+    wm.unfullscreen(ids[1]);
+    assert_eq!(wm.clients[ids[1]].geometry, tiled);
+    wm.shade(ids[1]);
+    assert!(wm.clients[ids[1]].placement.floating);
+    wm.toggle_floating(ids[1]);
+    assert!(!wm.clients[ids[1]].flags.contains(ClientFlags::SHADED));
+    wm.set_workspace_layout(0, Freeform);
+    assert_eq!(wm.clients[ids[1]].geometry, original);
+}
+
+#[test]
+fn spatial_workspace_deletion_merges_order_without_losing_freeform() {
+    use crate::LayoutMode::*;
+    let (mut wm, ids) = spatial_desktop(3);
+    let original = wm.clients[ids[1]].geometry;
+    wm.set_workspace_layout(0, Mosaic);
+    wm.move_client_to_workspace(ids[1], 1);
+    assert_eq!(wm.clients[ids[1]].geometry, original);
+    wm.set_workspace_layout(1, Flow);
+    wm.switch_workspace(1);
+    wm.remove_workspace(0);
+    assert_eq!(wm.workspace_layout(0), Flow);
+    assert_eq!(wm.layout_order(0).len(), 3);
+    wm.set_workspace_layout(0, Freeform);
+    assert_eq!(wm.clients[ids[1]].geometry, original);
+}
+
+#[test]
+fn spatial_client_resize_requests_cannot_destroy_managed_or_saved_geometry() {
+    let (mut wm, ids) = spatial_desktop(3);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    let id = ids[0];
+    let before = wm.clients[id].geometry;
+    let saved = wm.clients[id].placement.freeform;
+    wm.handle_configure_request(
+        wm.clients[id].window,
+        Rect::new(Point::new(0, 0), Size::new(10, 10)),
+    );
+    assert_eq!(wm.clients[id].geometry, before);
+    assert_eq!(wm.clients[id].placement.freeform, saved);
+}
+
+#[test]
+fn spatial_restore_order_does_not_depend_on_application_startup_order() {
+    let (mut wm, ids) = spatial_desktop(4);
+    for (id, rank) in ids.iter().zip([3, 1, 2, 0]) {
+        wm.restore_window_placement(*id, crate::WindowPlacement::default(), rank);
+    }
+    assert_eq!(wm.layout_order(0), &[ids[3], ids[1], ids[2], ids[0]]);
+}
+
+#[test]
+fn spatial_pointer_reorder_commits_only_on_release_and_resize_cancels_exactly() {
+    for mode in [crate::LayoutMode::Mosaic, crate::LayoutMode::Flow] {
+        let (mut wm, ids) = spatial_desktop(3);
+        wm.set_workspace_layout(0, mode);
+        wm.focus_client(ids[0]);
+        let original = wm.layout_order(0).to_vec();
+        let window = wm.clients[ids[0]].window;
+        let target = client_frame_rect(&wm.clients[ids[1]]);
+        let center = Point::new(target.pos.x + target.size.w as i32 / 2, target.pos.y + 20);
+        wm.handle_pointer_motion(wm.clients[ids[0]].geometry.pos);
+        wm.handle_move_request(window);
+        assert!(wm.interactive_drag_active());
+        wm.preview_managed_move(ids[0], center);
+        assert_eq!(wm.layout_order(0), original);
+        wm.dispatch(BackendEvent::DragCancelled);
+        assert_eq!(wm.layout_order(0), original);
+        assert_eq!(wm.backend().outstanding_pointer_grabs, 0);
+        wm.handle_pointer_motion(wm.clients[ids[0]].geometry.pos);
+        wm.handle_move_request(window);
+        assert!(wm.interactive_drag_active());
+        wm.preview_managed_move(ids[0], center);
+        wm.dispatch(BackendEvent::DragEnded);
+        assert_ne!(wm.layout_order(0), original);
+        assert_eq!(wm.focused_client(), Some(ids[0]));
+        let before: Vec<_> = ids.iter().map(|&id| wm.clients[id].geometry).collect();
+        let frame = client_frame_rect(&wm.clients[ids[0]]);
+        let west = mode == crate::LayoutMode::Mosaic && frame.pos.x > 0;
+        wm.handle_resize_request(
+            window,
+            if west {
+                ResizeEdge::West
+            } else {
+                ResizeEdge::East
+            },
+        );
+        wm.handle_resize_motion(Point::new(
+            if west {
+                frame.pos.x - 80
+            } else {
+                frame.pos.x + frame.size.w as i32 + 80
+            },
+            frame.pos.y + 50,
+        ));
+        assert_ne!(wm.clients[ids[0]].geometry, before[0]);
+        wm.dispatch(BackendEvent::DragCancelled);
+        wm.dispatch(BackendEvent::DragCancelled);
+        for (&id, rect) in ids.iter().zip(&before) {
+            assert_eq!(&wm.clients[id].geometry, rect);
+        }
+        assert_eq!(wm.backend().outstanding_pointer_grabs, 0);
+        assert_eq!(wm.focused_client(), Some(ids[0]));
+        let order = wm.layout_order(0).to_vec();
+        wm.handle_pointer_motion(wm.clients[ids[0]].geometry.pos);
+        wm.handle_move_request(window);
+        assert!(wm.interactive_drag_active());
+        wm.preview_managed_move(ids[0], center);
+        wm.toggle_floating(ids[0]);
+        wm.dispatch(BackendEvent::DragEnded);
+        assert_eq!(wm.layout_order(0), order);
+        assert!(!wm.interactive_drag_active());
+        assert!(wm.clients[ids[0]].placement.floating);
+    }
+}
+
+#[test]
+fn spatial_shared_boundaries_preserve_workarea_and_proportions() {
+    let (mut wm, ids) = spatial_desktop(3);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    let original = client_frame_rect(&wm.clients[ids[0]]);
+    wm.resize_layout_window(ids[0], Point::new(90, 0));
+    let left = client_frame_rect(&wm.clients[ids[0]]);
+    let right = client_frame_rect(&wm.clients[ids[1]]);
+    let bottom = client_frame_rect(&wm.clients[ids[2]]);
+    assert!(left.size.w > original.size.w);
+    assert_eq!(right.pos.x, bottom.pos.x);
+    assert_eq!(right.size.w, bottom.size.w);
+    assert!(left.pos.x + left.size.w as i32 <= right.pos.x);
+    let adjusted: Vec<_> = ids.iter().map(|&id| wm.clients[id].geometry).collect();
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    for (&id, rect) in ids.iter().zip(&adjusted) {
+        assert_eq!(&wm.clients[id].geometry, rect);
+    }
+    wm.resize_layout_window(ids[0], Point::new(i32::MAX, 0));
+    for id in ids {
+        assert!(wm.clients[id].geometry.size.w > 0);
+    }
+}
+
+#[test]
+fn spatial_output_affinity_survives_offscreen_flow_hotplug_and_reconnect() {
+    let (mut wm, ids) = spatial_desktop(4);
+    wm.backend_mut().set_monitors(dual_monitors());
+    wm.set_workareas(vec![LEFT_WORKAREA, RIGHT_HEAD]);
+    let original = wm.clients[ids[0]].geometry;
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    for &id in &ids {
+        assert!(wm.move_client_to_output(id, 1));
+    }
+    wm.focus_client(ids[3]);
+    for &id in &ids {
+        assert_eq!(wm.client_output_index(id), 1);
+    }
+    wm.fullscreen(ids[0]); // named offscreen target still belongs to right
+    assert_eq!(wm.clients[ids[0]].geometry, RIGHT_HEAD);
+    wm.unfullscreen(ids[0]);
+    wm.maximize(ids[0], MaximizeDirections::FULL);
+    assert_eq!(client_frame_rect(&wm.clients[ids[0]]), RIGHT_HEAD);
+    wm.unmaximize(ids[0]);
+    wm.backend_mut()
+        .set_monitors(vec![dual_monitors().remove(0)]);
+    wm.rescue_clients_from_removed_monitor(RIGHT_HEAD);
+    for &id in &ids {
+        assert_eq!(wm.client_output_index(id), 0);
+    }
+    let focused = client_frame_rect(&wm.clients[ids[3]]);
+    assert!(focused.pos.x >= 0 && focused.pos.x + focused.size.w as i32 <= 800);
+    wm.backend_mut().set_monitors(dual_monitors());
+    wm.relayout_all_clients();
+    for &id in &ids {
+        assert_eq!(wm.client_output_index(id), 1);
+    }
+    wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+    assert_eq!(wm.clients[ids[0]].geometry, original);
+}
+
+#[test]
+fn spatial_return_to_freeform_while_fullscreen_over_maximize_keeps_both_restores() {
+    let (mut wm, ids) = spatial_desktop(2);
+    let id = ids[0];
+    let original = wm.clients[id].geometry;
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    wm.maximize(id, MaximizeDirections::FULL);
+    let maximized = wm.clients[id].geometry;
+    wm.fullscreen(id);
+    wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+    wm.unfullscreen(id);
+    assert_eq!(wm.clients[id].geometry, maximized);
+    wm.unmaximize(id);
+    assert_eq!(wm.clients[id].geometry, original);
+}
+
+#[test]
+fn spatial_late_metadata_reflows_without_overwriting_freeform_intent() {
+    for mode in [crate::LayoutMode::Mosaic, crate::LayoutMode::Flow] {
+        let (mut wm, ids) = spatial_desktop(3);
+        let id = ids[0];
+        let window = wm.clients[id].window;
+        let original = wm.clients[id].geometry;
+        wm.set_workspace_layout(0, mode);
+        let frame = client_frame_rect(&wm.clients[id]);
+        let focus = wm.focused_client();
+        for own_chrome in [true, false] {
+            wm.backend_mut()
+                .set_client_draws_own_chrome(window, own_chrome);
+            wm.refresh_client_chrome(id);
+            assert_eq!(client_frame_rect(&wm.clients[id]), frame);
+            assert_eq!(wm.focused_client(), focus);
+        }
+        wm.dispatch(BackendEvent::ModalChanged {
+            window,
+            modal: true,
+        });
+        assert!(!wm.is_layout_managed(id));
+        assert_eq!(wm.clients[id].geometry, original);
+        assert_eq!(wm.layout_statistics().managed_windows, 2);
+        let child = wm.clients[ids[1]].window;
+        let parent = wm.clients[ids[2]].window;
+        let saved = wm.clients[ids[1]].placement.freeform.unwrap();
+        wm.backend_mut().set_window_parent(child, parent);
+        wm.dispatch(BackendEvent::ParentChanged(child));
+        assert!(!wm.is_layout_managed(ids[1]));
+        assert_eq!(wm.clients[ids[1]].geometry.size, saved.size);
+        assert_eq!(wm.layout_statistics().managed_windows, 1);
+        wm.set_workspace_layout(0, crate::LayoutMode::Freeform);
+        assert_eq!(wm.clients[id].geometry, original);
+        assert_eq!(wm.clients[ids[1]].geometry, saved);
+    }
+}
+
+#[test]
+fn spatial_dialog_fixed_size_and_impossible_minimum_are_floating_exceptions() {
+    let (mut wm, ids) = spatial_desktop(2);
+    let window = wm.clients[ids[0]].window;
+    wm.backend_mut().set_size_hints(
+        window,
+        SizeHints {
+            min_size: Some(Size::new(10000, 10000)),
+            ..Default::default()
+        },
+    );
+    for kind in [WindowType::Dialog, WindowType::Normal] {
+        let window = wm.backend_mut().create_window();
+        wm.backend_mut().set_window_type(window, kind);
+        wm.backend_mut().set_size_hints(
+            window,
+            SizeHints {
+                min_size: Some(Size::new(120, 80)),
+                max_size: Some(Size::new(120, 80)),
+                ..Default::default()
+            },
+        );
+        wm.dispatch(BackendEvent::MapRequest(window));
+        let id = wm.client_for_window(window).unwrap();
+        assert!(wm.clients[id].placement.floating);
+    }
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    assert!(!wm.is_layout_managed(ids[0]));
+    assert!(wm.is_layout_managed(ids[1]));
+    assert_eq!(wm.layout_statistics().managed_windows, 1);
+}
+
+#[test]
+fn spatial_resize_only_changes_the_boundary_the_pointer_grabbed() {
+    let (mut wm, _) = spatial_desktop(8);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    let order = wm.layout_order(0).to_vec();
+    let middle = order
+        .iter()
+        .copied()
+        .find(|&id| {
+            let rect = client_frame_rect(&wm.clients[id]);
+            rect.pos.x > 0 && rect.pos.x < 800
+        })
+        .unwrap();
+    let frame = client_frame_rect(&wm.clients[middle]);
+    let far_right = *order.last().unwrap();
+    let unchanged = wm.clients[far_right].geometry;
+    wm.resize_managed(middle, Point::new(50, 0), Some(ResizeEdge::West));
+    let resized = client_frame_rect(&wm.clients[middle]);
+    assert!(resized.pos.x < frame.pos.x);
+    assert_eq!(
+        resized.pos.x + resized.size.w as i32,
+        frame.pos.x + frame.size.w as i32
+    );
+    assert_eq!(wm.clients[far_right].geometry, unchanged);
+    let top_left = order[0];
+    let before: Vec<_> = order.iter().map(|&id| wm.clients[id].geometry).collect();
+    wm.resize_managed(top_left, Point::new(0, 50), Some(ResizeEdge::North));
+    for (&id, rect) in order.iter().zip(before) {
+        assert_eq!(wm.clients[id].geometry, rect);
+    }
+}
+
+#[test]
+fn spatial_mixed_scale_output_moves_preserve_logical_flow_width_and_gaps() {
+    let (mut wm, ids) = spatial_desktop(2);
+    let mut monitors = dual_monitors();
+    monitors[1].geometry.size = Size::new(1600, 1200);
+    wm.backend_mut().set_monitors(monitors);
+    wm.backend_mut().set_monitor_scales(vec![1.0, 2.0]);
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    let width = client_frame_rect(&wm.clients[ids[0]]).size.w;
+    let logical_width = wm.clients[ids[0]].placement.flow_width;
+    wm.move_client_to_output(ids[0], 1);
+    wm.move_client_to_output(ids[1], 1);
+    assert_eq!(client_frame_rect(&wm.clients[ids[0]]).size.w, width * 2);
+    assert_eq!(wm.clients[ids[0]].placement.flow_width, logical_width);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    let a = client_frame_rect(&wm.clients[ids[0]]);
+    let b = client_frame_rect(&wm.clients[ids[1]]);
+    assert_eq!(b.pos.x - a.pos.x - a.size.w as i32, 12);
+    assert_eq!(b.pos.x + b.size.w as i32, 2400);
+    assert_eq!(a.size.h, 1200);
+}
+
+#[test]
+fn spatial_deleting_into_freeform_restores_geometry_and_empty_desktops_restore() {
+    let (mut wm, ids) = spatial_desktop(3);
+    let original: Vec<_> = ids.iter().map(|&id| wm.clients[id].geometry).collect();
+    wm.set_workspace_layout(2, crate::LayoutMode::Freeform);
+    assert_eq!(wm.workspace_count(), 3);
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    assert!(wm.remove_workspace(0));
+    assert_eq!(wm.workspace_layout(0), crate::LayoutMode::Freeform);
+    for (&id, rect) in ids.iter().zip(original) {
+        assert_eq!(wm.clients[id].geometry, rect);
+        assert!(wm.clients[id].placement.freeform.is_none());
+    }
+    assert_eq!(wm.layout_order(0).len(), 3);
+}
+
+#[test]
+fn spatial_keyboard_moves_to_an_empty_neighbor_output_and_focus_returns_spatially() {
+    let (mut wm, ids) = spatial_desktop(2);
+    wm.backend_mut().set_monitors(dual_monitors());
+    wm.toggle_floating(ids[0]);
+    assert!(
+        !wm.clients[ids[0]].placement.floating,
+        "Freeform toggle must not change future membership invisibly"
+    );
+    wm.set_workspace_layout(0, crate::LayoutMode::Mosaic);
+    wm.focus_client(ids[1]);
+    assert!(wm.move_layout_window(ids[1], FocusDirection::Right));
+    assert_eq!(wm.client_output_index(ids[1]), 1);
+    assert_eq!(wm.focused_client(), Some(ids[1]));
+    assert!(wm.focus_direction(FocusDirection::Left));
+    assert_eq!(wm.focused_client(), Some(ids[0]));
+    wm.set_workspace_layout(0, crate::LayoutMode::Flow);
+    assert!(!wm.move_layout_window(ids[0], FocusDirection::Up));
+    assert_eq!(wm.client_output_index(ids[0]), 0);
+}

--- a/crates/wm-core/src/spatial.rs
+++ b/crates/wm-core/src/spatial.rs
@@ -1,0 +1,491 @@
+//! The three workspace styles and their small, deterministic geometry solver.
+//! All solver coordinates are output-local logical units, including the gap.
+use crate::{ClientId, Point, Rect, Size};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum LayoutMode {
+    #[default]
+    Freeform,
+    Mosaic,
+    Flow,
+}
+
+impl LayoutMode {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Freeform => "Freeform",
+            Self::Mosaic => "Mosaic",
+            Self::Flow => "Flow",
+        }
+    }
+
+    pub fn parse(name: &str) -> Option<Self> {
+        match name.to_ascii_lowercase().as_str() {
+            "freeform" => Some(Self::Freeform),
+            "mosaic" | "dwindle" => Some(Self::Mosaic),
+            "flow" | "scrolling" => Some(Self::Flow),
+            _ => None,
+        }
+    }
+
+    pub fn compatible_name(self) -> &'static str {
+        match self {
+            Self::Freeform => "freeform",
+            Self::Mosaic => "dwindle",
+            Self::Flow => "scrolling",
+        }
+    }
+}
+
+/// Fixed counters for development instrumentation; no per-frame logging.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LayoutStatistics {
+    pub calculations: u64,
+    pub calculation_us: u128,
+    pub managed_windows: usize,
+    pub geometry_changes: u64,
+}
+
+/// Intent survives temporary presentation, including edits to a floated tile.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WindowPlacement {
+    pub freeform: Option<Rect>,
+    pub floating: bool,
+    /// EDID identity where available, otherwise connector name.
+    pub output: Option<String>,
+    /// Logical frame width. Zero chooses the useful default on first entry.
+    pub flow_width: u32,
+    /// Horizontal/vertical proportions; zero means the default equal share.
+    pub mosaic_weight: [u32; 2],
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct WorkspaceLayout {
+    pub mode: LayoutMode,
+    /// Includes floating and minimized clients so returning is reversible.
+    pub order: Vec<ClientId>,
+    pub viewports: std::collections::HashMap<String, i32>,
+}
+
+/// One interactive resize rollback, discarded on commit.
+pub(crate) struct ResizeSnapshot {
+    pub workspace: usize,
+    pub placements: Vec<(ClientId, [u32; 2], u32)>,
+    pub viewports: std::collections::HashMap<String, i32>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Item {
+    pub min: Size,
+    pub weight: [u32; 2],
+    pub width: u32,
+}
+
+const GAP: u32 = 6;
+const DEFAULT_WEIGHT: u32 = 1000;
+
+fn weight(value: u32) -> u64 {
+    (if value == 0 {
+        DEFAULT_WEIGHT
+    } else {
+        value.clamp(1, 1_000_000)
+    }) as u64
+}
+
+/// Weighted, minimum-constrained partition. Rounding remainder stays inside
+/// the last cell. None means the caller must float a constrained exception.
+fn partition(length: u32, gap: u32, minima: &[u32], weights: &[u32]) -> Option<Vec<u32>> {
+    let available = length.checked_sub(gap.checked_mul(minima.len().saturating_sub(1) as u32)?)?;
+    let minimum: u64 = minima.iter().map(|&m| m.max(1) as u64).sum();
+    if minimum > available as u64 {
+        return None;
+    }
+    let mut result = vec![0; minima.len()];
+    let mut remaining = available as u64;
+    let mut total: u64 = weights.iter().map(|&w| weight(w)).sum();
+    loop {
+        let mut clamped = false;
+        for (i, &min) in minima.iter().enumerate() {
+            if result[i] == 0 && remaining * weight(weights[i]) / total.max(1) < min.max(1) as u64 {
+                result[i] = min.max(1);
+                remaining -= result[i] as u64;
+                total -= weight(weights[i]);
+                clamped = true;
+            }
+        }
+        if !clamped {
+            break;
+        }
+    }
+    for (i, value) in result.iter_mut().enumerate() {
+        if *value != 0 {
+            continue;
+        }
+        let w = weight(weights[i]);
+        *value = (remaining * w / total.max(1)) as u32;
+        remaining -= *value as u64;
+        total -= w;
+    }
+    Some(result)
+}
+
+fn columns(
+    area: Size,
+    items: &[Item],
+    indices: &[usize],
+    count: usize,
+    gap: u32,
+) -> Option<Vec<Rect>> {
+    let mut minima = Vec::with_capacity(count);
+    let mut weights = Vec::with_capacity(count);
+    for column in 0..count {
+        let slice = &indices[column * indices.len() / count..(column + 1) * indices.len() / count];
+        minima.push(slice.iter().map(|&i| items[i].min.w).max().unwrap_or(1));
+        weights.push(
+            (slice
+                .iter()
+                .map(|&i| weight(items[i].weight[0]))
+                .sum::<u64>()
+                / slice.len() as u64) as u32,
+        );
+    }
+    let widths = partition(area.w, gap, &minima, &weights)?;
+    let mut result = Vec::with_capacity(indices.len());
+    let mut x = 0;
+    for (column, width) in widths.into_iter().enumerate() {
+        let slice = &indices[column * indices.len() / count..(column + 1) * indices.len() / count];
+        minima.clear();
+        weights.clear();
+        for &i in slice {
+            minima.push(items[i].min.h);
+            weights.push(items[i].weight[1]);
+        }
+        let heights = partition(area.h, gap, &minima, &weights)?;
+        let mut y = 0;
+        for height in heights {
+            result.push(Rect {
+                pos: Point::new(x as i32, y as i32),
+                size: Size::new(width, height),
+            });
+            y += height + gap;
+        }
+        x += width + gap;
+    }
+    Some(result)
+}
+
+/// Balanced columns, transposed on portrait outputs. Feasibility takes
+/// precedence over aspect preference. Infeasible clients are explicit None
+/// entries; their membership and saved freeform geometry are never discarded.
+pub(crate) fn mosaic(area: Size, items: &[Item]) -> Vec<Option<Rect>> {
+    let portrait = area.h > area.w;
+    let area = if portrait {
+        Size::new(area.h, area.w)
+    } else {
+        area
+    };
+    let transposed: Vec<_> = items
+        .iter()
+        .map(|item| {
+            if portrait {
+                Item {
+                    min: Size::new(item.min.h, item.min.w),
+                    weight: [item.weight[1], item.weight[0]],
+                    ..*item
+                }
+            } else {
+                *item
+            }
+        })
+        .collect();
+    let mut indices: Vec<_> = transposed
+        .iter()
+        .enumerate()
+        .filter(|(_, i)| i.min.w.max(1) <= area.w && i.min.h.max(1) <= area.h)
+        .map(|(i, _)| i)
+        .collect();
+    let mut result = vec![None; items.len()];
+    let demand = |i: usize| {
+        let min = transposed[i].min;
+        min.w.max(1) as u128 * min.h.max(1) as u128
+    };
+    let mut minimum_area: u128 = indices.iter().map(|&i| demand(i)).sum();
+    let available_area = area.w as u128 * area.h as u128;
+    while !indices.is_empty() {
+        let n = indices.len();
+        let preferred = ((n as f64 * area.w as f64 / area.h.max(1) as f64 / 1.6)
+            .sqrt()
+            .round() as usize)
+            .clamp(if n > 1 { 2 } else { 1 }, n);
+        let gap = GAP
+            .min(area.w / (n as u32 * 4))
+            .min(area.h / (n as u32 * 4));
+        // Start at the preferred aspect, then test nearest alternatives.
+        // No partition can fit when the clients' minimum areas exceed the
+        // output. Skip futile column searches while removing the same largest
+        // exceptions the fallback below would select anyway.
+        for offset in 0..if minimum_area <= available_area { n } else { 0 } {
+            for count in [
+                preferred.checked_sub(offset),
+                (offset != 0).then_some(preferred + offset),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                if count == 0 || count > n {
+                    continue;
+                }
+                if let Some(rects) = columns(area, &transposed, &indices, count, gap) {
+                    for (&i, rect) in indices.iter().zip(rects) {
+                        result[i] = Some(if portrait {
+                            Rect {
+                                pos: Point::new(rect.pos.y, rect.pos.x),
+                                size: Size::new(rect.size.h, rect.size.w),
+                            }
+                        } else {
+                            rect
+                        });
+                    }
+                    return result;
+                }
+            }
+        }
+        // One demanding client must not force every other client to float.
+        let largest = indices
+            .iter()
+            .enumerate()
+            .max_by_key(|(_, i)| {
+                let min = transposed[**i].min;
+                min.w.max(1) as u64 * min.h.max(1) as u64
+            })
+            .map(|(i, _)| i)
+            .unwrap();
+        minimum_area -= demand(indices.remove(largest));
+    }
+    result
+}
+
+pub(crate) fn flow(
+    area: Size,
+    items: &[Item],
+    focused: Option<usize>,
+    viewport: &mut i32,
+) -> Vec<Option<Rect>> {
+    let mut x = 0i32;
+    let mut result = Vec::with_capacity(items.len());
+    for item in items {
+        if item.min.w > area.w || item.min.h > area.h || area.w == 0 || area.h == 0 {
+            result.push(None);
+            continue;
+        }
+        let width = (if item.width == 0 {
+            area.w * 2 / 3
+        } else {
+            item.width
+        })
+        .clamp(item.min.w.max(1), area.w);
+        result.push(Some(Rect {
+            pos: Point::new(x, 0),
+            size: Size::new(width, area.h),
+        }));
+        x = x.saturating_add(width as i32).saturating_add(GAP as i32);
+    }
+    let limit = x
+        .saturating_sub(GAP as i32)
+        .saturating_sub(area.w as i32)
+        .max(0);
+    *viewport = (*viewport).clamp(0, limit);
+    if let Some(Some(rect)) = focused.and_then(|i| result.get(i)) {
+        let margin = (area.w / 12).min(area.w.saturating_sub(rect.size.w) / 2) as i32;
+        if rect.pos.x < viewport.saturating_add(margin) {
+            *viewport = rect.pos.x.saturating_sub(margin).max(0);
+        } else if rect.pos.x as i64 + rect.size.w as i64
+            > *viewport as i64 + area.w as i64 - margin as i64
+        {
+            *viewport = (rect.pos.x as i64 + rect.size.w as i64 - area.w as i64 + margin as i64)
+                .clamp(0, limit as i64) as i32;
+        }
+    }
+    for rect in result.iter_mut().flatten() {
+        rect.pos.x = rect.pos.x.saturating_sub(*viewport);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn item() -> Item {
+        Item {
+            min: Size::new(1, 1),
+            weight: [0, 0],
+            width: 0,
+        }
+    }
+
+    #[test]
+    fn generated_constraints_and_proportions_never_break_geometry() {
+        let mut seed = 0x43484f4e4b535445u64;
+        let mut next = || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed as u32
+        };
+        for case in 0..2000 {
+            let area = Size::new(next() % 2001, next() % 2001);
+            let items: Vec<_> = (0..1 + next() % 32)
+                .map(|_| Item {
+                    min: Size::new(next() % 1501, next() % 1501),
+                    weight: [next(), next()],
+                    width: next(),
+                })
+                .collect();
+            let result = mosaic(area, &items);
+            assert_eq!(result, mosaic(area, &items), "case {case}");
+            for (i, rect) in result
+                .iter()
+                .enumerate()
+                .filter_map(|(i, r)| r.map(|r| (i, r)))
+            {
+                assert!(rect.size.w >= items[i].min.w.max(1));
+                assert!(rect.size.h >= items[i].min.h.max(1));
+                assert_eq!(
+                    Rect::new(Point::new(0, 0), area).intersection(rect),
+                    Some(rect)
+                );
+                for other in result.iter().skip(i + 1).flatten() {
+                    assert!(rect.intersection(*other).is_none(), "case {case}");
+                }
+            }
+            let mut viewport = next() as i32;
+            let focused = next() as usize % items.len();
+            let flow = flow(area, &items, Some(focused), &mut viewport);
+            if let Some(rect) = flow[focused] {
+                assert!(rect.pos.x >= 0 && rect.pos.x as u32 + rect.size.w <= area.w);
+            }
+            assert!(viewport >= 0);
+            let mut previous = None;
+            for rect in flow.iter().flatten() {
+                assert!(rect.size.w > 0 && rect.size.h > 0);
+                if let Some(before) = previous {
+                    assert!(rect.pos.x > before);
+                }
+                previous = Some(rect.pos.x + rect.size.w as i32);
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "development solver profile; product-path benchmark lives in chonk-testkit"]
+    fn constrained_solver_profile() {
+        for n in [8, 64, 256] {
+            let items = vec![
+                Item {
+                    min: Size::new(600, 600),
+                    ..item()
+                };
+                n
+            ];
+            let started = std::time::Instant::now();
+            let output = mosaic(Size::new(1000, 1000), std::hint::black_box(&items));
+            eprintln!(
+                "{n} demanding clients: {} us; {} managed",
+                started.elapsed().as_micros(),
+                output.iter().flatten().count()
+            );
+            assert_eq!(output.iter().flatten().count(), 1);
+        }
+    }
+
+    #[test]
+    fn mosaic_is_deterministic_positive_disjoint_and_contained() {
+        for area in [
+            Size::new(1920, 1080),
+            Size::new(801, 1399),
+            Size::new(17, 13),
+            Size::new(1, 1),
+            Size::new(0, 0),
+        ] {
+            for n in 1..=10 {
+                let items = vec![item(); n];
+                let rects = mosaic(area, &items);
+                assert_eq!(rects, mosaic(area, &items));
+                if area.w as u64 * area.h as u64 >= n as u64 {
+                    assert!(rects.iter().all(Option::is_some));
+                }
+                for (i, a) in rects
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, r)| r.map(|r| (i, r)))
+                {
+                    assert!(a.size.w > 0 && a.size.h > 0);
+                    assert!(a.pos.x >= 0 && a.pos.y >= 0);
+                    assert!(
+                        a.pos.x as u32 + a.size.w <= area.w && a.pos.y as u32 + a.size.h <= area.h
+                    );
+                    for b in rects.iter().skip(i + 1).flatten() {
+                        assert!(
+                            a.pos.x + a.size.w as i32 <= b.pos.x
+                                || b.pos.x + b.size.w as i32 <= a.pos.x
+                                || a.pos.y + a.size.h as i32 <= b.pos.y
+                                || b.pos.y + b.size.h as i32 <= a.pos.y
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn three_windows_have_a_large_first_region_and_portrait_transposes() {
+        let items = vec![item(); 3];
+        let r = mosaic(Size::new(1200, 800), &items);
+        assert_eq!(r[0].unwrap().size.h, 800);
+        assert_eq!(r[1].unwrap().pos.x, r[2].unwrap().pos.x);
+        let portrait = mosaic(Size::new(800, 1200), &items);
+        assert_eq!(portrait[0].unwrap().size.w, 800);
+    }
+
+    #[test]
+    fn minima_are_respected_and_a_bad_client_does_not_break_its_neighbors() {
+        let items = [
+            Item {
+                min: Size::new(900, 200),
+                ..item()
+            },
+            item(),
+            Item {
+                min: Size::new(u32::MAX, u32::MAX),
+                ..item()
+            },
+        ];
+        let r = mosaic(Size::new(1000, 800), &items);
+        assert!(r[0].unwrap().size.w >= 900 && r[1].is_some() && r[2].is_none());
+        assert_eq!(partition(101, 1, &[80, 1], &[1, 1000]), Some(vec![80, 20]));
+    }
+
+    #[test]
+    fn flow_follows_focus_and_retains_distinct_widths() {
+        let items = [
+            Item {
+                width: 400,
+                ..item()
+            },
+            Item {
+                width: 700,
+                ..item()
+            },
+            item(),
+        ];
+        let mut viewport = 0;
+        let r = flow(Size::new(1000, 700), &items, Some(2), &mut viewport);
+        assert!(viewport > 0);
+        assert_eq!(r[0].unwrap().size.w, 400);
+        assert_eq!(r[1].unwrap().size.w, 700);
+        let last = r[2].unwrap();
+        assert!(last.pos.x >= 0 && last.pos.x as u32 + last.size.w <= 1000);
+        flow(Size::new(1000, 700), &items, Some(0), &mut viewport);
+        assert_eq!(viewport, 0);
+    }
+}

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -243,6 +243,8 @@ pub enum BackendEvent<Win, Frame> {
     ///
     /// [`Backend::client_draws_own_chrome`]: crate::Backend::client_draws_own_chrome
     ChromeChanged(Win),
+    /// Committed minimum/maximum sizes or resize increments changed.
+    SizeHintsChanged(Win),
     /// The toplevel's transient parent changed. Backends emit this for
     /// `xdg_toplevel.set_parent` and `WM_TRANSIENT_FOR` updates.
     ParentChanged(Win),
@@ -276,6 +278,8 @@ pub enum BackendEvent<Win, Frame> {
     /// A backend may emit this instead of, or in addition to, a
     /// `PointerButton` release; ending a drag is idempotent.
     DragEnded,
+    /// A modal owner, lock, or device loss cancelled the grab.
+    DragCancelled,
     /// The client asked the window manager to start resizing it from
     /// `edge` — X11's `_NET_WM_MOVERESIZE` resize directions, or a
     /// Wayland toplevel's `resize` request.

--- a/crates/wm-theme-api/src/geometry.rs
+++ b/crates/wm-theme-api/src/geometry.rs
@@ -129,8 +129,22 @@ impl Rect {
     pub fn contains(&self, p: Point) -> bool {
         p.x >= self.pos.x
             && p.y >= self.pos.y
-            && p.x < self.pos.x + self.size.w as i32
-            && p.y < self.pos.y + self.size.h as i32
+            && (p.x as i64) < self.pos.x as i64 + self.size.w as i64
+            && (p.y as i64) < self.pos.y as i64 + self.size.h as i64
+    }
+
+    /// Half-open intersection, including rectangles crossing the signed
+    /// coordinate limit. Empty rectangles never contribute visible pixels.
+    pub fn intersection(self, other: Self) -> Option<Self> {
+        let x = self.pos.x.max(other.pos.x);
+        let y = self.pos.y.max(other.pos.y);
+        let right = (self.pos.x as i64 + self.size.w as i64)
+            .min(other.pos.x as i64 + other.size.w as i64);
+        let bottom = (self.pos.y as i64 + self.size.h as i64)
+            .min(other.pos.y as i64 + other.size.h as i64);
+        (right > x as i64 && bottom > y as i64).then(|| {
+            Self::new(Point::new(x, y), Size::new((right - x as i64) as u32, (bottom - y as i64) as u32))
+        })
     }
 }
 
@@ -145,6 +159,19 @@ mod tests {
         assert!(r.contains(Point::new(14, 14)));
         assert!(!r.contains(Point::new(15, 15)));
         assert!(!r.contains(Point::new(9, 10)));
+    }
+
+    #[test]
+    fn rectangles_handle_extreme_coordinates_and_empty_intersections() {
+        let rect = Rect::new(Point::new(i32::MAX - 10, i32::MIN), Size::new(100, u32::MAX));
+        assert!(rect.contains(Point::new(i32::MAX, 0)));
+        assert!(!rect.contains(Point::new(i32::MAX - 11, 0)));
+        let part = Rect::new(Point::new(i32::MAX, 0), Size::new(1, 1));
+        assert_eq!(rect.intersection(part), Some(part));
+        assert_eq!(part.intersection(rect), Some(part));
+        assert_eq!(rect.intersection(Rect::new(rect.pos, Size::default())), None);
+        let adjacent = Rect::new(Point::new(10, 0), Size::new(5, 5));
+        assert_eq!(adjacent.intersection(Rect::new(Point::new(0, 0), Size::new(10, 5))), None);
     }
 
     #[test]

--- a/crates/wm-theme/src/overview/live.rs
+++ b/crates/wm-theme/src/overview/live.rs
@@ -8,6 +8,48 @@ use crate::{
 };
 use wm_theme_api::{DecorationBuffer, Point, Rect, Size};
 
+/// Keep Mosaic's rows/columns and Flow's sequence recognizable in Overview.
+/// Bounding the whole virtual arrangement also brings offscreen Flow clients
+/// into the existing live, selectable panel without changing their geometry.
+pub fn preserve_arrangement(layout: &mut OverviewLayout, sources: &[Rect]) {
+    if sources.is_empty() {
+        return;
+    }
+    let left = sources.iter().map(|r| r.pos.x as i64).min().unwrap();
+    let top = sources.iter().map(|r| r.pos.y as i64).min().unwrap();
+    let right = sources
+        .iter()
+        .map(|r| r.pos.x as i64 + r.size.w as i64)
+        .max()
+        .unwrap();
+    let bottom = sources
+        .iter()
+        .map(|r| r.pos.y as i64 + r.size.h as i64)
+        .max()
+        .unwrap();
+    let scale = (layout.grid.size.w as f64 / (right - left).max(1) as f64)
+        .min(layout.grid.size.h as f64 / (bottom - top).max(1) as f64)
+        .min(0.8);
+    let origin = Point::new(
+        layout.grid.pos.x
+            + ((layout.grid.size.w as f64 - (right - left) as f64 * scale) / 2.0) as i32,
+        layout.grid.pos.y
+            + ((layout.grid.size.h as f64 - (bottom - top) as f64 * scale) / 2.0) as i32,
+    );
+    for (cell, source) in layout.cells.iter_mut().zip(sources) {
+        *cell = Rect::new(
+            Point::new(
+                origin.x + ((source.pos.x as i64 - left) as f64 * scale) as i32,
+                origin.y + ((source.pos.y as i64 - top) as f64 * scale) as i32,
+            ),
+            Size::new(
+                (source.size.w as f64 * scale * 0.94).round().max(1.0) as u32,
+                (source.size.h as f64 * scale * 0.94).round().max(1.0) as u32,
+            ),
+        );
+    }
+}
+
 pub fn layout(panel: Size, tile: u32, sizes: &[Size], workspaces: usize) -> OverviewLayout {
     let pad = (tile / 4).max(8).min(panel.w / 8).min(panel.h / 8);
     let label_h = (tile / 2).max(16);
@@ -228,6 +270,47 @@ mod tests {
                     .strip
                     .iter()
                     .all(|s| s.pos.y < l.grid.pos.y && s.size.w > s.size.h));
+            }
+        }
+    }
+    #[test]
+    fn managed_overview_preserves_spatial_structure_and_selectable_live_cells() {
+        for sources in [
+            vec![
+                Rect::new(Point::new(0, 0), Size::new(700, 900)),
+                Rect::new(Point::new(706, 0), Size::new(700, 447)),
+                Rect::new(Point::new(706, 453), Size::new(700, 447)),
+            ],
+            vec![
+                Rect::new(Point::new(-1800, 0), Size::new(800, 900)),
+                Rect::new(Point::new(-994, 0), Size::new(600, 900)),
+                Rect::new(Point::new(-388, 0), Size::new(1200, 900)),
+            ],
+        ] {
+            for scale in [1, 2] {
+                let sizes: Vec<_> = sources.iter().map(|r| r.size).collect();
+                let mut panel = layout(Size::new(1280 * scale, 800 * scale), 56 * scale, &sizes, 3);
+                preserve_arrangement(&mut panel, &sources);
+                for (index, cell) in panel.cells.iter().enumerate() {
+                    assert!(cell.pos.x >= panel.grid.pos.x && cell.pos.y >= panel.grid.pos.y);
+                    assert!(
+                        cell.pos.x + cell.size.w as i32
+                            <= panel.grid.pos.x + panel.grid.size.w as i32
+                    );
+                    assert!(
+                        cell.pos.y + cell.size.h as i32
+                            <= panel.grid.pos.y + panel.grid.size.h as i32
+                    );
+                    assert_eq!(
+                        panel.cell_at(Point::new(
+                            cell.pos.x + cell.size.w as i32 / 2,
+                            cell.pos.y + cell.size.h as i32 / 2
+                        )),
+                        Some(index)
+                    );
+                }
+                assert!(panel.cells[0].pos.x < panel.cells[1].pos.x);
+                assert_eq!(panel.cells[0].pos.y, panel.cells[1].pos.y);
             }
         }
     }

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -135,3 +135,6 @@ smithay = { version = "0.7.0", default-features = false, features = [
     "wayland_frontend",
     "xwayland",
 ] }
+
+[dev-dependencies]
+chonk-test-support = { path = "../chonk-test-support" }

--- a/crates/wm-wayland/src/backend_impl.rs
+++ b/crates/wm-wayland/src/backend_impl.rs
@@ -216,6 +216,40 @@ impl Backend for WaylandBackend {
 
     // -- lifecycle --------------------------------------------------------
 
+    fn present_layout(
+        &mut self,
+        window: WlWindowId,
+        frame: Option<WlFrameId>,
+        source: Rect,
+        destination: Rect,
+        clip: Option<Rect>,
+        animate: bool,
+    ) {
+        let mut changed = false;
+        if let Some(ManagedSurface::Xdg(surface)) = self.windows.get(&window).map(|r| &r.surface) {
+            surface.with_pending_state(|state| {
+                for edge in [XdgToplevelState::TiledLeft, XdgToplevelState::TiledRight,
+                    XdgToplevelState::TiledTop, XdgToplevelState::TiledBottom] {
+                    changed |= state.states.contains(edge) != clip.is_some();
+                    if clip.is_some() { state.states.set(edge); } else { state.states.unset(edge); }
+                }
+            });
+        }
+        if changed { self.note_configure(window); }
+        crate::layout_scene::present(self, window, frame, source, destination, clip, animate);
+    }
+    fn show_layout_mode(&mut self, _mode: wm_core::LayoutMode, label: DecorationBuffer) {
+        crate::layout_scene::caption(self, label);
+    }
+    fn preview_layout_drop(
+        &mut self,
+        drag: Option<wm_core::LayoutDrag<WlWindowId, WlFrameId>>,
+        target: Option<Rect>,
+    ) {
+        crate::layout_scene::preview(self, drag, target);
+        self.mark_damaged();
+    }
+
     fn scan_existing_windows(&mut self) -> Vec<Self::WindowId> {
         // A compositor owns its display from the first instant — no
         // client can have connected before `run()` created the socket,

--- a/crates/wm-wayland/src/capture.rs
+++ b/crates/wm-wayland/src/capture.rs
@@ -168,7 +168,10 @@ impl ScreenshotRequestPoller {
 pub(crate) fn refresh_snapshots(comp: &mut Compositor) {
     // Overview composes the clients' existing GPU surfaces. Readbacks have no
     // consumer here and would synchronously stall input for unrelated icons.
-    if comp.wm.backend().overview.is_some() || comp.wm.backend().gesture_scene.is_some() {
+    if comp.wm.backend().overview.is_some()
+        || comp.wm.backend().gesture_scene.is_some()
+        || comp.wm.backend().layout_scene.animating()
+    {
         return;
     }
     let now = Instant::now();

--- a/crates/wm-wayland/src/hyprland_ipc.rs
+++ b/crates/wm-wayland/src/hyprland_ipc.rs
@@ -220,11 +220,7 @@ fn build_snapshot(
         counts[client.workspace] += 1;
 
         let geometry = client.geometry;
-        let centre = Point {
-            x: geometry.pos.x + i32::try_from(geometry.size.w / 2).unwrap_or(0),
-            y: geometry.pos.y + i32::try_from(geometry.size.h / 2).unwrap_or(0),
-        };
-        let monitor = i32::try_from(wm.monitor_index_at(centre)).unwrap_or(0);
+        let monitor = i32::try_from(wm.client_output_index(id)).unwrap_or(0);
         workspace_monitors[client.workspace].get_or_insert(monitor);
         workspace_fullscreen[client.workspace] |=
             client.flags.contains(wm_core::ClientFlags::FULLSCREEN);
@@ -246,6 +242,7 @@ fn build_snapshot(
             // Hyprland's own "unknown" — a number invented to fill the
             // gap would let a script signal the wrong process.
             pid: wm.backend().window_pid(client.window).and_then(|pid| i32::try_from(pid).ok()).unwrap_or(0),
+            floating: !wm.is_layout_managed(id),
             xwayland: wm.backend().windows.get(&client.window)
                 .is_some_and(|record| matches!(record.surface, ManagedSurface::X11(_))),
             fullscreen: client.flags.contains(wm_core::ClientFlags::FULLSCREEN),
@@ -269,6 +266,7 @@ fn build_snapshot(
                 .unwrap_or(0);
             Workspace {
                 index,
+                layout: wm.workspace_layout(index).compatible_name().into(),
                 monitor: monitors.iter().find(|monitor| monitor.id == monitor_id)
                     .map(|monitor| monitor.name.clone()).unwrap_or_default(),
                 monitor_id,
@@ -541,6 +539,12 @@ pub(crate) fn apply(comp: &mut Compositor, action: Action) -> bool {
                 (None, _, _) => false,
             }
         }
+        Action::ToggleMaximize => {
+            if let Some(id) = wm.focused_client() {
+                wm.toggle_maximize(id, wm_core::MaximizeDirections::FULL);
+            }
+            true
+        }
         Action::Fullscreen(which) => match wm.focused_client() {
             Some(client) => {
                 match which {
@@ -553,13 +557,21 @@ pub(crate) fn apply(comp: &mut Compositor, action: Action) -> bool {
             None => false,
         },
         Action::CycleFocus { forward } => wm.focus_adjacent_client(forward),
-        Action::FocusDirection(direction) => wm.focus_direction(match direction {
-            chonk_hyprland_ipc::dispatch::Direction::Left => wm_core::FocusDirection::Left,
-            chonk_hyprland_ipc::dispatch::Direction::Right => wm_core::FocusDirection::Right,
-            chonk_hyprland_ipc::dispatch::Direction::Up => wm_core::FocusDirection::Up,
-            chonk_hyprland_ipc::dispatch::Direction::Down => wm_core::FocusDirection::Down,
-        }),
-        Action::MoveWindow { window, x, y, relative } => match client_of(wm, window) {
+        Action::FocusDirection(direction) => {
+            wm.focus_direction(match direction {
+                chonk_hyprland_ipc::dispatch::Direction::Left => wm_core::FocusDirection::Left,
+                chonk_hyprland_ipc::dispatch::Direction::Right => wm_core::FocusDirection::Right,
+                chonk_hyprland_ipc::dispatch::Direction::Up => wm_core::FocusDirection::Up,
+                chonk_hyprland_ipc::dispatch::Direction::Down => wm_core::FocusDirection::Down,
+            });
+            true
+        }
+        Action::MoveWindow {
+            window,
+            x,
+            y,
+            relative,
+        } => match client_of(wm, window) {
             Some(id) => {
                 let Some(client) = wm.client(id) else { return false };
                 let mut geometry = client.geometry;
@@ -592,10 +604,52 @@ pub(crate) fn apply(comp: &mut Compositor, action: Action) -> bool {
             None => false,
         },
         Action::SetTag { window, tag, present } => client_of(wm, window).is_some_and(|id| wm.set_client_tag(id, &tag, present)),
-        Action::ConfirmFloating(window) => client_of(wm, window).is_some(),
-        Action::SetMonitorScale { output, scale_120 } => comp.set_output_scale(&output, scale_120 as f64 / 120.0),
-        Action::SetDpms { output, powered } => crate::output_power::set_from_ipc(comp, output.as_deref(), powered),
-        Action::SwitchKeyboardLayout { device, target } => switch_keyboard_layout(comp, &device, target),
+        Action::SetFloating { window, floating } => {
+            if let Some(id) = client_of(wm, window) {
+                if let Some(value) = floating {
+                    wm.set_floating(id, value);
+                } else {
+                    wm.toggle_floating(id);
+                }
+                true
+            } else {
+                false
+            }
+        }
+        Action::SetWorkspaceLayout { workspace, mode } => {
+            if let Some(mode) = wm_core::LayoutMode::parse(&mode) {
+                wm.set_workspace_layout(workspace, mode);
+                true
+            } else {
+                false
+            }
+        }
+        Action::ToggleLayout => {
+            wm.toggle_workspace_layout();
+            true
+        }
+        Action::LayoutNoop => true,
+        Action::MoveDirection(direction) => {
+            let direction = match direction {
+                chonk_hyprland_ipc::dispatch::Direction::Left => wm_core::FocusDirection::Left,
+                chonk_hyprland_ipc::dispatch::Direction::Right => wm_core::FocusDirection::Right,
+                chonk_hyprland_ipc::dispatch::Direction::Up => wm_core::FocusDirection::Up,
+                chonk_hyprland_ipc::dispatch::Direction::Down => wm_core::FocusDirection::Down,
+            };
+            if let Some(id) = wm.focused_client() {
+                wm.move_layout_window(id, direction);
+            }
+            true
+        }
+        Action::SetMonitorScale { output, scale_120 } => {
+            comp.set_output_scale(&output, scale_120 as f64 / 120.0)
+        }
+        Action::SetDpms { output, powered } => {
+            crate::output_power::set_from_ipc(comp, output.as_deref(), powered)
+        }
+        Action::SwitchKeyboardLayout { device, target } => {
+            switch_keyboard_layout(comp, &device, target)
+        }
         Action::SetCursorHidden(hidden) => {
             let owner = hidden.then(|| {
                 comp.seat

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -584,7 +584,7 @@ fn reclaim_leaked_grab(state: &mut Compositor, seat: &Seat<Compositor>) {
     }
     tracing::debug!(buttons_held, "reclaiming a pointer grab its drag outlived");
     backend.end_pointer_grab();
-    backend.queue(WmEvent::DragEnded);
+    backend.queue(WmEvent::DragCancelled);
 }
 
 /// Applies a pointer-grab transition the ledger recorded, in the one
@@ -1270,6 +1270,7 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
     let seat = state.seat.clone();
     let shortcuts_inhibited = seat.keyboard_shortcuts_inhibited();
     let modal_owns_keyboard = keyboard::modal_owns_keyboard(state);
+    let dragging = state.wm.interactive_drag_active();
     keyboard.input::<(), _>(state, keycode, key_state, serial, time, |data, mods, handle| {
         // Level-0 (unshifted) keysym, exactly like `wm-x11`'s
         // `keysym_for_keycode` taking the keycode's first sym: a combo
@@ -1359,7 +1360,10 @@ fn on_keyboard_key<I: InputBackend>(state: &mut Compositor, event: I::KeyboardKe
                 {
                     return FilterResult::Forward;
                 }
-                if modal_owns_keyboard || backend.grabbed_combos.contains(&combo) {
+                if modal_owns_keyboard
+                    || (dragging && combo.keysym == 0xff1b)
+                    || backend.grabbed_combos.contains(&combo)
+                {
                     if !backend.release_combos.contains(&combo) {
                         backend.queue(WmEvent::KeyPress(combo));
                     }
@@ -2812,6 +2816,14 @@ fn hit_at(backend: &WaylandBackend, at: Point, position: LogicalPoint<f64, Logic
 
     // Frame band.
     for entry in backend.stacking.iter().rev() {
+        let window = match entry {
+            StackEntry::Window(id) => Some(*id),
+            StackEntry::Frame(id) => backend.frames.get(id).map(|f| f.window),
+        };
+        if window.is_some_and(|id| !backend.layout_scene.allows_pointer(id, at)) {
+            continue;
+        }
+
         // A managed window with no frame is in this band at its own
         // depth (see `StackEntry::Window`). Everything the frame arm
         // below does applies to it but the chrome: popups first, then

--- a/crates/wm-wayland/src/layout_scene.rs
+++ b/crates/wm-wayland/src/layout_scene.rs
@@ -1,0 +1,489 @@
+//! Cached presentation of core layout transactions. No layout policy lives here.
+use crate::overview::{interpolate, Window};
+use crate::renderer::SceneElement;
+use crate::state::{Compositor, Graphics, StackEntry, WaylandBackend, WlFrameId, WlWindowId};
+use smithay::backend::renderer::element::{memory::MemoryRenderBuffer, Id};
+use smithay::backend::renderer::{gles::GlesRenderer, Color32F};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use wm_core::gesture_physics::Spring;
+use wm_theme_api::{DecorationBuffer, Point, Rect};
+
+struct Motion {
+    from: Rect,
+    to: Rect,
+    spring: Spring,
+}
+impl Motion {
+    fn geometry(&self) -> Rect {
+        interpolate(self.from, self.to, self.spring.position)
+    }
+}
+
+struct Presentation {
+    window: Window,
+    clip: Option<Rect>,
+    motion: Option<Motion>,
+    crop: Id,
+}
+
+struct Caption {
+    buffer: MemoryRenderBuffer,
+    geometry: Rect,
+    expires: Instant,
+}
+
+pub(crate) struct Scene {
+    pub setups: u64,
+    pub setup_ns: u128,
+    pub build_ns: std::cell::Cell<u128>,
+    pub builds: std::cell::Cell<u64>,
+    pub culled: std::cell::Cell<u64>,
+    pub configures: u64,
+    windows: HashMap<WlWindowId, Presentation>,
+    caption: Option<Caption>,
+    preview: Option<Rect>,
+    drag: Option<Window>,
+    preview_ids: [Id; 4],
+    last_frame: Instant,
+    next_frame: Instant,
+}
+impl Default for Scene {
+    fn default() -> Self {
+        Self {
+            setups: 0,
+            setup_ns: 0,
+            build_ns: std::cell::Cell::new(0),
+            builds: std::cell::Cell::new(0),
+            culled: std::cell::Cell::new(0),
+            configures: 0,
+            windows: HashMap::new(),
+            caption: None,
+            preview: None,
+            drag: None,
+            preview_ids: std::array::from_fn(|_| Id::new()),
+            last_frame: Instant::now(),
+            next_frame: Instant::now(),
+        }
+    }
+}
+impl Scene {
+    pub fn workarea(&self, window: WlWindowId) -> Option<Rect> {
+        self.windows.get(&window).and_then(|p| p.clip)
+    }
+
+    pub fn transitioning(&self, window: WlWindowId) -> bool {
+        self.windows
+            .get(&window)
+            .is_some_and(|p| p.motion.is_some())
+    }
+
+    pub fn animating(&self) -> bool {
+        self.windows.values().any(|w| w.motion.is_some())
+    }
+
+    pub fn allows_pointer(&self, window: WlWindowId, at: Point) -> bool {
+        self.windows
+            .get(&window)
+            .is_none_or(|p| p.motion.is_none() && p.clip.is_none_or(|clip| clip.contains(at)))
+    }
+
+    /// Idempotent: settle to already committed semantic geometry, discard
+    /// transient effects, and retain only the output clips still in use.
+    pub fn cancel(&mut self) {
+        self.windows.retain(|_, p| {
+            p.motion = None;
+            p.clip.is_some()
+        });
+        self.caption = None;
+        self.preview = None;
+        self.drag = None;
+    }
+}
+
+pub(crate) fn present(
+    backend: &mut WaylandBackend,
+    window: WlWindowId,
+    frame: Option<WlFrameId>,
+    source: Rect,
+    destination: Rect,
+    clip: Option<Rect>,
+    animate: bool,
+) {
+    let started = Instant::now();
+    if !backend.windows.contains_key(&window) {
+        return;
+    }
+    if source == destination
+        && clip.is_some()
+        && !backend.layout_scene.windows.contains_key(&window)
+    {
+        let snapshot = Window::snapshot(window, frame, destination, backend);
+        backend.layout_scene.windows.insert(
+            window,
+            Presentation {
+                window: snapshot,
+                clip,
+                motion: None,
+                crop: Id::new(),
+            },
+        );
+    }
+    let scene = &mut backend.layout_scene;
+    if source == destination {
+        if scene
+            .windows
+            .get(&window)
+            .is_some_and(|p| p.window.source != destination)
+        {
+            scene.windows.remove(&window);
+        }
+        if let Some(p) = scene.windows.get_mut(&window) {
+            p.clip = clip;
+        }
+        return;
+    }
+    let from = scene
+        .drag
+        .as_ref()
+        .filter(|w| w.window == window)
+        .map(|w| w.destination)
+        .unwrap_or_else(|| {
+            scene
+                .windows
+                .get(&window)
+                .and_then(|p| p.motion.as_ref())
+                .map_or(source, Motion::geometry)
+        });
+    let was_animating = scene.animating();
+    let snapshot = Window::snapshot(window, frame, destination, backend);
+    let scene = &mut backend.layout_scene;
+    let crop = scene
+        .windows
+        .get(&window)
+        .map_or_else(Id::new, |p| p.crop.clone());
+    scene.windows.insert(
+        window,
+        Presentation {
+            window: snapshot,
+            clip,
+            crop,
+            motion: animate.then(|| Motion {
+                from,
+                to: destination,
+                spring: Spring::new(0.0, 0.0, 1.0),
+            }),
+        },
+    );
+    if !was_animating {
+        scene.last_frame = Instant::now();
+    }
+    scene.next_frame = Instant::now();
+    backend.mark_damaged();
+    backend.layout_scene.setups += 1;
+    backend.layout_scene.setup_ns += started.elapsed().as_nanos();
+}
+
+pub(crate) fn preview(
+    backend: &mut WaylandBackend,
+    drag: Option<wm_core::LayoutDrag<WlWindowId, WlFrameId>>,
+    target: Option<Rect>,
+) {
+    if let Some(wm_core::LayoutDrag {
+        window: id,
+        frame,
+        source,
+        destination,
+    }) = drag
+    {
+        if let Some(window) = backend
+            .layout_scene
+            .drag
+            .as_mut()
+            .filter(|w| w.window == id)
+        {
+            window.destination = destination;
+        } else {
+            let mut window = Window::snapshot(id, frame, source, backend);
+            window.destination = destination;
+            backend.layout_scene.drag = Some(window);
+        }
+    } else {
+        backend.layout_scene.drag = None;
+    }
+    backend.layout_scene.preview = target;
+}
+
+pub(crate) fn caption(backend: &mut WaylandBackend, label: DecorationBuffer) {
+    let Some(buffer) = crate::backend_impl::import_buffer(&label, false) else {
+        return;
+    };
+    let Some(monitor) = backend
+        .monitors
+        .iter()
+        .find(|m| m.primary)
+        .or_else(|| backend.monitors.first())
+    else {
+        return;
+    };
+    let geometry = Rect::new(
+        Point::new(
+            monitor.geometry.pos.x
+                + (monitor.geometry.size.w.saturating_sub(label.width) / 2) as i32,
+            monitor.geometry.pos.y + (monitor.geometry.size.h / 12) as i32,
+        ),
+        wm_core::Size::new(label.width, label.height),
+    );
+    backend.layout_scene.caption = Some(Caption {
+        buffer,
+        geometry,
+        expires: Instant::now() + Duration::from_millis(950),
+    });
+    backend.mark_damaged();
+}
+
+pub(crate) fn tick(comp: &mut Compositor) {
+    let cancel = comp.wm.backend().locked
+        || comp.wm.backend().gesture_scene.is_some()
+        || comp.wm.backend().overview.is_some()
+        || comp.wm.backend().keyboard_grabbed
+        || comp.wm.backend().capture_ui.is_some()
+        || comp.layer_shell.exclusive_focus.is_some()
+        || comp.focus_grab.is_active()
+        || !comp.running
+        || comp.restart;
+    if cancel && comp.wm.interactive_drag_active() {
+        comp.wm.dispatch(wm_core::BackendEvent::DragCancelled);
+    }
+    let now = Instant::now();
+    let interval = comp
+        .outputs
+        .iter()
+        .filter_map(|o| o.output.current_mode())
+        .filter(|m| m.refresh > 0)
+        .map(|m| {
+            Duration::from_nanos(1_000_000_000_000 / (m.refresh as u64).clamp(1000, 1_000_000))
+        })
+        .min()
+        .unwrap_or(Duration::from_nanos(1_000_000_000 / 60));
+    let backend = comp.wm.backend_mut();
+    let scene = &mut backend.layout_scene;
+    let mut damaged = scene.animating();
+    if cancel {
+        scene.cancel();
+    }
+    let dt = now
+        .saturating_duration_since(scene.last_frame)
+        .as_secs_f64();
+    scene.windows.retain(|id, p| {
+        let Some(record) = backend.windows.get(id).filter(|r| r.surface.alive()) else {
+            return false;
+        };
+        if !record.mapped {
+            p.motion = None;
+        }
+        if p.motion
+            .as_mut()
+            .is_some_and(|motion| motion.spring.advance(dt))
+        {
+            p.motion = None;
+        }
+        p.motion.is_some() || p.clip.is_some()
+    });
+    if scene.caption.as_ref().is_some_and(|c| now >= c.expires) {
+        scene.caption = None;
+        damaged = true;
+    }
+    scene.last_frame = now;
+    scene.next_frame = now + interval;
+    if damaged {
+        backend.mark_damaged();
+    }
+}
+
+pub(crate) fn deadline(comp: &Compositor) -> Option<Instant> {
+    let scene = &comp.wm.backend().layout_scene;
+    let animation = (matches!(comp.graphics, Graphics::Winit(_)) && scene.animating())
+        .then_some(scene.next_frame);
+    animation
+        .into_iter()
+        .chain(scene.caption.as_ref().map(|c| c.expires))
+        .min()
+}
+
+pub(crate) fn render_window(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    entry: &StackEntry,
+    viewport: Rect,
+) -> bool {
+    let id = match entry {
+        StackEntry::Window(id) => *id,
+        StackEntry::Frame(id) => match backend.frames.get(id) {
+            Some(f) if f.mapped => f.window,
+            _ => return false,
+        },
+    };
+    if backend
+        .layout_scene
+        .drag
+        .as_ref()
+        .is_some_and(|w| w.window == id)
+    {
+        return true;
+    }
+    let Some(p) = backend.layout_scene.windows.get(&id) else {
+        return false;
+    };
+    if !backend.windows.get(&id).is_some_and(|r| r.mapped) {
+        return false;
+    }
+    let Some(mut visible) = p
+        .clip
+        .map_or(Some(viewport), |clip| clip.intersection(viewport))
+    else {
+        return true;
+    };
+    let started = Instant::now();
+    let mut destination = p.motion.as_ref().map_or(p.window.source, Motion::geometry);
+    destination.pos.x -= viewport.pos.x;
+    destination.pos.y -= viewport.pos.y;
+    visible.pos.x -= viewport.pos.x;
+    visible.pos.y -= viewport.pos.y;
+    let start = elements.len();
+    crate::overview::render_layout_window(
+        elements,
+        renderer,
+        backend,
+        &p.window,
+        destination,
+        visible,
+    );
+    if let Some(mut clip) = p.clip {
+        clip.pos.x -= viewport.pos.x;
+        clip.pos.y -= viewport.pos.y;
+        crate::renderer::clip_plane(elements, start, clip, &p.crop);
+    }
+    let scene = &backend.layout_scene;
+    scene
+        .build_ns
+        .set(scene.build_ns.get() + started.elapsed().as_nanos());
+    scene.builds.set(scene.builds.get() + 1);
+    if start == elements.len() {
+        scene.culled.set(scene.culled.get() + 1);
+    }
+    true
+}
+
+pub(crate) fn render_feedback(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    viewport: Rect,
+) {
+    use smithay::backend::renderer::element::{memory::MemoryRenderBufferRenderElement, Kind};
+    let scene = &backend.layout_scene;
+    if let Some(drag) = &scene.drag {
+        let mut destination = drag.destination;
+        destination.pos.x -= viewport.pos.x;
+        destination.pos.y -= viewport.pos.y;
+        crate::overview::render_window(elements, renderer, backend, drag, destination, 0.82);
+    }
+    if let Some(caption) = &scene.caption {
+        if let Ok(element) = MemoryRenderBufferRenderElement::from_buffer(
+            renderer,
+            (
+                (caption.geometry.pos.x - viewport.pos.x) as f64,
+                (caption.geometry.pos.y - viewport.pos.y) as f64,
+            ),
+            &caption.buffer,
+            None,
+            None,
+            None,
+            Kind::Unspecified,
+        ) {
+            elements.push(element.into());
+        }
+    }
+    if let Some(mut rect) = scene.preview {
+        rect.pos.x -= viewport.pos.x;
+        rect.pos.y -= viewport.pos.y;
+        let thickness = (backend.scale_at(viewport) * 3.0).round().max(1.0) as u32;
+        let w = rect.size.w;
+        let h = rect.size.h;
+        for (id, (x, y, w, h)) in scene.preview_ids.iter().zip([
+            (0, 0, w, thickness),
+            (0, h.saturating_sub(thickness), w, thickness),
+            (0, 0, thickness, h),
+            (w.saturating_sub(thickness), 0, thickness, h),
+        ]) {
+            crate::overview::solid(
+                elements,
+                id,
+                Rect::new(
+                    Point::new(rect.pos.x + x as i32, rect.pos.y + y as i32),
+                    wm_core::Size::new(w, h),
+                ),
+                Color32F::new(0.6, 0.75, 0.9, 0.8),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[global_allocator]
+    static ALLOCATOR: chonk_test_support::AllocationCounter = chonk_test_support::AllocationCounter;
+
+    #[test]
+    fn cached_layout_motion_allocates_nothing_while_interpolating_live_frames() {
+        let from = Rect::new(Point::new(-800, 80), wm_core::Size::new(800, 600));
+        let to = Rect::new(Point::new(100, 0), wm_core::Size::new(600, 1000));
+        let (_, allocations) = chonk_test_support::measure(|| {
+            for _ in 0..1000 {
+                let mut motion = Motion {
+                    from,
+                    to,
+                    spring: Spring::new(0.0, 0.0, 1.0),
+                };
+                for _ in 0..144 {
+                    motion.spring.advance(std::hint::black_box(1.0 / 144.0));
+                    std::hint::black_box(motion.geometry());
+                }
+            }
+        });
+        assert_eq!((allocations.calls, allocations.requested_bytes), (0, 0));
+    }
+
+    #[test]
+    fn live_geometry_interpolates_interrupts_and_settles_at_actual_frame_rates() {
+        let from = Rect::new(Point::new(80, 100), wm_core::Size::new(900, 600));
+        let to = Rect::new(Point::new(0, 0), wm_core::Size::new(1280, 1000));
+        for hz in [60, 120, 144, 240] {
+            let mut m = Motion {
+                from,
+                to,
+                spring: Spring::new(0.0, 0.0, 1.0),
+            };
+            assert_eq!(m.geometry(), from);
+            m.spring.advance(0.05);
+            let middle = m.geometry();
+            assert_ne!(middle, from);
+            assert_ne!(middle, to);
+            let mut replacement = Motion {
+                from: middle,
+                to: from,
+                spring: Spring::new(0.0, 0.0, 1.0),
+            };
+            assert_eq!(replacement.geometry(), middle);
+            for _ in 0..hz * 2 {
+                m.spring.advance(1.0 / hz as f64);
+            }
+            assert_eq!(m.geometry(), to);
+            replacement.spring.advance(10.0);
+            assert_eq!(replacement.geometry(), from);
+        }
+    }
+}

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -58,6 +58,7 @@ mod readback;
 mod renderer;
 mod overview;
 mod gesture_scene;
+mod layout_scene;
 mod selection;
 mod session;
 mod state;

--- a/crates/wm-wayland/src/lock.rs
+++ b/crates/wm-wayland/src/lock.rs
@@ -291,7 +291,7 @@ fn enter_lock_domain(comp: &mut Compositor) {
     // held across the lock cannot route the first post-unlock events
     // to a pre-lock target.
     backend.end_pointer_grab();
-    backend.queue(BackendEvent::DragEnded);
+    backend.queue(BackendEvent::DragCancelled);
     backend.mark_damaged();
     let seat = comp.seat.clone();
     crate::input::clear_implicit_grab(&seat);

--- a/crates/wm-wayland/src/overview.rs
+++ b/crates/wm-wayland/src/overview.rs
@@ -198,7 +198,12 @@ fn overlaps(a: Rect, b: Rect) -> bool {
         && b.pos.y < a.pos.y + a.size.h as i32
 }
 
-fn solid(elements: &mut Vec<SceneElement<GlesRenderer>>, id: &Id, rect: Rect, color: Color32F) {
+pub(crate) fn solid(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    id: &Id,
+    rect: Rect,
+    color: Color32F,
+) {
     if rect.size.w == 0 || rect.size.h == 0 {
         return;
     }
@@ -378,6 +383,40 @@ pub(crate) fn render_window(
     destination: Rect,
     alpha: f32,
 ) {
+    render_window_scaled(
+        elements,
+        renderer,
+        backend,
+        window,
+        destination,
+        alpha,
+        false,
+        None,
+    );
+}
+
+pub(crate) fn render_layout_window(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    window: &Window,
+    destination: Rect,
+    viewport: Rect,
+) {
+    render_window_scaled(elements, renderer, backend, window, destination, 1.0, true, Some(viewport));
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_window_scaled(
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    backend: &WaylandBackend,
+    window: &Window,
+    destination: Rect,
+    alpha: f32,
+    stretch: bool,
+    viewport: Option<Rect>,
+) {
     let Some(record) = backend
         .windows
         .get(&window.window)
@@ -390,28 +429,75 @@ pub(crate) fn render_window(
     if scale <= 0.0 {
         return;
     }
+    let sx = if stretch {
+        destination.size.w as f64 / window.source.size.w.max(1) as f64
+    } else {
+        scale
+    };
+    let sy = if stretch {
+        destination.size.h as f64 / window.source.size.h.max(1) as f64
+    } else {
+        scale
+    };
     let before = elements.len();
     if let Some(surface) = record.surface.wl_surface().filter(|_| window.draw_content) {
         let origin = SPoint::<i32, Physical>::from((
             destination.pos.x
                 + ((record.content.pos.x - record.content_offset.x - window.source.pos.x) as f64
-                    * scale)
+                    * sx)
                     .round() as i32,
             destination.pos.y
                 + ((record.content.pos.y - record.content_offset.y - window.source.pos.y) as f64
-                    * scale)
+                    * sy)
                     .round() as i32,
         ));
-        push_surface_tree_alpha(
-            elements,
-            renderer,
-            &surface,
-            origin,
-            backend.window_surface_scale(record) * scale,
-            1.0,
-            Kind::Unspecified,
-            alpha,
-        );
+        let factor = backend.window_surface_scale(record);
+        let committed = if stretch {
+            crate::xdg::committed_content_size(&surface, factor, backend.output_size)
+                .unwrap_or(record.content.size)
+        } else {
+            record.content.size
+        };
+        let surface_scale = smithay::utils::Scale::from((
+            factor * sx * record.content.size.w as f64 / committed.w.max(1) as f64,
+            factor * sy * record.content.size.h as f64 / committed.h.max(1) as f64,
+        ));
+        // Managed presentation owns the same popup plane as ordinary windows.
+        // Each popup keeps its own committed scale, anchored through its
+        // parent's transform. Overview retains its existing thumbnail policy.
+        if stretch {
+            for (popup, offset) in backend.popups_for_surface(&surface) {
+                let popup_surface = popup.wl_surface();
+                let popup_factor = crate::xdg::effective_surface_scale(
+                    crate::xdg::committed_surface_scale(popup_surface),
+                    backend.scale_at(record.content),
+                );
+                let popup_scale = smithay::utils::Scale::from((popup_factor * sx, popup_factor * sy));
+                let at = Point::new(
+                    origin.x.saturating_add((offset.x as f64 * factor * sx).round() as i32),
+                    origin.y.saturating_add((offset.y as f64 * factor * sy).round() as i32),
+                );
+                if viewport.is_none_or(|v| crate::renderer::surface_tree_reaches_viewport(
+                    popup_surface, at, Rect::new(at, Size::default()), popup_scale, v,
+                )) {
+                    push_surface_tree_alpha(elements, renderer, popup_surface,
+                        (at.x, at.y).into(), popup_scale, 1.0, Kind::Unspecified, alpha);
+                }
+            }
+        }
+        if viewport.is_none_or(|v| crate::renderer::surface_tree_reaches_viewport(
+            &surface, Point::new(origin.x, origin.y), destination, surface_scale, v,
+        )) {
+            push_surface_tree_alpha(
+                elements, renderer, &surface, origin, surface_scale, 1.0, Kind::Unspecified, alpha,
+            );
+        }
+    }
+    // Offscreen Flow cells still get the exact surface-tree check above: a
+    // subsurface or popup may extend into view. Their chrome and fallback
+    // cannot, so skip their imports and element construction entirely.
+    if viewport.is_some_and(|v| destination.intersection(v).is_none()) {
+        return;
     }
     if let Some(buffer) = window
         .fallback
@@ -447,10 +533,10 @@ pub(crate) fn render_window(
         for part in &frame.parts {
             let origin = SPoint::<i32, Physical>::from((
                 destination.pos.x
-                    + ((frame.geometry.pos.x + part.offset.x - window.source.pos.x) as f64 * scale)
+                    + ((frame.geometry.pos.x + part.offset.x - window.source.pos.x) as f64 * sx)
                         .round() as i32,
                 destination.pos.y
-                    + ((frame.geometry.pos.y + part.offset.y - window.source.pos.y) as f64 * scale)
+                    + ((frame.geometry.pos.y + part.offset.y - window.source.pos.y) as f64 * sy)
                         .round() as i32,
             ));
             if let Ok(element) = MemoryRenderBufferRenderElement::from_buffer(
@@ -462,7 +548,14 @@ pub(crate) fn render_window(
                 None,
                 Kind::Unspecified,
             ) {
-                elements.push(RescaleRenderElement::from_element(element, origin, scale).into());
+                elements.push(
+                    RescaleRenderElement::from_element(
+                        element,
+                        origin,
+                        smithay::utils::Scale::from((sx, sy)),
+                    )
+                    .into(),
+                );
             }
         }
         solid(

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -318,6 +318,8 @@ pub(crate) fn build_scene_into(
         push_layer_band(elements, renderer, backend, WlrLayer::Top, viewport);
     }
 
+    crate::layout_scene::render_feedback(elements, renderer, backend, viewport);
+
     // XWayland override-redirect windows (menus, tooltips —
     // `WindowType::Unmanaged`, so they own no frame and no
     // stacking entry) draw above every managed frame, which is
@@ -330,6 +332,9 @@ pub(crate) fn build_scene_into(
     }
 
     for entry in backend.stacking.iter().rev() {
+        if crate::layout_scene::render_window(elements, renderer, backend, entry, viewport) {
+            continue;
+        }
         // A managed window whose client drew its own chrome has no
         // frame and no decoration buffer — just its content, at the
         // depth its own stacking slot gives it. Nothing else in this
@@ -1286,25 +1291,26 @@ fn push_window_content(
 /// incorrectly clipping overflow at an output boundary. The expensive
 /// import/element construction then runs only for outputs the tree can
 /// actually reach.
-fn surface_tree_reaches_viewport(
+pub(crate) fn surface_tree_reaches_viewport(
     surface: &WlSurface,
     global_origin: Point,
     ledger_rect: Rect,
-    factor: f64,
+    factor: impl Into<Scale<f64>>,
     viewport: Rect,
 ) -> bool {
     if overlap_area(ledger_rect, viewport) > 0 {
         return true;
     }
+    let factor = factor.into();
     let logical = bbox_from_surface_tree(surface, (0, 0));
     let x = global_origin
         .x
-        .saturating_add(crate::xdg::scale_length(logical.loc.x, factor));
+        .saturating_add(crate::xdg::scale_length(logical.loc.x, factor.x));
     let y = global_origin
         .y
-        .saturating_add(crate::xdg::scale_length(logical.loc.y, factor));
-    let width = crate::xdg::scale_length(logical.size.w, factor).max(0) as u32;
-    let height = crate::xdg::scale_length(logical.size.h, factor).max(0) as u32;
+        .saturating_add(crate::xdg::scale_length(logical.loc.y, factor.y));
+    let width = crate::xdg::scale_length(logical.size.w, factor.x).max(0) as u32;
+    let height = crate::xdg::scale_length(logical.size.h, factor.y).max(0) as u32;
     overlap_area(Rect::new(Point::new(x, y), wm_theme_api::Size::new(width, height)), viewport) > 0
 }
 
@@ -1357,9 +1363,14 @@ pub(crate) fn push_surface_tree(
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn push_surface_tree_alpha(
-    elements: &mut Vec<SceneElement<GlesRenderer>>, renderer: &mut GlesRenderer,
-    surface: &WlSurface, location: SPoint<i32, Physical>, factor: f64,
-    render_scale: f64, kind: Kind, alpha: f32,
+    elements: &mut Vec<SceneElement<GlesRenderer>>,
+    renderer: &mut GlesRenderer,
+    surface: &WlSurface,
+    location: SPoint<i32, Physical>,
+    factor: impl Into<Scale<f64>>,
+    render_scale: f64,
+    kind: Kind,
+    alpha: f32,
 ) {
     // This is smithay's `render_elements_from_surface_tree` traversal
     // with its sink made caller-owned. That helper necessarily returns
@@ -1377,6 +1388,7 @@ pub(crate) fn push_surface_tree_alpha(
     // inside smithay that cannot be rewritten from here — but the walk
     // this compositor owns should not need that bound to be safe, and
     // does not.
+    let factor = factor.into();
     let tree_origin = location;
     let scale: Scale<f64> = render_scale.into();
     let mut pending = take_walk_stack();

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -364,6 +364,8 @@ impl ManagedSurface {
 /// caches it and the queries become lookups.
 pub(crate) struct WindowRecord {
     pub surface: ManagedSurface,
+    /// Last observed protocol constraints, for change-driven core events.
+    pub size_hints: wm_core::SizeHints,
     /// The client content's root-relative rectangle — the analogue of
     /// the client window's geometry inside its X11 frame. Written by
     /// `Backend::configure_client`/`position_client`; read by the
@@ -480,6 +482,7 @@ impl WindowRecord {
     pub(crate) fn new(surface: ManagedSurface, content: Rect) -> Self {
         Self {
             surface,
+            size_hints: wm_core::SizeHints::default(),
             content,
             mapped: false,
             fullscreen: false,
@@ -626,6 +629,7 @@ pub struct WaylandBackend {
     pub(crate) shells: HashMap<WlShellId, ShellRecord>,
     pub(crate) overview: Option<crate::overview::Overview>,
     pub(crate) gesture_scene: Option<crate::gesture_scene::Transition>,
+    pub(crate) layout_scene: crate::layout_scene::Scene,
     pub(crate) capture_ui: Option<crate::capture_tool::Overlay>,
     /// Bottom-to-top managed application order — see [`StackEntry`].
     pub(crate) stacking: Vec<StackEntry>,
@@ -1016,6 +1020,7 @@ impl WaylandBackend {
             windows: HashMap::new(),
             overview: None,
             gesture_scene: None,
+            layout_scene: crate::layout_scene::Scene::default(),
             capture_ui: None,
             scene_index: SceneIndex::default(),
             surface_windows: HashMap::new(),
@@ -1211,7 +1216,11 @@ impl WaylandBackend {
         }
         crate::xdg::effective_surface_scale(
             crate::xdg::committed_surface_scale(&surface),
-            self.scale_at(record.content),
+            self.scale_at(
+                self.window_for_surface(&surface)
+                    .and_then(|id| self.layout_scene.workarea(id))
+                    .unwrap_or(record.content),
+            ),
         )
     }
 
@@ -2517,6 +2526,7 @@ impl Compositor {
         // Spring commits join the ordinary notification/focus/protocol drain
         // below, so a workspace settles and receives keyboard focus together.
         crate::gesture_scene::tick(self);
+        crate::layout_scene::tick(self);
         self.apply_pending_keyboard();
         if let Some(config) = self.wm.backend_mut().pending_pointer.take() {
             self.wm.backend_mut().scroll_factor = config.scroll_factor.unwrap_or(1.0);
@@ -4228,6 +4238,9 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
             wait = wait.min(deadline.saturating_duration_since(now));
         }
         if let Some(deadline) = crate::session::next_render_deadline(&comp.graphics) {
+            wait = wait.min(deadline.saturating_duration_since(now));
+        }
+        if let Some(deadline) = crate::layout_scene::deadline(&comp) {
             wait = wait.min(deadline.saturating_duration_since(now));
         }
         if let Some(deadline) = crate::gesture_scene::deadline(&comp) {

--- a/crates/wm-wayland/src/test_door.rs
+++ b/crates/wm-wayland/src/test_door.rs
@@ -813,6 +813,12 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                 logical_focus.map_or(0, |w| w.0), seat_focus.map_or(0, |w| w.0)));
             let (owner, (x, y), motion) = crate::input::gestures::inspect(comp);
             reply.push_str(&format!("swipe-stream owner={owner} x={x} y={y} axis={:?}\n", motion.map(|m| m.axis)));
+            let spatial = comp.wm.layout_statistics();
+            reply.push_str(&format!("spatial mode={} moving={} calculations={} calculation_us={} managed={} changes={} setups={} setup_us={} configures={} builds={} build_us={} culled={}\n",
+                comp.wm.workspace_layout(comp.wm.current_workspace()).name(), backend.layout_scene.animating(), spatial.calculations,
+                spatial.calculation_us, comp.wm.layout_order(comp.wm.current_workspace()).iter().filter(|&&id| comp.wm.is_layout_managed(id)).count(), spatial.geometry_changes,
+                backend.layout_scene.setups, backend.layout_scene.setup_ns / 1000, backend.layout_scene.configures,
+                backend.layout_scene.builds.get(), backend.layout_scene.build_ns.get() / 1000, backend.layout_scene.culled.get()));
             reply.push_str(&format!("scale {}\n", comp.ui_scale));
             reply.push_str(&format!("workspaces current={} count={}\n",
                 comp.wm.current_workspace(), comp.wm.workspace_count()));

--- a/crates/wm-wayland/src/xdg.rs
+++ b/crates/wm-wayland/src/xdg.rs
@@ -73,7 +73,7 @@ use smithay::{
     delegate_xdg_decoration, delegate_xdg_shell,
 };
 
-use wm_core::{BackendEvent, NetState, NetStateAction};
+use wm_core::{Backend, BackendEvent, NetState, NetStateAction};
 use wm_theme_api::{
     clamp_client_size, client_size_limit, subsurface_link_exceeds_depth, Point, Rect, ResizeEdge,
     Size, MAX_SUBSURFACE_DEPTH,
@@ -522,7 +522,11 @@ fn committed_content_offset(surface: &WlSurface, factor: f64, screen: Size) -> P
 /// any other number and the three descriptions of one window stop
 /// agreeing: the frame is drawn to one rectangle, the pointer routed by
 /// a second, and the client's pixels land in a third.
-fn committed_content_size(surface: &WlSurface, factor: f64, screen: Size) -> Option<Size> {
+pub(crate) fn committed_content_size(
+    surface: &WlSurface,
+    factor: f64,
+    screen: Size,
+) -> Option<Size> {
     let geometry = with_states(surface, |states| {
         let mut guard = states.cached_state.get::<SurfaceCachedState>();
         guard.current().geometry
@@ -1122,7 +1126,8 @@ impl Compositor {
         let backend = self.wm.backend();
         if let Some(id) = owner {
             if let Some(record) = backend.windows.get(&id) {
-                return backend.scale_at(record.content);
+                return backend
+                    .scale_at(backend.layout_scene.workarea(id).unwrap_or(record.content));
             }
         }
         if let Some(record) = backend
@@ -1168,6 +1173,13 @@ impl Compositor {
             with_renderer_surface_state(&root, |state| state.buffer().is_some()).unwrap_or(false);
         let was_mapped = mapped_marker(&root);
         let backend = self.wm.backend_mut();
+        let hints = backend.size_hints(id);
+        if let Some(record) = backend.windows.get_mut(&id) {
+            if record.size_hints != hints {
+                record.size_hints = hints;
+                backend.queue(WmEvent::SizeHintsChanged(id));
+            }
+        }
         let parent = toplevel
             .parent()
             .and_then(|surface| backend.window_for_surface(&surface));
@@ -1297,7 +1309,12 @@ impl Compositor {
                         client_behind, echoes_ask, staged = backend.configure_debt.contains_key(&id),
                         "committed client geometry differs from desired geometry");
                 }
-                if record.mapped && !client_behind && !echoes_ask && size != record.content.size {
+                if record.mapped
+                    && !client_behind
+                    && !echoes_ask
+                    && !backend.layout_scene.transitioning(id)
+                    && size != record.content.size
+                {
                     let requested = Rect {
                         pos: record.content.pos,
                         size,
@@ -1542,6 +1559,8 @@ impl WaylandBackend {
                 continue;
             }
             let staged_configure_sent = toplevel.send_pending_configure().is_some();
+            self.layout_scene.configures +=
+                u64::from(staged_configure_sent || debt.forces_configure(staged_configure_sent));
             if debt.forces_configure(staged_configure_sent) {
                 // Nothing changed, so `wm-core` declined the request (or
                 // the window was already in the asked-for state). The

--- a/crates/wm-wayland/src/xwayland.rs
+++ b/crates/wm-wayland/src/xwayland.rs
@@ -436,6 +436,9 @@ impl XwmHandler for Compositor {
             WmWindowProperty::MotifHints => {
                 backend.queue(WmEvent::ChromeChanged(id));
             }
+            WmWindowProperty::NormalHints => {
+                backend.queue(WmEvent::SizeHintsChanged(id));
+            }
             // ICCCM `WM_HINTS`, whose urgency bit is how the great
             // majority of X11 applications actually ask for attention —
             // IRC and chat clients, terminal bells, mail notifiers.

--- a/crates/wm-x11/src/backend.rs
+++ b/crates/wm-x11/src/backend.rs
@@ -1266,6 +1266,9 @@ impl X11Backend {
                 if e.atom == self.motif_wm_hints {
                     return Some(BackendEvent::ChromeChanged(XWindow(e.window)));
                 }
+                if e.atom == u32::from(AtomEnum::WM_NORMAL_HINTS) {
+                    return Some(BackendEvent::SizeHintsChanged(XWindow(e.window)));
+                }
                 if e.atom == u32::from(AtomEnum::WM_TRANSIENT_FOR) {
                     return Some(BackendEvent::ParentChanged(XWindow(e.window)));
                 }

--- a/docs/engineering/2026-09-06-spatial-layout.md
+++ b/docs/engineering/2026-09-06-spatial-layout.md
@@ -1,0 +1,145 @@
+# Three views of the same desktop
+
+Baseline: `8acbc30` (`feat/overview-window-drag`), including finger-following
+workspace and Overview gestures. No existing spatial layout engine was found.
+The untracked maintainer notes are left alone. This change builds on that HEAD.
+
+The subsequent [adversarial review](2026-09-07-adversarial-review.md) records
+additional lifecycle/protocol fixes, hardened escaped session records, expanded
+native tests, and revised measurements. Results below describe the initial
+implementation; the follow-up supersedes its setup-counter resolution limit.
+
+## Ownership
+
+`wm-core::WindowManager` owns workspace mode, ordered membership, remembered
+freeform content geometry, output affinity, Mosaic proportions and Flow widths.
+The existing global workspace row stays global. Each mode arranges its windows
+independently within each output's reserved workarea. Floating and minimized
+windows retain their positions in the ordered membership list. Neither renderer,
+shell nor input adapter owns a second copy of layout policy.
+
+Core and backend currently exchange root-relative device-coordinate rectangles,
+including pre-scaled decoration extents. The solver uses output-local logical
+coordinates; its boundary adapter converts positions and dimensions once using
+that output's scale. It must not reinterpret the existing core geometry contract.
+Output affinity is independent of Flow's offscreen geometry. Hardware identity,
+then connector, then the current primary output resolves affinity after hotplug.
+
+Entering a managed mode snapshots freeform geometry once. Mode changes, reflow,
+temporary floating edits, minimize, maximize and fullscreen never overwrite that
+snapshot. Returning to Freeform restores it through the existing reachability
+rules. A subsequent visit begins a new snapshot. Explicitly floating windows,
+dialogs/transients, fixed-size and rule-selected utility windows stay floating.
+Maximize/fullscreen temporarily suspend participation and restore it afterwards.
+Shade explicitly floats a managed window before rolling it up; rejoining unshades.
+
+## Layout and interaction
+
+Mosaic uses deterministic balanced columns (rows on portrait outputs), with
+one large first region for three windows. No tree or tree commands. Weighted
+partitions retain user proportions; minimum sizes constrain boundaries. Windows
+whose constraints cannot fit remain reachable as floating exceptions rather
+than breaking the other cells. Flow is one horizontal sequence per output, with
+remembered useful widths and a focus-following viewport. Up/down within Flow is
+an intentional no-op. Spatial movement reorders the same membership list.
+
+Managed drags use whole-cell targets and a retained native preview. Release
+commits reordering; cancellation commits nothing. Floating is always explicit.
+Focus stays on the same client during mode changes, reflow, resizing and toggles;
+only existing focus operations change it. Destruction removes the generational
+client identity from all membership state before selecting a successor.
+
+## Presentation and protocol boundary
+
+Reuse `gesture_physics::Spring`, native surface trees, retained render elements,
+GPU clipping and the existing frame/deadline loop. A layout transaction records
+source/destination rectangles and stages final geometry once through the existing
+configure queue. Scene transforms animate live committed buffers to the final
+rectangles; client ack/commit remains asynchronous and cannot hold the animation
+open indefinitely. No screenshots, per-frame configures or animation workers.
+Interrupted reflow starts at its currently displayed geometry. One cleanup path
+settles transforms when a modal/gesture/lock/output change takes ownership.
+
+The small mode caption is native, input-transparent and transient. Layout IPC
+is projected from core state. Omarchy's dwindle/scrolling names map to
+Mosaic/Flow; its layout-toggle launcher is translated directly into a native
+action. Super+T floats/rejoins, Super+L toggles Mosaic/Flow, and Super+Shift+L
+returns to Freeform. Freeform's floating toggle changes nothing. Inapplicable
+layout messages deliberately succeed quietly. IPC exposes `tiledLayout`, actual
+floating membership and the standard `changefloatingmode` event.
+
+## Integration and validation
+
+Living Desktop extends its atomic, debounced store with optional layout metadata;
+legacy workspace state loads as Freeform. Invalid workspace modes fall back to
+Freeform; invalid window metadata is ignored without losing the base record.
+Saved ordering is applied independently of application startup order. Floating
+edits have a separate monitor-relative rectangle; the original freeform rectangle
+stays intact. The saved focused client reconstructs Flow's useful viewport.
+The shell's existing live Overview and drag/drop paths continue to use core
+membership. Managed arrangements inform Overview placement without changing
+gesture ownership or semantic workspace focus during a partial gesture.
+
+Behavior tests cover solver bounds and constraints, geometry preservation,
+membership/lifecycle, focus, output affinity, persistence, spring interruption,
+native rendering/configure counts, scaling and existing gestures/Overview.
+Fixed counters record reflow duration, affected windows, transition setup and
+actual configure flushes without production logging. They are exposed through
+the existing opt-in test socket. `calculation_us` measures the whole core reflow,
+including chrome/geometry staging; `setup_us` measures presentation setup.
+Existing frame counters include nested presentation waits, so their `render_us`
+must not be reported as CPU rendering cost. The existing memory-profile build
+measures allocations separately from shipping-build timings.
+Headless nested E2E can verify live pixels and protocol behavior; physical
+multi-output cadence, input latency and subjective feel require hardware checks
+and will be reported separately from automated evidence.
+
+The native acceptance test drives Freeform arrangement, animated Mosaic, floating
+edits/rejoin, Flow navigation/resize/reorder, minimize/restore, Overview from every
+mode, workspace gestures and the return to original freeform geometry at 1x,
+1.5x and 2x. A separate real SIGKILL/relaunch test checks membership, proportions,
+width, floating edits and empty-workspace modes. Pointer tests cover previews,
+commit, Escape rollback, modal takeover and disappearing clients. Mixed-output
+affinity, scale conversion, unplug/reconnect and workspace deletion are exercised
+through the core backend contract; the nested host exposes one output at 60 Hz.
+Spring/interpolation tests exercise 60/120/144/240 Hz and delayed frames. The
+cached motion path allocates zero bytes across 144,000 sampled frames; this is
+not a claim that the entire Wayland renderer or application commits allocate
+nothing.
+
+Reproduce with `scripts/check.sh all`, `cargo test --workspace`, and
+`scripts/e2e.sh --headless`. For shipping-build product measurements, build
+`chonkstep-wayland --release` and run the native `spatial_layout` target with
+`CHONKSTEP_WAYLAND_BIN` pointing to that preserved binary. Build the same binary
+with `--features memory-profile` for allocation measurements. The native
+benchmark reports 4/8-window modes, rapid focus, repeated mode changes and
+floating/rejoining, and asserts no idle render loop after settlement.
+
+Shipping-build samples on the isolated 1280x800 Weston/llvmpipe host:
+
+| Operation | Core reflow | Final configures |
+| --- | ---: | ---: |
+| 4-window Mosaic | 724 µs | 4 |
+| 4-window Flow | 545 µs | 4 |
+| 8-window Mosaic | 592 µs | 8 |
+| 8-window Flow | 826 µs | 8 |
+
+The 144-reflow focus/mode/membership sequence took 13.2 ms total in core and
+emitted 368 configures. Presentation setup is below the counter's one-microsecond
+per-window resolution in most release samples; a reported zero is rounding,
+not zero work. In the separate allocation build, a 120 ms transition interval
+allocated 61,357 bytes in 394 operations including renderer, client commits and
+test IPC. The complete stress sequence retained 9,162,781 bytes before and
+9,121,045 after. These are local samples, not hardware latency guarantees.
+The stress test also exposed and fixed a probe-client leak: replaced `wl_buffer`
+and `wl_shm_pool` objects must be destroyed so repeated configures cannot exhaust
+the test runtime's storage quota.
+
+Validation completed: strict Clippy, private rustdoc, workspace tests, the 26
+Python harness tests, formatting checks for the new Rust modules, allocation
+tests and the full native Wayland suite. The final lifecycle changes also passed
+all five native layout tests and ten existing desktop regression tests in the
+release build. The full suite explicitly skipped three optional Chonkcraft tests
+because their game fixtures were absent. Native screenshots were inspected for
+the mode caption, Mosaic/Flow drag previews and Flow's live Overview. Physical
+multi-output and high-refresh input/rendering remain hardware validation work.

--- a/docs/engineering/2026-09-07-adversarial-review.md
+++ b/docs/engineering/2026-09-07-adversarial-review.md
@@ -1,0 +1,165 @@
+# Hybrid layout adversarial review
+
+This review starts at `8acbc30` plus the uncommitted hybrid layout implementation
+on `feat/hybrid-spatial-layout`. It is an engineering readiness assessment, not
+a claim of exhaustive security certification or commercial release approval.
+The user's existing desktop was not replaced or restarted.
+
+## Confirmed defects and repairs
+
+| Finding | Consequence | Repair and regression evidence |
+| --- | --- | --- |
+| Managed rendering omitted xdg popups | Application menus received input while invisible | Live popup trees use the parent's scene transform and each popup's own scale. Native tests check colored pixels and delivered clicks in all three styles at 1x, 1.5x and 2x. The preserved baseline fails in Mosaic with parent pixels at the popup's input location. |
+| Floating a maximized/fullscreen window wrote into its visible geometry | Maximized flags and geometry disagreed; restore could return to a tile | Membership updates the existing restore chain while preserving the active presentation. Tests exercise both states and fullscreen over maximize. |
+| Changing maximize underneath fullscreen retained the wrong restore rectangle | Eventually returning to Freeform could lose the original arrangement | Derive maximization from the underlying state; unmaximizing updates fullscreen's restore target. Direct tests and generated lifecycle sequences cover repeated changes. |
+| Pinning an offscreen Flow cell retained its virtual position | A pinned window became unreachable on every workspace | Restore its freeform view while pinned, retain managed order, and reflow on unpin. |
+| Unpinning on another workspace retained keyboard ownership | Focus could belong to a hidden window | Select the existing visible successor before hiding it. Generated lifecycle coverage checks focus eligibility after every operation. |
+| Output moves changed affinity without refitting special presentations | A fullscreen/maximized window remained on its old output | Refit the active presentation through the existing core paths. |
+| Lifecycle changes could outlive an interactive grab | Moving/minimizing/maximizing during a drag retained stale targets or rollback | Cancel the affected interaction before mutation; committed cross-output drops use the internal placement path without cancelling themselves. |
+| Fast repeated drags counted as titlebar double-clicks | An intended reorder shaded and floated the window | Clear click history after movement; require spatial proximity and wrap-safe timestamps for real double-clicks. Test all three styles. |
+| Managed windows never advertised xdg tiled states | Clients could retain inappropriate freeform chrome/edge affordances | Stage the four tiled edge states through the existing deduplicated configure queue and clear them on exclusion. Native tests inspect the client's actual configure. |
+| Committed size-hint changes did not reflow Mosaic | Late minimum sizes could invalidate the layout until another operation | Emit change-driven constraint events from native xdg, XWayland and X11 metadata paths. Reflow/cancel through the authoritative core. |
+| Unescaped session text could create records/directives | Tabs/newlines in client identity corrupted recovery and could forge workspace modes | Versioned, JSON-escaped text fields; legacy records still load. No client payloads in corruption warnings. |
+| Unbounded session reads and predictable temporary writes | Corrupt files consumed unbounded memory; stale temporary symlinks could redirect writes | Bounded regular-file reads, bounded records, owner-only unique atomic replacement, and retry tests. Process-crash atomicity is distinct from power-loss durability. |
+| Extreme saved coordinates overflowed restoration arithmetic | Returning to Freeform could panic in debug or choose the wrong monitor in release | Saturating frame/content offsets and a widened exact monitor-distance score. Regression tests restore both signed limits through floating and direct mode exit, retaining size and focus. |
+| Flow constructed invisible chrome/surface elements | Unnecessary per-frame imports and allocations | Reuse the renderer's exact surface-tree visibility check before construction; preserve overflow shadows/subsurfaces/popups. |
+| Impossible minimum-area cases repeatedly searched every partition | Many demanding clients could stall the event loop | Reject impossible total minimum area before searching, retaining the exact deterministic exclusion policy. |
+| Presentation setup rounded each window to microseconds | Fast operations misleadingly reported zero setup cost | Accumulate nanoseconds and convert only when reporting. Separate layout scene-build cost from nested presentation waits. |
+
+The tiling behavior tests now live in `wm-core/src/manager/tests/spatial.rs`.
+This keeps policy tests beside their owner without adding another public API or
+expanding the already large manager file. The seeded tests exercise 2,000 solver
+cases and 3,840 lifecycle operations. They check constraints, nonoverlap,
+determinism, unique workspace ownership, focus eligibility and preserved intent.
+Neither suite asserts a fixed number of animation frames.
+
+## Product measurements
+
+The preserved before/candidate binaries and raw logs are in the local campaign
+directory `../chonkstep-engineering-artifacts/2026-09-07-hybrid-audit`.
+The host is nested Weston with llvmpipe, LLVM 22.1.8; these results do not measure
+physical input-to-photon latency or KMS high-refresh behavior.
+
+The constrained solver profile (1,000 x 1,000 workarea, 600 x 600 client minima)
+changed from 10/692/35,272 µs for 8/64/256 clients to 4/10/56 µs. This is a
+synthetic regression case, not an ordinary desktop benchmark. The optimization
+does not change which client remains managed.
+
+The native benchmark covers 4/8-window Mosaic and Flow, 112 focus moves,
+16 mode changes, and 16 floating/rejoining operations. It measures actual
+configure flushes and asserts that settling leaves no idle render loop.
+`build_us` measures layout surface/chrome element construction and clipping;
+it excludes GPU submission and presentation waits. `render_us` includes those
+waits and must not be presented as CPU time. Allocation counts require a
+separate `memory-profile` binary and include client commits and test IPC.
+
+The final normal release binary measured 587/525/610/834 µs for 4-window
+Mosaic/Flow and 8-window Mosaic/Flow, with 4/4/8/8 final configures. Its
+144-operation sequence took 13.58 ms in core and emitted 368 configures.
+
+The final instrumented product run measured 594/511/611/817 µs for 4-window
+Mosaic/Flow and 8-window Mosaic/Flow respectively, with exactly 4/4/8/8 final
+configures. The 144-operation focus/mode/membership sequence took 13.98 ms in
+core, staged 1,152 presentation changes in 652 µs total, and emitted 368
+configures. Compare these instrumented timings only with instrumented builds.
+
+An additional live-client benchmark alternates eight-window Mosaic and Flow,
+waits for transitions and captions to finish, and measures actual client-paced
+frames for 500 ms. Both before and after builds emitted **zero layout calculations
+and zero configures** during these settled intervals. Flow allocation operations
+per rendered frame changed from 46.7/45.9 to 41.7/41.8 in the two observations.
+The new visibility check skipped three quarters of window builds in each Flow sample.
+This is an allocation-count reduction, not an allocation-free renderer claim:
+requested byte counts varied with client and sampler activity, and Mosaic did
+not consistently improve (46.8/44.5 versus 46.6/45.0 operations per frame).
+
+The complete operation sequence changed from 103,312 to 100,725 allocation
+operations, with about 103 MB cumulatively requested in either build. Final
+Rust live bytes were below their pre-sequence values in both runs, as were the
+two settled Flow samples in the final build. These short runs do not establish
+a long-term leak bound. The independent cached-motion
+test still performs zero allocations across 144,000 interpolated frames.
+
+A separate two-minute workload completed 566 additional client lifecycle cycles
+after warmup, including live Overview, theme changes, dock toggling, screencopy
+and native Hyprland IPC. Descriptors stayed at 74 (66 non-pipe), threads at 60,
+and final windows/frames/clipboard devices at zero. Anonymous-plus-swap memory
+rose 5,076 KiB; RSS rose 12,052 KiB. Rust live memory grew from 6,318,245 to
+9,903,468 bytes while glyph-image payload grew from 24,975 to 2,133,772 bytes.
+The existing raster cache has 16,384-entry/8 MiB soft limits and eviction tests;
+this run ended below those thresholds and does not demonstrate a plateau.
+Average process CPU use was 0.48 cores in this software-rendered workload,
+including its real client and desktop activity. Raw `/proc` samples and allocator
+counters are retained under the campaign's `soak` directory.
+
+## Wider project review
+
+- The Rust dependency audit examined 378 resolved packages against RustSec
+  database commit `5a0ebedfe8bdd2e295b171f4162f8c977bcad9a5`. It reported zero
+  vulnerability-class entries, **but is not warning-free**: `cgmath 0.18.0`
+  has unmaintained and unsound warnings; `ttf-parser 0.25.1` is unmaintained.
+  The `cgmath` warning concerns `Matrix::swap_columns` with identical indices.
+  No invocation exists in ChonkStep or its vendored Smithay source. Smithay
+  supplies that transitive dependency; fontdb/cosmic-text supplies ttf-parser.
+  An upstream dependency migration remains maintenance work, not a suppressed
+  advisory or an undocumented new fork.
+- The dependency inventory records package versions, declared licenses, sources,
+  repositories, toolchain, host, HEAD and lockfile digest. Every resolved package
+  declares a license. This does not audit artwork/font rights or establish legal
+  compliance for a binary distribution and its system libraries.
+- The vendored Smithay patches already have archive checksums, upstream links,
+  attribution and focused lifecycle tests in `vendor/README.md`; preserve that
+  discipline when upgrading. This review adds no vendor patch or unsafe block.
+- Control/Hyprland sockets already use bounded nonblocking reads/backlogs,
+  private paths and peer checks. They intentionally grant session control to
+  same-user processes; they are not a sandbox boundary between those processes.
+  The native test door remains opt-in. Capture and native client-buffer parsing
+  continue to require adversarial protocol and hardware coverage.
+- Existing release packaging tests the workspace, inspects package contents,
+  and attests binary/debug artifacts. Packaging is now gated on the reusable
+  full CI workflow for the **same release revision**, including SDK, installer,
+  lint, X11 and nested Wayland tests. A passing earlier branch build is not used
+  as evidence for a newly tagged revision.
+
+## Remaining release evidence
+
+`scripts/check.sh all` passed: strict Clippy, private rustdoc, 1,997 Rust tests
+(including gesture/Overview/session/allocation coverage), and 26 Python harness
+tests. The 254 ignored Rust cases are separately classified display-dependent
+or development tests, not counted as passes. The Python SDK, Go SDK race tests,
+isolated Omarchy installer fixtures, installed menu/theme fixtures and actionlint
+also passed. The complete final native run passed 227 exercised native cases
+and three installed Omarchy fixtures. Three optional Chonkcraft cases explicitly
+skipped because the external game fixtures were absent; they are not claimed as
+coverage. The earlier full run caught two test readers that still assumed legacy
+session rows; those readers now accept escaped rows, and the legacy startup
+fixture remains. All seven spatial tests passed, including the expanded popup
+and live-frame benchmarks, on both final normal and instrumented binaries.
+Native screenshots were inspected for the popup fix,
+Mosaic/Flow insertion previews and fractional-scale live Overview. The campaign
+retains raw logs, source hashes and separate normal/instrumented release binaries.
+
+Reproduce the native gates with `scripts/e2e.sh --headless --release`; select
+`--test spatial_layout --nocapture` for product measurements. Point
+`CHONKSTEP_WAYLAND_BIN` at an explicitly preserved binary built with
+`--features memory-profile` for allocation counters. The sustained run used
+`CHONKSTEP_SOAK_SECONDS=120`, `CHONKSTEP_SOAK_MEMORY_STATS=1` and
+`CHONKSTEP_SOAK_SELECTION_STATS=1` with `--test stability_soak --nocapture`.
+
+Formatting checks pass for all six new Rust modules and `git diff --check` is
+clean. `cargo fmt --all -- --check` still reports drift in 232 files, including
+untouched baseline code. A repository-wide formatting migration remains separate
+maintenance work; this review does not represent that global gate as passing.
+
+Physical KMS on Intel/AMD/NVIDIA, mixed-output fractional scale, rotation,
+hotplug during animation, suspend/resume and 120/144+ Hz input/render cadence
+still need a hardware campaign. Headless scale tests and analytic spring tests
+do not substitute for those observations. Long-running production workloads,
+assistive-input/accessibility review, application-specific UI polish, and a
+human evaluation of the complete acceptance sequence remain release gates.
+
+Session replacement survives a process crash atomically. It does not currently
+promise durable persistence across sudden power loss; adding fsync on the
+compositor thread would require latency measurements and a deliberate I/O design.
+The new reader accepts legacy files; older binaries do not understand versioned
+escaped rows, so downgrades should preserve a copy of the session state.

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -73,11 +73,11 @@ Each binding gets one of three answers:
    Omarchy's `omarchy-menu`, not an imitation of it.
 3. **Everything else stays unbound**, with the reason logged.
 
-The third answer is the important one, and the rule behind it is *an
-approximation is worse than a dead key*. `SUPER + J` toggles a tiling
-split on Omarchy; on a stacking desk there is nothing to split. A dead
-key is discovered in five seconds and looked up; a key that does
-something *else* is a bug report.
+Workspace styles are native: `dwindle` selects Mosaic and `scrolling` selects
+Flow. Omarchy's layout toggle and floating toggle work without a config change.
+`Super+Shift+L` returns to Freeform. Tree-only messages such as `togglesplit`
+are quiet no-ops in every style, including Flow; unavailable window groups
+remain explicitly unsupported.
 
 Because the recogniser keys on the **dispatcher** rather than on the
 chord, moving "close window" from `SUPER + W` to `SUPER + Q` through
@@ -213,18 +213,19 @@ specific directive, not a count. Turn on `RUST_LOG=debug` to see them.
 
 ### Bindings this desktop has no verb for
 
-Beyond the tiling vocabulary, one specific chord family stays dead and
+One additional chord family remains unbound and
 is worth knowing about:
 
 - **The universal clipboard chords** (`SUPER + C/V/X`), which Omarchy
   builds by synthesising `Ctrl+C` at the seat. That is the
   compositor's own input path; no command could stand in.
 
-Directional focus (`movefocus l/r/u/d`) is native: Chonkstep ranks the
-visible floating frames by their actual root-coordinate geometry and
-focuses the closest candidate in that direction. Directional movement
-and swapping remain tiling-only because a free-form window has no
-neighbouring slot to move into.
+Directional focus (`movefocus l/r/u/d`) follows actual geometry in Freeform
+and Mosaic. Flow follows its horizontal sequence; up/down does nothing.
+`movewindow` and `swapwindow` directions reorder managed windows while keeping
+focus. `resizeactive` changes Mosaic boundaries or the focused Flow width.
+`fullscreen 0` toggles real fullscreen; `fullscreen 1` toggles maximize within
+the workarea. Floating windows retain traditional movement and resizing.
 
 Silent workspace sends (`movetoworkspacesilent 1..99`) are native too:
 the active window moves without changing the current workspace, and an
@@ -354,7 +355,7 @@ shape this reader cannot follow. There is never a moment where both are
 in effect.
 
 The preset's *judgements* are carried over rather than re-argued: the
-same `Unbound` reasons, the same "tiling-only stays dead", the same
+same `Unbound` reasons, the same deliberate handling of unsupported operations, the same
 scratchpad-to-`miniaturize` call. `docs/keybindings.md` still documents
 that table, and it remains accurate for a machine with no Hyprland
 configuration on it.
@@ -462,10 +463,10 @@ One `info` line per read, and one `debug` line per thing skipped:
 
 ```
 INFO  hyprland-config: read the desktop's live Hyprland configuration
-      files=42 bindings=153 commands=113 env=8 autostart=4
-      float_rules=45 monitors=1 skipped=173
-DEBUG hyprland-config: not carried over kind=bind what="SUPER + J (Toggle window split)"
-      why="tiling-only: no meaning on a stacking desk"
+      files=42 bindings=161 commands=113 env=8 autostart=4
+      float_rules=45 monitors=1 skipped=165
+DEBUG hyprland-config: not carried over kind=bind what="SUPER + G (Toggle window group)"
+      why="requires window groups or a feature ChonkStep does not provide"
 ```
 
 `skipped` being large is normal and not a problem — a stock Omarchy

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -31,9 +31,9 @@ hyprctl dispatch 'hl.dsp.focus({ window = "address:0x..." })' || \
 The policy is consequently:
 
 - implement every reachable, meaningful Omarchy operation;
-- omit known tiling-only actions from chonkstep's mirrored menu;
-- return `Invalid dispatcher: <reason>` for operations with no honest
-  floating-desktop meaning;
+- omit unsupported Hyprland script actions from chonkstep's mirrored menu;
+- make inapplicable layout messages quiet no-ops;
+- return `Invalid dispatcher: <reason>` for unavailable operations;
 - log every refusal at warning level with a session-long counter.
 
 That makes interactive failures readable and silent script failures
@@ -84,7 +84,7 @@ start with `[[BATCH]]` and use `;` separators.
 | --- | --- |
 | `status` | `configProvider="chonkstep"`; Quickshell uses classic dispatch while scripts may use the supported Lua forms |
 | `monitors` | Live output name, geometry, scale, focus, active workspace, transform, DPMS state, and measured VRR capability/runtime state. The optional `all` argument is accepted and ignored because connected outputs remain in the layout while powered down. |
-| `workspaces` | One-based ids; real per-workspace monitor assignment and fullscreen state |
+| `workspaces` | One-based ids; real per-workspace monitor assignment, fullscreen state and `tiledLayout` (`freeform`, `dwindle`, `scrolling`) |
 | `clients` / `activewindow` | Live pid, class/title, position, size, workspace, monitor, XWayland, floating, pinned, fullscreen, tags, focus history and idle inhibition |
 | `activeworkspace` | Exactly the active workspace, in JSON or one plain block |
 | `cursorpos` | The live pointer as plain `X, Y` |
@@ -118,7 +118,11 @@ actions. Supported families include:
 - workspace focus and moving a window to a workspace;
 - focus by selector or spatial direction, close, kill-active, cycle,
   fullscreen/maximize;
-- move, resize, center, raise, pin, tags, and confirm-floating;
+- move, resize, center, raise, pin, tags, and floating membership;
+- `layout freeform|mosaic|flow`, `togglelayout`, `togglefloating`, `setfloating`,
+  `settiled`, and directional `movewindow`/`swapwindow`;
+- `eval hl.workspace_rule({ workspace = "1", layout = "scrolling" })` and
+  `keyword workspace 1, layout:scrolling` (also `dwindle` and `freeform`);
 - `exec -- <argv...>` as direct argv and Lua `exec_cmd` as shell
   source, including `[[...]]` and `[=[...]=]` strings;
 - `eval hl.dispatch(hl.dsp....)`;
@@ -137,7 +141,7 @@ not reported as unknown syntax. Monitor scaling validates the output
 and range before changing anything, so an Omarchy script cannot record
 a scale that the compositor said it applied but did not.
 
-`keyword` is refused except for the named
+`keyword` supports workspace layouts and the named
 `keyword cursor:invisible BOOL` screensaver fallback, which reaches the
 same live cursor flag as `hl.config`. If the focused client that hid
 the cursor disconnects without restoring it, chonkstep restores the
@@ -168,13 +172,12 @@ and runtime activation is restricted to direct scanout. Set
 `CHONKSTEP_NO_VRR=1` to force it off. A backend driving no real mode reports 60 Hz rather than 0,
 because a bar divides this into a frame budget.
 
-Tiling vocabulary—`layoutmsg`, `togglesplit`, `swapwindow`, `pseudo`,
-groups, special workspaces, tiled workspace options—has no faithful
-meaning on this floating desktop and is refused. The mirrored Omarchy
-menu continues to hide the five installed `omarchy-hyprland-*` actions;
-each remains genuinely tiling/Hyprland specific. In particular,
-workspace layout toggle (`SUPER+L`) is unbound and its menu row is
-absent, so it cannot display a false “layout changed” notification.
+Omarchy's `dwindle` and `scrolling` select Mosaic and Flow. `Super+L` toggles
+between them; `Super+Shift+L` restores Freeform. `layoutmsg`, `togglesplit`,
+`swapsplit`, `pseudo` and `splitratio` are deliberate quiet no-ops. Groups,
+special workspaces and unsupported workspace options remain explicit refusals.
+The mirrored menu retains its filter for direct Hyprland script rows; native
+shortcuts show a transient compositor caption without launching a script.
 
 ## Event stream and workspace lifetime
 
@@ -185,7 +188,7 @@ event:
 `createworkspacev2`, `destroyworkspacev2`, `workspacev2`, `workspace`,
 `moveworkspacev2`, `focusedmon`, `fullscreen`, `openwindow`,
 `closewindow`, `movewindowv2`, `windowtitlev2`, `windowtitle`,
-`activewindowv2`, `activewindow`, `urgent`, and `activelayout`.
+`activewindowv2`, `activewindow`, `urgent`, `changefloatingmode`, and `activelayout`.
 
 Addresses are `0x...` in JSON and bare hexadecimal in events; both are
 the same `ClientId`. Workspace ids are one-based on this wire and

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -43,6 +43,24 @@ Window-targeted actions (`close`, `toggle-maximize`, `toggle-shade`,
 `miniaturize`, `toggle-fullscreen`, `window-menu`) act on the focused
 window and do nothing when no window is focused.
 
+ChonkStep has three workspace styles. **Freeform** lets you place windows
+yourself. **Mosaic** keeps windows visible. **Flow** extends them sideways.
+**Super+L** enters Mosaic, then toggles Mosaic/Flow. **Super+Shift+L** returns
+to Freeform, with your original positions intact. **Super+T** floats a window
+and returns it to its remembered place on the next press.
+
+In the native keymap, **Super+Ctrl+arrows** focuses spatially and
+**Super+Shift+arrows** moves a managed window. **Super+minus/equal** adjusts
+width; add Shift to adjust height in Mosaic. Flow's up/down actions are quiet.
+The Omarchy keymap keeps **Super+arrows** for focus. Drag a managed titlebar onto
+another window to reorder; the outline shows the destination. Drag a resize
+edge to adjust a shared Mosaic boundary or a Flow width. Escape cancels a drag.
+Shading floats a managed window; rejoining unshades it. Maximize and fullscreen
+are temporary presentations, and minimizing keeps the window's remembered place.
+At an output edge, a move carries the managed window onto the neighboring
+output. Freeform’s floating toggle is a quiet no-op. Workspace style and
+organization are saved with Living Desktop.
+
 See [Capture](capture.md) for saving, clipboard, selection and recording.
 The Omarchy keymap uses **Super+Ctrl+Shift+3/4/5** instead, because
 Super+Shift+digits already carries windows to desktops there. Its unmodified
@@ -90,7 +108,7 @@ time. Bind them like anything else:
 keymap = "omarchy"        # ...or desktop = "omarchy", which defaults it
 ```
 
-131 bindings, including four native capture shortcuts, derived from Omarchy's
+145 bindings, including four native capture shortcuts, derived from Omarchy's
 own configuration on the machine —
 `$OMARCHY_PATH/default/hypr/bindings/*.lua` — rather than from memory of
 Hyprland, with the `o.bind` helpers expanded the way `helpers.lua`
@@ -112,7 +130,7 @@ guarantees; whether that Omarchy command does anything under a
 compositor that is not Hyprland is
 [omarchy-integration.md](omarchy-integration.md)'s subject — it is the
 honest inventory, script by script, and a few of the commands below
-are intentional floating-desktop refusals. The integration guide records
+are intentional compatibility limits. The integration guide records
 those boundaries; night light, capture layers, and the common window
 helpers are supported directly.
 
@@ -132,6 +150,20 @@ helpers are supported directly.
 | `super+w`                | `close`                                | --                                                                                                                  |
 | `super+f`                | `toggle-fullscreen`                    | --                                                                                                                  |
 | `super+alt+f`            | `toggle-maximize`                      | --                                                                                                                  |
+| `super+j` | `layout-noop` | -- |
+| `super+p` | `layout-noop` | -- |
+| `super+ctrl+f` | `toggle-maximize` | -- |
+| `super+equal` | `grow-width` | -- |
+| `super+minus` | `shrink-width` | -- |
+| `super+shift+equal` | `grow-height` | -- |
+| `super+shift+minus` | `shrink-height` | -- |
+| `super+t` | `toggle-floating` | -- |
+| `super+l` | `toggle-layout` | -- |
+| `super+shift+l` | `layout-freeform` | -- |
+| `super+shift+left` | `move-left` | -- |
+| `super+shift+right` | `move-right` | -- |
+| `super+shift+up` | `move-up` | -- |
+| `super+shift+down` | `move-down` | -- |
 | `super+left`             | `focus-left`                           | --                                                                                                                  |
 | `super+right`            | `focus-right`                          | --                                                                                                                  |
 | `super+up`               | `focus-up`                             | --                                                                                                                  |
@@ -252,28 +284,21 @@ helpers are supported directly.
 
 ### Deliberately unbound
 
-32 groups of Omarchy chord this keymap leaves dead, and why. Left dead
-rather than approximated: a dead key is looked up in five seconds,
-while a `super+j` that does something *else* is a bug report.
+26 groups of Omarchy chords remain unbound in the static preset. The table
+explains each limit; the live configuration reader supports additional chords.
 
 | Omarchy chord                                                                                      | What Omarchy does with it                                            | Why not here                                                |
 |----------------------------------------------------------------------------------------------------|----------------------------------------------------------------------|-------------------------------------------------------------|
 | `super+alt+return, super+ctrl+return, super+shift+{a,c,d,e,g,m,o,p,s,w,x,y,/}, +alt/ctrl variants` | Omarchy's preinstalled application, TUI and webapp chords            | Omarchy binds it conditionally; a table of constants cannot |
 | `super+c / super+v / super+x`                                                                      | universal copy / paste / cut, by synthesising Ctrl+C/V/X at the seat | chonkstep has no verb for it, and no command can stand in   |
-| `super+j`                                                                                          | toggle window split                                                  | tiling-only: no meaning on a stacking desk                  |
-| `super+p`                                                                                          | pseudo-tile the window                                               | tiling-only: no meaning on a stacking desk                  |
-| `super+t`                                                                                          | toggle floating / tiling                                             | tiling-only: no meaning on a stacking desk                  |
-| `super+ctrl+f`                                                                                     | tiled fullscreen                                                     | tiling-only: no meaning on a stacking desk                  |
-| `super+o`                                                                                          | pop the window out, floating and pinned                              | tiling-only: no meaning on a stacking desk                  |
+| `super+o` | pop the window out, floating and pinned | requires window groups or a feature ChonkStep does not provide |
 | `super+home / super+alt+home`                                                                      | restore / save window width                                          | commands Hyprland, which is not running                     |
-| `super+l`                                                                                          | cycle the workspace layout                                           | commands Hyprland, which is not running                     |
-| `super+g / super+alt+g`                                                                            | toggle grouping / move out of group                                  | tiling-only: no meaning on a stacking desk                  |
-| `super+alt+left/right/up/down`                                                                     | move the window into the group in that direction                     | tiling-only: no meaning on a stacking desk                  |
-| `super+alt+tab / super+alt+shift+tab`                                                              | next / previous window in the group                                  | tiling-only: no meaning on a stacking desk                  |
-| `super+ctrl+left / super+ctrl+right`                                                               | move the grouped-window focus                                        | tiling-only: no meaning on a stacking desk                  |
-| `super+alt+1..5`                                                                                   | focus the nth window of the group                                    | tiling-only: no meaning on a stacking desk                  |
-| `super+shift+left/right/up/down`                                                                   | swap the window with its neighbour                                   | tiling-only: no meaning on a stacking desk                  |
-| `super+minus / super+equal, +shift/alt/ctrl variants`                                              | grow and shrink the window by 25 / 100 / 300 px                      | tiling-only: no meaning on a stacking desk                  |
+| `super+g / super+alt+g` | toggle grouping / move out of group | requires window groups or a feature ChonkStep does not provide |
+| `super+alt+left/right/up/down` | move the window into the group in that direction | requires window groups or a feature ChonkStep does not provide |
+| `super+alt+tab / super+alt+shift+tab` | next / previous window in the group | requires window groups or a feature ChonkStep does not provide |
+| `super+ctrl+left / super+ctrl+right` | move the grouped-window focus | requires window groups or a feature ChonkStep does not provide |
+| `super+alt+1..5` | focus the nth window of the group | requires window groups or a feature ChonkStep does not provide |
+| `super+alt/ctrl+minus/equal` | large resize increments | chonkstep has no verb for it, and no command can stand in |
 | `super+s`                                                                                          | toggle the scratchpad workspace                                      | chonkstep has no verb for it, and no command can stand in   |
 | `super+ctrl+tab`                                                                                   | the workspace before this one                                        | chonkstep has no verb for it, and no command can stand in   |
 | `super+shift+alt+left/right/up/down`                                                               | move the workspace to the monitor in that direction                  | chonkstep has no verb for it, and no command can stand in   |

--- a/docs/omarchy-integration.md
+++ b/docs/omarchy-integration.md
@@ -153,10 +153,12 @@ Hyprland's independent per-monitor workspace/focus model, so requests that
 promise monitor-specific placement are refused and logged rather than
 pretending all screens landed correctly.
 
-Tiling-only operations—layouts, groups, pseudo-tiling, silent moves, and
-special workspaces—remain deliberately unsupported on chonkstep's floating
-desktop. The mirrored root menu omits the installed actions that have no
-honest meaning here. Every IPC refusal emits a warning and increments a
+Workspace layout switching, floating/rejoining, spatial movement and silent
+workspace sends are native. Mosaic/Flow accept inapplicable split and pseudo
+messages quietly. Groups and special workspaces remain unsupported. The
+mirrored root menu retains its conservative filter for direct Hyprland scripts;
+layout switching is available through the native shortcuts. Every IPC refusal
+emits a warning and increments a
 session counter; see [hyprland-ipc.md](hyprland-ipc.md) for the exact query,
 mutation, and event surface.
 

--- a/docs/omarchy-mode.md
+++ b/docs/omarchy-mode.md
@@ -163,11 +163,9 @@ Three kinds of Omarchy binding get three different answers:
    command, declared in `[commands]` by the preset. `super+space` opens
    Omarchy's menu because it runs Omarchy's `omarchy-menu` — not an
    imitation of it.
-3. **Everything else stays unbound, and says why.** A tiling desktop's
-   vocabulary is full of verbs with no meaning on a stacking desk, and
-   an approximation is worse than a dead key: a dead key is looked up in
-   five seconds, while `super+j` that does something *else* is a bug
-   report.
+3. **Workspace styles are native.** Super+T floats/rejoins a window,
+   Super+L toggles Mosaic/Flow, and Super+Shift+L returns to Freeform.
+   Tree-only messages are quiet no-ops; grouping remains unsupported.
 
 ### Three chords we do differently
 
@@ -184,11 +182,11 @@ keys marked `locked = true` work over the lock screen, ramps marked
 ### When a mapped command is itself the limitation
 
 The keymap guarantees the chord reaches the command. Whether a
-Hyprland-specific operation has an honest floating-desktop equivalent is a
+Hyprland-specific operation has a native equivalent is a
 separate question, answered script by script in
 [omarchy-integration.md](omarchy-integration.md). Common window, capture,
-input, and night-light paths are supported; tiling-only operations are
-refused and logged.
+input, layout, and night-light paths are supported. Unsupported grouping
+operations are reported; inapplicable layout messages are quiet no-ops.
 
 ### On a real Omarchy machine, the table is read live
 
@@ -203,8 +201,8 @@ between "chonkstep knows what Omarchy's chords were in August" and
 "Omarchy's menu still configures your machine": rebind a key through
 their UI and the running session follows it within a second.
 
-On the machine this was developed on the live read produced **153
-bindings over 113 commands**, against the baked table's 131 over 77 —
+On the machine this was developed on the live read produced **161
+bindings over 113 commands**, against the baked table's 145 over 77 —
 the extra ones are mostly the preinstalled webapp and TUI chords, which
 a table of constants had to write off because Omarchy gates them on a
 file test that only a live read can make.
@@ -224,8 +222,8 @@ what the live read falls back to.
 
 Both tables live in the keybinding card, beside chonkstep's own:
 **[keybindings.md](keybindings.md), under "The Omarchy keymap"**
-— 131 bindings over 77 declared commands, then the 32 groups of Omarchy
-chords that are deliberately dead here and why. Both are transcribed
+— 145 bindings over 77 declared commands, then the 26 groups of Omarchy
+chords that remain unbound and why. Both are transcribed
 from `crates/wm-config/src/preset.rs`, which is the authoritative list;
 `crates/wm-config/tests/preset_doc.rs` fails if the card and the table
 disagree.


### PR DESCRIPTION
Add three per-workspace styles: Freeform preserves manual placement, Mosaic keeps windows visible in deterministic constrained tiles, and Flow provides a horizontal sequence with useful widths and a focus-following viewport. Switching styles preserves the original freeform arrangement; floating/rejoining and minimize/restore retain managed ordering.

WindowManager owns placement and workspace policy. Native live-surface transforms reuse the existing gesture spring and configure queue. The change integrates spatial focus, drag previews, shared-boundary/width resizing, Overview, output affinity, Living Desktop restoration, and Omarchy's Super+T/Super+L muscle memory. Layout-specific tree commands intentionally succeed quietly.

The implementation also hardens popup rendering and input, fullscreen/maximize restore chains, focus and drag cancellation, late client constraints, extreme coordinates, and session serialization/atomic replacement. Flow culls offscreen scene work, demanding minimum-size cases avoid futile partition searches, and release packaging requires the full CI workflow on the release revision.

Validation on the final source:

- `scripts/check.sh all`: strict Clippy, private rustdoc, 1,997 Rust tests and 26 Python harness tests.
- Complete release native Wayland suite: 227 exercised cases and three installed Omarchy fixtures; three optional external game fixtures were unavailable.
- All seven spatial E2E tests passed with normal and memory-profile release binaries, including 1x/1.5x/2x rendering, crash recovery, live popup clicks, gestures and configure-count checks.
- Generated coverage: 2,000 solver cases and 3,840 lifecycle operations; cached motion allocates nothing over 144,000 samples.
- Two-minute resource workload: 566 additional lifecycle cycles, stable descriptor/thread counts, no stale windows/frames/clipboard devices. Memory growth and glyph-cache effects are recorded explicitly.
- Python SDK, Go race tests, installer fixtures, workflow lint, new-module formatting and diff whitespace checks passed.

The [engineering review](https://github.com/iconidentify/chonkstep/blob/c7a9bfac0ed7905035964623177245c4455893ea/docs/engineering/2026-09-07-adversarial-review.md) records measurements and remaining release evidence, including physical multi-output/high-refresh validation, transitive dependency warnings and existing repository-wide formatting drift. Nested software-renderer timings are not hardware latency claims.
