### PR TITLE
Release 0.4.1: fix capture selection and orientation; build packages once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             packaging/arch/PKGBUILD-release \
             scripts/check.sh \
             scripts/build-release.sh \
+            scripts/release-validation.sh \
             scripts/e2e.sh \
             scripts/install.sh \
             scripts/chonkstep-bugreport \
@@ -77,6 +78,7 @@ jobs:
           shellcheck \
             scripts/check.sh \
             scripts/build-release.sh \
+            scripts/release-validation.sh \
             scripts/e2e.sh \
             scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,16 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Only merged commits pay for native packaging. PRs keep their existing
+  # checks; tagging a green main commit promotes these exact attested files.
+  package:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/package.yml
+    permissions:
+      contents: read
+      attestations: write
+      id-token: write
+
   dependency-audit:
     runs-on: ubuntu-latest
     permissions:
@@ -70,6 +80,8 @@ jobs:
             scripts/check.sh \
             scripts/build-release.sh \
             scripts/release-validation.sh \
+            scripts/release-metadata.sh \
+            scripts/verify-release-assets.sh \
             scripts/e2e.sh \
             scripts/install.sh \
             scripts/chonkstep-bugreport \
@@ -83,6 +95,8 @@ jobs:
             scripts/check.sh \
             scripts/build-release.sh \
             scripts/release-validation.sh \
+            scripts/release-metadata.sh \
+            scripts/verify-release-assets.sh \
             scripts/e2e.sh \
             scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_call:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dependency-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             packaging/arch/PKGBUILD \
             packaging/arch/PKGBUILD-release \
             scripts/check.sh \
+            scripts/build-release.sh \
             scripts/e2e.sh \
             scripts/install.sh \
             scripts/chonkstep-bugreport \
@@ -75,6 +76,7 @@ jobs:
             scripts/wayland-session.sh
           shellcheck \
             scripts/check.sh \
+            scripts/build-release.sh \
             scripts/e2e.sh \
             scripts/chonkstep-bugreport \
             scripts/omarchy-install-desktop-chonkstep \

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -7,6 +7,7 @@ on:
       - "preview-v*"
 
 permissions:
+  actions: read
   contents: read
   attestations: write
   id-token: write
@@ -16,8 +17,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validation-status:
+    name: find validation for this exact revision
+    runs-on: ubuntu-24.04
+    outputs:
+      reusable: ${{ steps.proof.outputs.reusable }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check recent main-branch CI
+        id: proof
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/release-validation.sh
+
   validation:
     name: validate the release revision
+    needs: validation-status
+    if: needs.validation-status.outputs.reusable != 'true'
     uses: ./.github/workflows/ci.yml
     permissions:
       contents: read
@@ -153,8 +169,12 @@ jobs:
 
   publish-preview:
     name: publish preview release
-    if: startsWith(github.ref, 'refs/tags/preview-v')
-    needs: [validation, package]
+    if: >-
+      always() && !cancelled() && startsWith(github.ref, 'refs/tags/preview-v') &&
+      needs.validation-status.result == 'success' && needs.package.result == 'success' &&
+      (needs.validation.result == 'success' ||
+       (needs.validation.result == 'skipped' && needs.validation-status.outputs.reusable == 'true'))
+    needs: [validation-status, validation, package]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,4 +1,4 @@
-name: build GitHub Arch packages
+name: release GitHub Arch packages
 
 on:
   workflow_dispatch:
@@ -20,11 +20,16 @@ jobs:
   validation-status:
     name: find validation for this exact revision
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     outputs:
       reusable: ${{ steps.proof.outputs.reusable }}
+      package_run_id: ${{ steps.proof.outputs.package_run_id }}
+      package_artifact_ids: ${{ steps.proof.outputs.package_artifact_ids }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Check recent main-branch CI
+      - name: Validate release identity even when reusing packages
+        run: bash scripts/release-metadata.sh
+      - name: Check recent main-branch CI and packages
         id: proof
         env:
           GH_TOKEN: ${{ github.token }}
@@ -38,156 +43,60 @@ jobs:
     permissions:
       contents: read
       checks: write
+      attestations: write
+      id-token: write
 
   package:
-    name: package (${{ matrix.arch }})
-    # Build the exact revision while its independent checks run. Publication
-    # below still requires BOTH architectures and every validation job.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: x86_64
-            platform: amd64
-            runner: ubuntu-24.04
-          - arch: aarch64
-            platform: arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          fetch-depth: 0
-
-      - name: Validate version and prepare an exact source archive
-        id: metadata
-        shell: bash
-        run: |
-          set -euo pipefail
-          version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
-          package_release=$(sed -n 's/^pkgrel=//p' packaging/arch/PKGBUILD-release | head -n1)
-          source_id=$(git describe --tags --always --dirty)
-          if [[ $GITHUB_REF == refs/tags/preview-v* ]]; then
-            tag_version=${GITHUB_REF_NAME#preview-v}
-            if [[ $tag_version =~ ^(.+)-r([1-9][0-9]*)$ ]]; then
-              tag_version=${BASH_REMATCH[1]}
-              tag_release=${BASH_REMATCH[2]}
-              test "$tag_release" = "$package_release" || {
-                echo "tag package release r$tag_release does not match PKGBUILD pkgrel=$package_release" >&2
-                exit 1
-              }
-            fi
-            test "$tag_version" = "$version" || {
-              echo "tag version $tag_version does not match workspace version $version" >&2
-              exit 1
-            }
-          fi
-          build_dir="$RUNNER_TEMP/chonkstep-package"
-          install -d -m777 "$build_dir"
-          git archive \
-            --format=tar.gz \
-            --prefix="chonkstep-$version/" \
-            --output="$build_dir/chonkstep-$version.tar.gz" \
-            HEAD
-          install -m644 packaging/arch/PKGBUILD-release "$build_dir/PKGBUILD"
-
-          package_name="chonkstep-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
-          # `options=(strip debug)` in the PKGBUILD makes makepkg emit
-          # this beside the main package: the symbols a coredump needs
-          # to be more than a list of addresses. Shipped as its own
-          # asset so the main package stays small and only someone
-          # reading a crash pays for it.
-          debug_package_name="chonkstep-debug-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
-          {
-            echo "version=$version"
-            echo "package_release=$package_release"
-            echo "package_name=$package_name"
-            echo "debug_package_name=$debug_package_name"
-            echo "source_id=$source_id"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build the native Arch package environment
-        run: |
-          docker build \
-            --pull \
-            --platform "linux/${{ matrix.platform }}" \
-            --file packaging/arch/Dockerfile.builder \
-            --tag "chonkstep-arch-builder:${{ matrix.arch }}" \
-            packaging/arch
-
-      - name: Build, test, and inspect the package natively
-        run: |
-          docker run --rm \
-            --platform "linux/${{ matrix.platform }}" \
-            --env CARGO_INCREMENTAL=0 \
-            --env CARGO_PROFILE_DEV_DEBUG=0 \
-            --env CARGO_PROFILE_TEST_DEBUG=0 \
-            --env "CHONKSTEP_GIT_DESCRIBE=${{ steps.metadata.outputs.source_id }}" \
-            --volume "$RUNNER_TEMP/chonkstep-package:/build" \
-            --volume "$GITHUB_WORKSPACE:/source:ro" \
-            "chonkstep-arch-builder:${{ matrix.arch }}" \
-            bash -lc '
-              set -euo pipefail
-              makepkg --syncdeps --cleanbuild --clean --force --noconfirm
-              package="/build/${{ steps.metadata.outputs.package_name }}"
-              /source/scripts/verify-release-package.sh \
-                "$package" \
-                "${{ matrix.arch }}" \
-                "${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.package_release }}" \
-                "${{ steps.metadata.outputs.source_id }}"
-              install -d /build/dist
-              install -m644 "$package" /build/dist/
-              # The verifier above already failed the build if this was
-              # missing; installing it here is what gets it attested and
-              # published rather than discarded with the container.
-              install -m644 "/build/${{ steps.metadata.outputs.debug_package_name }}" /build/dist/
-            '
-
-      - name: Record package digests
-        run: |
-          cd "$RUNNER_TEMP/chonkstep-package/dist"
-          sha256sum "${{ steps.metadata.outputs.package_name }}" \
-                    "${{ steps.metadata.outputs.debug_package_name }}"
-
-      # Both subjects, so the symbols a user symbolises a crash with
-      # carry the same provenance guarantee as the binary that crashed.
-      - name: Attest package provenance
-        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
-        with:
-          subject-path: |
-            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}
-            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.debug_package_name }}
-
-      - name: Upload packages for release assembly
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: chonkstep-package-${{ matrix.arch }}
-          path: ${{ runner.temp }}/chonkstep-package/dist/
-          if-no-files-found: error
-          retention-days: 14
-          compression-level: 0 # .pkg.tar.zst files are already compressed.
+    name: build packages when none can be reused
+    needs: validation-status
+    if: needs.validation-status.outputs.package_run_id == ''
+    uses: ./.github/workflows/package.yml
 
   publish-preview:
-    name: publish preview release
+    name: verify packages and publish tagged releases
     if: >-
-      always() && !cancelled() && startsWith(github.ref, 'refs/tags/preview-v') &&
-      needs.validation-status.result == 'success' && needs.package.result == 'success' &&
+      always() && !cancelled() &&
+      needs.validation-status.result == 'success' &&
+      (needs.package.result == 'success' ||
+       (needs.package.result == 'skipped' && needs.validation-status.outputs.package_run_id != '')) &&
       (needs.validation.result == 'success' ||
        (needs.validation.result == 'skipped' && needs.validation-status.outputs.reusable == 'true'))
     needs: [validation-status, validation, package]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: read
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      - name: Download the verified packages from main
+        if: needs.validation-status.outputs.package_run_id != ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          github-token: ${{ github.token }}
+          run-id: ${{ needs.validation-status.outputs.package_run_id }}
+          artifact-ids: ${{ needs.validation-status.outputs.package_artifact_ids }}
+          path: dist
+          merge-multiple: true
+          digest-mismatch: error
+
+      - name: Download freshly built packages
+        if: needs.validation-status.outputs.package_run_id == ''
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: chonkstep-package-*
           path: dist
           merge-multiple: true
+          digest-mismatch: error
+
+      - name: Verify package identity and provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/verify-release-assets.sh dist
 
       - name: Verify the assembled release and publish it
+        if: startsWith(github.ref, 'refs/tags/preview-v')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -240,7 +149,8 @@ jobs:
           Verify a downloaded package's GitHub build provenance with:
 
           \`\`\`sh
-          gh attestation verify "\$chonkstep_dir/\$chonkstep_pkg" --repo $GITHUB_REPOSITORY
+          gh attestation verify "\$chonkstep_dir/\$chonkstep_pkg" --repo $GITHUB_REPOSITORY \
+            --signer-workflow $GITHUB_REPOSITORY/.github/workflows/package.yml
           \`\`\`
 
           Each architecture also has a \`chonkstep-debug-\` package. It is not

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -25,7 +25,8 @@ jobs:
 
   package:
     name: package (${{ matrix.arch }})
-    needs: validation
+    # Build the exact revision while its independent checks run. Publication
+    # below still requires BOTH architectures and every validation job.
     strategy:
       fail-fast: false
       matrix:
@@ -148,11 +149,12 @@ jobs:
           path: ${{ runner.temp }}/chonkstep-package/dist/
           if-no-files-found: error
           retention-days: 14
+          compression-level: 0 # .pkg.tar.zst files are already compressed.
 
   publish-preview:
     name: publish preview release
     if: startsWith(github.ref, 'refs/tags/preview-v')
-    needs: package
+    needs: [validation, package]
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,119 @@
+# One package producer for merged commits and releases without reusable artifacts.
+name: native Arch packages
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  attestations: write
+  id-token: write
+
+jobs:
+  package:
+    name: package (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            platform: amd64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            platform: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Validate version and prepare an exact source archive
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/release-metadata.sh >> "$GITHUB_OUTPUT"
+          # Metadata is also needed by this step to name the source archive.
+          version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+          package_release=$(sed -n 's/^pkgrel=//p' packaging/arch/PKGBUILD-release | head -n1)
+          build_dir="$RUNNER_TEMP/chonkstep-package"
+          install -d -m777 "$build_dir"
+          git archive \
+            --format=tar.gz \
+            --prefix="chonkstep-$version/" \
+            --output="$build_dir/chonkstep-$version.tar.gz" \
+            HEAD
+          install -m644 packaging/arch/PKGBUILD-release "$build_dir/PKGBUILD"
+
+          package_name="chonkstep-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
+          # `options=(strip debug)` in the PKGBUILD makes makepkg emit
+          # this beside the main package: the symbols a coredump needs
+          # to be more than a list of addresses. Shipped as its own
+          # asset so the main package stays small and only someone
+          # reading a crash pays for it.
+          debug_package_name="chonkstep-debug-$version-$package_release-${{ matrix.arch }}.pkg.tar.zst"
+          {
+            echo "package_name=$package_name"
+            echo "debug_package_name=$debug_package_name"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build the native Arch package environment
+        run: |
+          docker build \
+            --pull \
+            --platform "linux/${{ matrix.platform }}" \
+            --file packaging/arch/Dockerfile.builder \
+            --tag "chonkstep-arch-builder:${{ matrix.arch }}" \
+            packaging/arch
+
+      - name: Build, test, and inspect the package natively
+        run: |
+          docker run --rm \
+            --platform "linux/${{ matrix.platform }}" \
+            --env CARGO_INCREMENTAL=0 \
+            --env CARGO_PROFILE_DEV_DEBUG=0 \
+            --env CARGO_PROFILE_TEST_DEBUG=0 \
+            --env "CHONKSTEP_GIT_DESCRIBE=${{ steps.metadata.outputs.source_id }}" \
+            --volume "$RUNNER_TEMP/chonkstep-package:/build" \
+            --volume "$GITHUB_WORKSPACE:/source:ro" \
+            "chonkstep-arch-builder:${{ matrix.arch }}" \
+            bash -lc '
+              set -euo pipefail
+              makepkg --syncdeps --cleanbuild --clean --force --noconfirm
+              package="/build/${{ steps.metadata.outputs.package_name }}"
+              /source/scripts/verify-release-package.sh \
+                "$package" \
+                "${{ matrix.arch }}" \
+                "${{ steps.metadata.outputs.version }}-${{ steps.metadata.outputs.package_release }}" \
+                "${{ steps.metadata.outputs.source_id }}"
+              install -d /build/dist
+              install -m644 "$package" /build/dist/
+              # The verifier above already failed the build if this was
+              # missing; installing it here is what gets it attested and
+              # published rather than discarded with the container.
+              install -m644 "/build/${{ steps.metadata.outputs.debug_package_name }}" /build/dist/
+            '
+
+      - name: Record package digests
+        run: |
+          cd "$RUNNER_TEMP/chonkstep-package/dist"
+          sha256sum "${{ steps.metadata.outputs.package_name }}" \
+                    "${{ steps.metadata.outputs.debug_package_name }}"
+
+      # Both subjects, so the symbols a user symbolises a crash with
+      # carry the same provenance guarantee as the binary that crashed.
+      - name: Attest package provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-path: |
+            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.package_name }}
+            ${{ runner.temp }}/chonkstep-package/dist/${{ steps.metadata.outputs.debug_package_name }}
+
+      - name: Upload packages for release assembly
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: chonkstep-package-${{ matrix.arch }}
+          path: ${{ runner.temp }}/chonkstep-package/dist/
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0 # .pkg.tar.zst files are already compressed.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ crate and both session binaries carry the same number.
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-07
+
+- Window capture now finishes by clicking the highlighted window. A camera
+  cursor shows the capture hotspot, including at fractional display scales.
+  Dragging out of the toolbar cannot accidentally capture a window.
+- Screen and area recording normalize the output's advertised transform before
+  cropping, fixing upside-down video with wf-recorder 0.4.1 in nested sessions.
+  Changing-content regressions pass with wf-recorder 0.4.1 and 0.6.0.
+- Failed MP4 conversion retains the recoverable recording and encoder log, and
+  reports their paths for diagnosis.
+- Main CI builds both native release packages once. Releases reuse the verified
+  packages and debug symbols from the same commit, waiting for main CI if needed.
+  Release compilation selects only the five installed binaries, and superseded
+  PR checks are cancelled.
+
+The reported Omacut playback stall could not be reproduced in the available
+setup and remains unconfirmed. This release does not claim to resolve it.
+See the [0.4.1 release notes](docs/releases/0.4.1.md).
+
 ## [0.4.0] - 2026-09-07
 
 This alpha release adds native capture, finger-following gestures, reversible

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-about"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-btpair"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -434,21 +434,21 @@ dependencies = [
 
 [[package]]
 name = "chonk-build-info"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "object",
 ]
 
 [[package]]
 name = "chonk-dock-proto"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "chonk-dock-widget"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cosmic-text",
  "tracing",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockapp-torture"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockclock"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-ui",
 ]
 
 [[package]]
 name = "chonk-hyprland-ipc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "serde",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-instruments"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-widget",
  "chonk-test-support",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-netjoin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shelf"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shell"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "chonk-dock-widget",
@@ -539,11 +539,11 @@ dependencies = [
 
 [[package]]
 name = "chonk-test-support"
-version = "0.4.0"
+version = "0.4.1"
 
 [[package]]
 name = "chonk-testkit"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "chonk-hyprland-ipc",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-toplevel"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "wayland-client",
  "wayland-protocols-wlr",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-ui"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-dock-proto",
  "tiny-skia",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-xsettings"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep-wayland"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -3409,7 +3409,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wm-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "regex",
  "serde",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "wm-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitflags 2.13.1",
  "chonk-test-support",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wm-theme"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chonk-test-support",
  "cosmic-text",
@@ -3445,14 +3445,14 @@ dependencies = [
 
 [[package]]
 name = "wm-theme-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "wm-wayland"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "calloop 0.14.4",
  "chonk-build-info",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "wm-x11"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["examples/chonk-switch", "examples/layer-role-repro", "vendor/smithay
 smithay = { path = "vendor/smithay-0.7.0" }
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ in place. ChonkStep translates the Hyprland IPC and `hyprctl` calls that
 Omarchy relies on into a classic stacking-window model with real minimize,
 maximize, shade, fullscreen, snapping, workspaces, Alt-Tab, and Overview.
 
-Version 0.4.0 is an **alpha**. It is ready for adventurous users and bug
+Version 0.4.1 is an **alpha**. It is ready for adventurous users and bug
 reports, not machines where a compositor failure would be costly. Hyprland
 stays installed, so ChonkStep is easy to evaluate and easy to leave.
 
 ![ChonkStep replacing Hyprland beneath the Ristretto Omarchy desktop](site/shots/omarchy-desktop.png)
 
-## Install ChonkStep 0.4.0 alpha
+## Install ChonkStep 0.4.1 alpha
 
 Native packages are available for `x86_64` and `aarch64` (including M1 Macs
 running an Arch Linux ARM/Omarchy environment):
 
 ```sh
-curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.0/chonkstep-0.4.0-1-$(uname -m).pkg.tar.zst"
-sudo pacman -U "./chonkstep-0.4.0-1-$(uname -m).pkg.tar.zst"
+curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/chonkstep-0.4.1-1-$(uname -m).pkg.tar.zst"
+sudo pacman -U "./chonkstep-0.4.1-1-$(uname -m).pkg.tar.zst"
 omarchy install desktop-chonkstep
 ```
 
@@ -237,11 +237,11 @@ the local file to pacman:
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.0-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.1-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.0/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.0/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/crates/chonk-build-info/src/lib.rs
+++ b/crates/chonk-build-info/src/lib.rs
@@ -9,10 +9,12 @@ use std::path::Path;
 
 use object::Object;
 
-/// `git describe --tags --always --dirty` from build time.
+/// The source identity supplied by packaging, or `git describe` at build time.
 ///
 /// A source-archive packager supplies the description through
-/// `CHONKSTEP_GIT_DESCRIBE`, because an archive has no `.git` directory.
+/// `CHONKSTEP_GIT_DESCRIBE`, because an archive has no `.git` directory. GitHub
+/// packages use `v<version>+git.<commit>` so tagging can promote the exact binary
+/// already built and verified on main.
 /// A direct non-git build says `v<version>+unknown-source` rather than
 /// pretending the package version identifies unknown source exactly.
 pub const SOURCE_ID: &str = env!("CHONKSTEP_SOURCE_ID");

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -669,7 +669,7 @@ fn recording_screen_and_area_preserve_changing_content() {
             String::from_utf8_lossy(&decoded.stderr)
         );
         assert!(
-            decoded.stdout.len() > 90 * 3,
+            decoded.stdout.len() > 20 * 3,
             "recording has advancing frames"
         );
         let mut red = false;

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -99,6 +99,108 @@ fn boot(name: &str, scale: f32) -> Session {
     session
 }
 
+fn window_click_workflow(scale: f32, name: &str) {
+    let mut session = boot(name, scale);
+    let exports = session.dir.join("exports");
+    let probe = profile_binary("chonk-input-probe").unwrap();
+    session.launch(probe.to_str().unwrap(), &["1"]).unwrap();
+    let window = session.wait_for_window("input-probe").unwrap();
+    let at = ((window.x + 50) as f64, (window.y + 60) as f64);
+    session.door().click(at.0, at.1).unwrap();
+    let releases = session
+        .client_log("chonk-input-probe")
+        .matches(" release ")
+        .count();
+    shortcut(&mut session, 5);
+    let world = session.world().unwrap();
+    let width = (720.0 * scale).min(world.output_w as f32 - 16.0);
+    let left = (world.output_w as f32 - width) / 2.0;
+    let top = world.output_h as f32 - 110.0 * scale;
+    // Use the actual Window button, then drag out of its padding: that is
+    // navigation, never an implicit capture on the release over the desktop.
+    session
+        .door()
+        .click(
+            (left + width * 2.5 / 7.0) as f64,
+            (top + 23.0 * scale) as f64,
+        )
+        .unwrap();
+    session
+        .door()
+        .drag_to(
+            ((left + width / 2.0) as f64, (top + 3.0 * scale) as f64),
+            at,
+        )
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().barrier().unwrap();
+    assert!(files(&exports, "png").is_empty());
+    let camera = diagnostic(&mut session, "camera-cursor");
+    session
+        .door()
+        .motion(at.0 + 60.0 * scale as f64, at.1)
+        .unwrap();
+    let elsewhere = diagnostic(&mut session, "camera-moved");
+    let radius = (18.0 * scale) as u32;
+    let x = at.0 as u32;
+    let y = at.1 as u32;
+    let changed = (x - radius..x + radius)
+        .flat_map(|px| (y - radius..y + radius).map(move |py| (px, py)))
+        .filter(|&(px, py)| camera.pixel(px, py) != elsewhere.pixel(px, py))
+        .count();
+    assert!(
+        changed > (70.0 * scale * scale) as usize,
+        "camera glyph is visible at {scale}x"
+    );
+    // The camera body extends well beyond the old 21-pixel crosshair.
+    let edge_x = (at.0 + 12.0 * scale as f64) as u32;
+    assert_ne!(camera.pixel(edge_x, y), elsewhere.pixel(edge_x, y));
+    session.door().click(at.0, at.1).unwrap();
+    let path = saved(&exports, 1, "png");
+    let image = Screenshot::load(&path).unwrap();
+    let frame = world.frame_of(window.id).unwrap();
+    assert_eq!((image.width, image.height), (frame.w, frame.h));
+    reviews_opened(&session, &[("xdg-open", &path)]);
+    assert_eq!(
+        session
+            .client_log("chonk-input-probe")
+            .matches(" release ")
+            .count(),
+        releases,
+        "the capture click must not reach the target app"
+    );
+    session.door().tap_key(30).unwrap();
+    poll_until(
+        Duration::from_secs(5),
+        "window click releases input grab",
+        || {
+            session
+                .client_log("chonk-input-probe")
+                .contains("keyboard key 30 down")
+                .then_some(())
+        },
+    )
+    .unwrap();
+}
+
+#[test]
+#[ignore = "needs nested Wayland"]
+fn toolbar_window_click_1x() {
+    window_click_workflow(1.0, "capture-window-click-1x");
+}
+
+#[test]
+#[ignore = "needs nested Wayland"]
+fn toolbar_window_click_fractional() {
+    window_click_workflow(1.5, "capture-window-click-15x");
+}
+
+#[test]
+#[ignore = "needs nested Wayland"]
+fn toolbar_window_click_2x() {
+    window_click_workflow(2.0, "capture-window-click-2x");
+}
+
 fn reviews_opened(session: &Session, expected: &[(&str, &Path)]) {
     let mut bytes = Vec::new();
     for (program, path) in expected {
@@ -512,6 +614,136 @@ fn recording_odd_area_is_playable_and_controls_are_excluded() {
     }
     shortcut(&mut session, 4);
     session.door().tap_key(1).unwrap(); // Tool can be reopened after finalization.
+}
+
+#[test]
+#[ignore = "needs nested Wayland, wf-recorder and ffmpeg"]
+fn recording_screen_and_area_preserve_changing_content() {
+    let mut session = boot("capture-motion", 1.0);
+    session.launch("foot", &[
+        "--title=capture-animation", "--override=locked-title=yes", "bash", "-c",
+        "while true; do printf '\\033[48;2;240;20;20m\\033[2J'; sleep 0.4; printf '\\033[48;2;20;20;240m\\033[2J'; sleep 0.4; done",
+    ]).unwrap();
+    let window = session.wait_for_window("capture-animation").unwrap();
+    let x = window.x + 50;
+    let y = window.y + 60;
+    let exports = session.dir.join("exports");
+    for (index, mode) in [5, 6].into_iter().enumerate() {
+        shortcut(&mut session, 5);
+        session.door().tap_key(mode).unwrap(); // record screen / area
+        if mode == 6 {
+            session
+                .door()
+                .drag_to((x as f64, y as f64), ((x + 301) as f64, (y + 201) as f64))
+                .unwrap();
+            session.door().button("left", false).unwrap();
+        }
+        session.door().tap_key(28).unwrap();
+        // The video needs multiple timed changes, not just a decodable first
+        // frame or moving pointer. The producer's background changes every 400ms.
+        std::thread::sleep(Duration::from_secs(3));
+        shortcut(&mut session, 5);
+        let path = saved(&exports, index + 1, "mp4");
+        let (sample_x, sample_y) = if mode == 6 {
+            (10, 10)
+        } else {
+            (x + 10, y + 10)
+        };
+        let decoded = Command::new("ffmpeg")
+            .args(["-nostdin", "-v", "error", "-xerror", "-i"])
+            .arg(&path)
+            .args([
+                "-vf",
+                &format!("crop=16:16:{sample_x}:{sample_y},scale=1:1"),
+                "-pix_fmt",
+                "rgb24",
+                "-f",
+                "rawvideo",
+                "-",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            decoded.status.success(),
+            "{}",
+            String::from_utf8_lossy(&decoded.stderr)
+        );
+        assert!(
+            decoded.stdout.len() > 90 * 3,
+            "recording has advancing frames"
+        );
+        let mut red = false;
+        let mut blue = false;
+        let mut transitions = 0;
+        let mut previous = None;
+        for rgb in decoded.stdout.as_chunks::<3>().0 {
+            let is_red = rgb[0] > 150 && rgb[2] < 100;
+            let is_blue = rgb[2] > 150 && rgb[0] < 100;
+            red |= is_red;
+            blue |= is_blue;
+            if is_red || is_blue {
+                if previous.is_some_and(|last| last != is_red) {
+                    transitions += 1;
+                }
+                previous = Some(is_red);
+            }
+        }
+        assert!(red && blue && transitions >= 3,
+            "recording mode {mode} contains actual scene updates: red={red}, blue={blue}, transitions={transitions}");
+    }
+}
+
+#[test]
+#[ignore = "needs nested Wayland and wf-recorder"]
+fn failed_mp4_export_preserves_video_and_muxer_diagnostics() {
+    let mut session = boot("capture-mux-failure", 1.0);
+    let ffmpeg = session.dir.join("config/chonkstep/fixture-bin/ffmpeg");
+    std::fs::write(
+        &ffmpeg,
+        "#!/bin/sh\necho 'fixture: MP4 write failed' >&2\nexit 7\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(ffmpeg, std::fs::Permissions::from_mode(0o700)).unwrap();
+    shortcut(&mut session, 5);
+    session.door().tap_key(6).unwrap();
+    session
+        .door()
+        .drag_to((30.0, 40.0), (231.0, 153.0))
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().tap_key(28).unwrap();
+    std::thread::sleep(Duration::from_secs(2));
+    shortcut(&mut session, 5);
+    poll_until(Duration::from_secs(15), "MP4 failure is reported", || {
+        session.log().contains("MP4 export failed").then_some(())
+    })
+    .unwrap();
+    let exports = session.dir.join("exports");
+    assert!(files(&exports, "mp4").is_empty());
+    let paths: Vec<_> = std::fs::read_dir(exports)
+        .unwrap()
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    let video = paths
+        .iter()
+        .find(|p| p.extension().is_some_and(|e| e == "mkv"))
+        .unwrap();
+    let log = paths
+        .iter()
+        .find(|p| p.extension().is_some_and(|e| e == "log"))
+        .unwrap();
+    assert!(video.metadata().unwrap().len() > 1000);
+    assert!(std::fs::read_to_string(log)
+        .unwrap()
+        .contains("fixture: MP4 write failed"));
+    assert!(session.log().contains(&log.display().to_string()));
+    assert!(
+        !session.dir.join("capture-review.log").exists(),
+        "failed export does not launch Omacut"
+    );
+    shortcut(&mut session, 4);
+    session.door().tap_key(1).unwrap();
 }
 
 #[test]

--- a/crates/wm-wayland/src/capture_tool.rs
+++ b/crates/wm-wayland/src/capture_tool.rs
@@ -60,9 +60,11 @@ pub(crate) struct Overlay {
     toolbar: Rect,
     label: Option<MemoryRenderBuffer>,
     hint: Option<MemoryRenderBuffer>,
+    camera: Option<MemoryRenderBuffer>,
     dimming: dimming::Dimming,
     ids: [Id; 16],
     armed: Option<usize>,
+    armed_window: Option<WlWindowId>,
     hovered: Option<usize>,
 }
 
@@ -137,7 +139,7 @@ pub(crate) fn modal(backend: &WaylandBackend) -> bool {
     backend.capture_ui.as_ref().is_some_and(|ui| !ui.badge)
 }
 
-pub(crate) fn crosshair(backend: &WaylandBackend) -> Option<Point> {
+pub(crate) fn selection_cursor(backend: &WaylandBackend) -> Option<Point> {
     let ui = backend.capture_ui.as_ref().filter(|ui| !ui.badge)?;
     backend.pointer.filter(|p| !ui.toolbar.contains(*p))
 }
@@ -223,9 +225,11 @@ pub(crate) fn begin(comp: &mut Compositor, mode: CaptureMode) {
         toolbar,
         label: None,
         hint: None,
+        camera: None,
         dimming: dimming::Dimming::default(),
         ids: std::array::from_fn(|_| Id::new()),
         armed: None,
+        armed_window: None,
         hovered: None,
     });
     crate::input::release_pointer_constraint(comp);
@@ -349,9 +353,11 @@ fn commit(comp: &mut Compositor) {
                 ),
                 label: None,
                 hint: None,
+                camera: None,
                 dimming: dimming::Dimming::default(),
                 ids: std::array::from_fn(|_| Id::new()),
                 armed: None,
+                armed_window: None,
                 hovered: None,
             });
             // The badge may appear under a stationary pointer. Retire the
@@ -455,6 +461,9 @@ fn set_mode(comp: &mut Compositor, mode: Mode) {
         ui.selection = matches!(mode, Mode::Screen | Mode::RecordScreen).then_some(ui.monitor);
         ui.window = None;
         ui.drag = None;
+        ui.armed = None;
+        ui.armed_window = None;
+        ui.move_selection = false;
     }
     motion(comp, pointer(comp));
     repaint(comp);
@@ -586,6 +595,11 @@ pub(crate) fn button(comp: &mut Compositor, code: u32, pressed: bool) -> bool {
     if pressed {
         let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
         ui.armed = hit;
+        ui.armed_window = if !ui.toolbar.contains(at) && ui.mode == Mode::Window {
+            ui.window
+        } else {
+            None
+        };
         if hit.is_none() && ui.mode.area() && !ui.toolbar.contains(at) {
             let corner = ui
                 .selection
@@ -600,7 +614,13 @@ pub(crate) fn button(comp: &mut Compositor, code: u32, pressed: bool) -> bool {
     } else {
         let ui = comp.wm.backend_mut().capture_ui.as_mut().unwrap();
         let armed = ui.armed.take();
-        ui.drag = None;
+        let armed_window = ui.armed_window.take();
+        let dragged = ui.drag.take().is_some();
+        // Only finish a click we acquired. In particular, dragging out of a
+        // toolbar control or its padding must not photograph a nearby window.
+        if !held {
+            return true;
+        }
         if let Some(index) = hit.filter(|h| Some(*h) == armed) {
             match index {
                 0 => dismiss(comp),
@@ -616,7 +636,11 @@ pub(crate) fn button(comp: &mut Compositor, code: u32, pressed: bool) -> bool {
                 ),
                 _ => commit(comp),
             }
-        } else if armed.is_none() && ui.quick && !ui.toolbar.contains(at) {
+        } else if armed.is_none()
+            && !ui.toolbar.contains(at)
+            && ((ui.mode == Mode::Window && armed_window.is_some() && armed_window == ui.window)
+                || (ui.quick && ui.mode.area() && dragged))
+        {
             commit(comp);
         }
     }
@@ -872,34 +896,54 @@ pub(crate) fn render(
         .take_while(|e| e.kind() == Kind::Cursor)
         .count();
     let scene_end = elements.len();
-    if let Some(at) = crosshair(backend) {
-        for (i, (x, y, w, h)) in [
-            (at.x - 10, at.y - 1, 21, 3),
-            (at.x - 1, at.y - 10, 3, 21),
-            (at.x - 10, at.y, 21, 1),
-            (at.x, at.y - 10, 1, 21),
-        ]
-        .into_iter()
-        .enumerate()
-        .rev()
-        {
-            elements.push(
-                SolidColorRenderElement::new(
-                    ui.ids[8 + i].clone(),
-                    SRect::<i32, Physical>::new(
-                        (x - viewport.pos.x, y - viewport.pos.y).into(),
-                        (w, h).into(),
+    if let Some(at) = selection_cursor(backend) {
+        if ui.mode == Mode::Window {
+            if let Some(buffer) = &ui.camera {
+                let scale = ui.toolbar.size.h as f64 / 86.0;
+                if let Ok(element) = MemoryRenderBufferRenderElement::from_buffer(
+                    renderer,
+                    (
+                        (at.x - viewport.pos.x) as f64 - 16.0 * scale,
+                        (at.y - viewport.pos.y) as f64 - 16.0 * scale,
                     ),
-                    CommitCounter::default(),
-                    if i < 2 {
-                        Color32F::new(0.0, 0.0, 0.0, 1.0)
-                    } else {
-                        Color32F::new(1.0, 1.0, 1.0, 1.0)
-                    },
+                    buffer,
+                    None,
+                    None,
+                    None,
                     Kind::Cursor,
-                )
-                .into(),
-            );
+                ) {
+                    elements.push(element.into());
+                }
+            }
+        } else {
+            for (i, (x, y, w, h)) in [
+                (at.x - 10, at.y - 1, 21, 3),
+                (at.x - 1, at.y - 10, 3, 21),
+                (at.x - 10, at.y, 21, 1),
+                (at.x, at.y - 10, 1, 21),
+            ]
+            .into_iter()
+            .enumerate()
+            .rev()
+            {
+                elements.push(
+                    SolidColorRenderElement::new(
+                        ui.ids[8 + i].clone(),
+                        SRect::<i32, Physical>::new(
+                            (x - viewport.pos.x, y - viewport.pos.y).into(),
+                            (w, h).into(),
+                        ),
+                        CommitCounter::default(),
+                        if i < 2 {
+                            Color32F::new(0.0, 0.0, 0.0, 1.0)
+                        } else {
+                            Color32F::new(1.0, 1.0, 1.0, 1.0)
+                        },
+                        Kind::Cursor,
+                    )
+                    .into(),
+                );
+            }
         }
     }
     if let Some(buffer) = &ui.hint {

--- a/crates/wm-wayland/src/capture_tool.rs
+++ b/crates/wm-wayland/src/capture_tool.rs
@@ -317,7 +317,9 @@ fn commit(comp: &mut Compositor) {
             rect,
             monitor,
             entry.output.current_scale().integer_scale(),
-            entry.transform,
+            // Match the transform advertised to the screencopy client. The
+            // nested backend adds an EGL flip absent from the layout transform.
+            entry.output.current_transform(),
         ) else {
             comp.capture_tool.submit(Job::Error(
                 "This recording region cannot be represented by the output's capture grid".into(),

--- a/crates/wm-wayland/src/capture_tool/chrome.rs
+++ b/crates/wm-wayland/src/capture_tool/chrome.rs
@@ -33,6 +33,7 @@ struct StatusKey {
 pub(super) struct Cache {
     controls: Option<(ControlsKey, MemoryRenderBuffer)>,
     status: Option<(StatusKey, MemoryRenderBuffer)>,
+    camera: Option<(u32, MemoryRenderBuffer)>,
 }
 
 pub(super) fn hint_y(ui: &Overlay) -> i32 {
@@ -87,8 +88,55 @@ impl Cache {
         // Cloning these handles shares the backing pixels and uploaded texture.
         ui.label = self.controls.as_ref().map(|(_, buffer)| buffer.clone());
         ui.hint = self.status.as_ref().map(|(_, buffer)| buffer.clone());
+        if ui.mode == Mode::Window && !ui.badge {
+            if !self
+                .camera
+                .as_ref()
+                .is_some_and(|(height, _)| *height == ui.toolbar.size.h)
+            {
+                self.camera = paint_camera(ui.toolbar.size.h as f32 / 86.0)
+                    .and_then(import)
+                    .map(|buffer| (ui.toolbar.size.h, buffer));
+            }
+            ui.camera = self.camera.as_ref().map(|(_, buffer)| buffer.clone());
+        }
         changed
     }
+}
+
+// A small cached sprite, with the lens centered on the selection hotspot.
+// Drawing the glyph ourselves keeps it legible without a particular icon font
+// or cursor theme, and pointer motion only moves its uploaded buffer.
+fn paint_camera(scale: f32) -> Option<Pixmap> {
+    let mut pixmap = Pixmap::new((32.0 * scale).ceil() as u32, (30.0 * scale).ceil() as u32)?;
+    let mut path = PathBuilder::new();
+    path.move_to(4.0, 9.0);
+    path.line_to(10.0, 9.0);
+    path.line_to(12.0, 5.0);
+    path.line_to(20.0, 5.0);
+    path.line_to(22.0, 9.0);
+    path.line_to(28.0, 9.0);
+    path.line_to(28.0, 25.0);
+    path.line_to(4.0, 25.0);
+    path.close();
+    path.push_circle(16.0, 16.0, 5.0);
+    let path = path.finish()?;
+    for (width, color) in [(4.5, [12, 16, 23, 255]), (2.0, [255, 255, 255, 255])] {
+        let mut paint = Paint::default();
+        paint.set_color_rgba8(color[0], color[1], color[2], color[3]);
+        pixmap.stroke_path(
+            &path,
+            &paint,
+            &Stroke {
+                width,
+                line_join: tiny_skia::LineJoin::Round,
+                ..Stroke::default()
+            },
+            Transform::from_scale(scale, scale),
+            None,
+        );
+    }
+    Some(pixmap)
 }
 
 fn import(pixmap: Pixmap) -> Option<MemoryRenderBuffer> {
@@ -352,7 +400,7 @@ fn paint_status(key: StatusKey, fonts: &FontState) -> Option<Pixmap> {
     } else {
         let action = match key.mode {
             Mode::Screen => "Screen · Enter to capture",
-            Mode::Window => "Choose a window · Enter to capture",
+            Mode::Window => "Click a window to capture · Enter also captures",
             Mode::Area => "Drag an area · Enter to capture",
             Mode::RecordScreen => "Record screen · Enter to start",
             Mode::RecordArea => "Drag an area · Enter to record",
@@ -413,6 +461,8 @@ mod tests {
             toolbar: Rect::new(Point::new(280, 690), Size::new(720, 86)),
             selection: Some(Rect::new(Point::new(100, 100), Size::new(320, 240))),
             window: None,
+            camera: None,
+            armed_window: None,
             drag: None,
             move_selection: false,
             label: None,

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -721,12 +721,18 @@ fn record(output: &str, geometry: &str, filter: &str) -> Result<Recording, Strin
     let (partial, destination, file) = paths(true, "mp4")?;
     drop(file);
     let log = partial.with_extension("log");
-    let stderr = OpenOptions::new()
+    let stderr = match OpenOptions::new()
         .write(true)
         .create_new(true)
         .mode(0o600)
         .open(&log)
-        .map_err(|e| e.to_string())?;
+    {
+        Ok(file) => file,
+        Err(error) => {
+            let _ = std::fs::remove_file(&partial);
+            return Err(format!("Could not create recording log: {error}"));
+        }
+    };
     // Software H.264 is intentional: no VAAPI/NVIDIA assumption on Apple
     // Silicon / Asahi. Pad odd selections instead of dropping their last row.
     // calloop uses signalfd, so children inherit blocked INT/TERM/HUP. GNU env
@@ -785,7 +791,11 @@ fn finish(mut active: Recording, background: &mut Background, review: bool) {
     if !wait_child(&mut active.child, Duration::from_secs(8)) {
         background.notify(
             "Recording needs recovery",
-            &active.partial.display().to_string(),
+            &format!(
+                "{}\nDetails: {}",
+                active.partial.display(),
+                active.log.display()
+            ),
         );
         return;
     }
@@ -796,17 +806,25 @@ fn finish(mut active: Recording, background: &mut Background, review: bool) {
         .mode(0o600)
         .open(&temporary)
         .is_ok();
+    // Keep muxer diagnostics with encoder diagnostics. A missing ffmpeg is
+    // only one failure mode; disk errors and invalid media need their actual
+    // explanation, not a misleading instruction to reinstall the encoder.
     let converted = reserved
-        && Command::new("ffmpeg")
-            .args(["-nostdin", "-v", "error", "-y", "-i"])
-            .arg(&active.partial)
-            .args(["-c", "copy", "-movflags", "+faststart"])
-            .arg(&temporary)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .is_ok_and(|mut child| wait_child(&mut child, Duration::from_secs(30)));
+        && OpenOptions::new()
+            .append(true)
+            .open(&active.log)
+            .is_ok_and(|log| {
+                Command::new("ffmpeg")
+                    .args(["-nostdin", "-v", "error", "-y", "-i"])
+                    .arg(&active.partial)
+                    .args(["-c", "copy", "-movflags", "+faststart"])
+                    .arg(&temporary)
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(log)
+                    .spawn()
+                    .is_ok_and(|mut child| wait_child(&mut child, Duration::from_secs(30)))
+            });
     if converted && std::fs::hard_link(&temporary, &active.destination).is_ok() {
         let _ = std::fs::remove_file(&temporary);
         let _ = std::fs::remove_file(&active.partial);
@@ -822,8 +840,9 @@ fn finish(mut active: Recording, background: &mut Background, review: bool) {
         background.notify(
             "Recording preserved as MKV",
             &format!(
-                "{}\nInstall ffmpeg for MP4 export.",
-                active.partial.display()
+                "MP4 export failed. Video: {}\nDetails: {}",
+                active.partial.display(),
+                active.log.display()
             ),
         );
     }

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -1561,7 +1561,7 @@ pub(crate) fn push_cursor_elements(
     if matches!(status, CursorImageStatus::Hidden) {
         return;
     }
-    if crate::capture_tool::crosshair(backend).is_some() { return; }
+    if crate::capture_tool::selection_cursor(backend).is_some() { return; }
     let subject = if capture_cursor {
         crate::input::PointerSubject::Desktop
     } else {

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -40,6 +40,11 @@ area and window selection; click a highlighted window to capture it, including
 its Chonkstep titlebar, without overlapping applications. Escape or right-click
 cancels without saving or changing the clipboard.
 
+Window mode shows a camera cursor with its lens on the target. Clicking the
+highlighted window also captures directly when entered from the toolbar; there
+is no need to move back to Capture. Enter remains available. A drag from the
+toolbar onto a window does not capture it.
+
 The toolbar offers screen, window, area, record-screen and record-area modes.
 Keys 1–5 select the modes; Enter captures or starts recording. In toolbar area
 mode, releasing the pointer keeps the selection so it can be adjusted: drag

--- a/docs/engineering/2026-09-07-capture-ux.md
+++ b/docs/engineering/2026-09-07-capture-ux.md
@@ -1,0 +1,64 @@
+# Capture UX and release build follow-up
+
+The toolbar's Window mode previously selected a window on hover but committed
+only through Capture or Enter. Moving to Capture could replace the intended
+target while crossing another window. A click now captures the highlighted
+window in both quick and toolbar modes. A cached camera sprite replaces the
+crosshair in Window mode, with the lens as its hotspot. Controls still use the
+normal pointer. Both ends of the click must belong to the same window; dragging
+out of toolbar padding or changing modes during a press cannot capture it.
+
+Tests drive the actual Window toolbar button, inspect camera pixels at 1x, 1.5x
+and 2x, verify saved window dimensions and review launch, and verify that capture
+consumes its click and releases keyboard input. Existing tests cover quick
+capture, retained areas, clipboard bytes, occlusion, cancellation and recording
+badge input ownership.
+
+## Playback investigation
+
+A report described thumbnails appearing in Omacut without video playback for
+both screen and area recordings. The available machine runs an older installed
+ChonkStep session, so reproduction used the 0.4.0 source revision `3c12310` in an
+isolated nested compositor, not the installed 0.3.2 binary.
+
+The 0.4.0 baseline generated a 302x202 H.264 MP4 with a zero start time and
+3.033-second duration. The installed Omacut 0.4.0 displayed it, advanced its
+playhead on Space and responded to seeking. A second baseline probe exercised
+the actual background-worker launch of Omacut after recording a terminal whose
+background alternated red and blue. The MP4 contained both colors across 239
+frames, and Omacut displayed the changing preview with an advancing playhead.
+
+This does **not** reproduce or explain the reported playback failure on the
+affected machine. No decoder workaround or global Qt setting is justified by
+these observations. A failing clip, decoder diagnostics or the affected machine
+is still needed before declaring that symptom fixed.
+
+The old recording test checked metadata and one decoded frame. The new
+regression decodes the full screen and odd-sized area recordings, requiring
+multiple red/blue transitions inside the client's content. Pointer motion alone
+cannot satisfy it. Failed MP4 conversion also retains the muxer's stderr beside
+the recoverable MKV and reports that diagnostic path.
+
+Local artifacts, including the baseline executable, probe source, videos,
+Omacut screenshots and command logs, are retained outside the repository at
+`/home/chrisk/src/chonkstep-capture-ux-artifacts`.
+
+## Release build work
+
+The 0.4.0 GitHub release run `34137573202` took **32m43s**. Validation ran for
+about 12m30s before package jobs could begin. On x86_64, the release compilation
+then took **13m08s**, followed by **3m45s** of debug test compilation. The release
+build unnecessarily compiled and linked every E2E probe with thin LTO, although
+the package installs only five binaries.
+
+The package build now selects exactly those five executable targets. A
+regression compares the target list with both packaging recipes and verifies
+that Cargo failures propagate. The full workspace debug tests remain in each
+native architecture's package check. Validation and package building run
+concurrently, and publication depends on both. Already compressed package
+artifacts are uploaded without another compression pass. Release optimization,
+debug symbols, package verification, checksums and attestations are preserved.
+
+A local build of the five shipping binaries succeeded in 2m09s using the
+existing dependency cache. This is not a comparable cold CI timing; runner
+measurements are needed for a release-duration claim.

--- a/docs/engineering/2026-09-07-capture-ux.md
+++ b/docs/engineering/2026-09-07-capture-ux.md
@@ -39,6 +39,16 @@ multiple red/blue transitions inside the client's content. Pointer motion alone
 cannot satisfy it. Failed MP4 conversion also retains the muxer's stderr beside
 the recoverable MKV and reports that diagnostic path.
 
+The changing-content regression exposed another real recording defect in CI:
+the nested backend's advertised output includes an EGL flip, but recording had
+used its unflipped layout transform. wf-recorder 0.4.1 left the video upside
+down; 0.6.0's automatic transform hid that defect locally and applied the flip
+after the crop instead of before it. Recording now uses
+`entry.output.current_transform()` so its explicit normalization matches the
+actual screencopy buffer. Both 0.4.1 (in an isolated Ubuntu container) and the
+host's 0.6.0 pass the area and screen motion tests with this correction. This
+orientation defect does not establish the cause of the reported Omacut stall.
+
 Local artifacts, including the baseline executable, probe source, videos,
 Omacut screenshots and command logs, are retained outside the repository at
 `/home/chrisk/src/chonkstep-capture-ux-artifacts`.
@@ -67,11 +77,28 @@ explicitly checks native package success and either successful fresh validation
 or verified reuse; a skipped job alone never permits publication.
 
 A local build of the five shipping binaries succeeded in 2m09s using the
-existing dependency cache. This is not a comparable cold CI timing; runner
-measurements are needed for a release-duration claim.
+existing dependency cache. The native package rehearsal `34142960605` then
+measured these release compilation times on the same runner classes:
+
+| Architecture | 0.4.0 release | Five shipping binaries | Reduction |
+| --- | --- | --- | --- |
+| x86_64 | 13m08s | 9m52s | 25% |
+| aarch64 | 6m42s | 5m49s | 13% |
+
+Both native package jobs passed tests, package verification and attestations;
+the last package finished 16m24s after workflow start. The original release took
+32m43s including publication. The rehearsal itself is recorded as failed
+because its full Wayland gate exposed the orientation defect described above;
+it is not a successful-release measurement. The corrected source is qualified
+separately, and no 0.4.1 release has been published from this rehearsal.
 
 Local qualification passed 2,049 Rust unit/doc tests, strict workspace Clippy
 and documentation checks, the 15-test capture suite plus the MP4 failure test,
 49 Python harness tests, four validation-proof tests, Actionlint, ShellCheck and
 the Omarchy installer integration tests. Hardware decoder behavior on the
 reporter's machine remains unverified.
+
+The corrected implementation `21f2348` passed the complete GitHub CI run
+`34143790174`, including the full Wayland suite (12m31s), unit tests, lint,
+SDK/harness checks, installer integration and dependency audit. The follow-up
+commit to this report changes documentation only.

--- a/docs/engineering/2026-09-07-capture-ux.md
+++ b/docs/engineering/2026-09-07-capture-ux.md
@@ -102,3 +102,7 @@ The corrected implementation `21f2348` passed the complete GitHub CI run
 `34143790174`, including the full Wayland suite (12m31s), unit tests, lint,
 SDK/harness checks, installer integration and dependency audit. The follow-up
 commit to this report changes documentation only.
+
+A subsequent [release pipeline change](2026-09-07-release-promotion.md) moves
+native packaging into main CI so a release can promote those exact verified
+artifacts instead of compiling them again after the merge.

--- a/docs/engineering/2026-09-07-capture-ux.md
+++ b/docs/engineering/2026-09-07-capture-ux.md
@@ -59,6 +59,19 @@ concurrently, and publication depends on both. Already compressed package
 artifacts are uploaded without another compression pass. Release optimization,
 debug symbols, package verification, checksums and attestations are preserved.
 
+Tags may reuse the latest successful main-branch push CI for the exact commit
+when it started within the preceding 24 hours. Wrong revisions, PRs, failed or
+cancelled runs, old runs, and API errors require fresh CI. Tests exercise these
+fallbacks, including a newer failure following an older success. Publication
+explicitly checks native package success and either successful fresh validation
+or verified reuse; a skipped job alone never permits publication.
+
 A local build of the five shipping binaries succeeded in 2m09s using the
 existing dependency cache. This is not a comparable cold CI timing; runner
 measurements are needed for a release-duration claim.
+
+Local qualification passed 2,049 Rust unit/doc tests, strict workspace Clippy
+and documentation checks, the 15-test capture suite plus the MP4 failure test,
+49 Python harness tests, four validation-proof tests, Actionlint, ShellCheck and
+the Omarchy installer integration tests. Hardware decoder behavior on the
+reporter's machine remains unverified.

--- a/docs/engineering/2026-09-07-release-promotion.md
+++ b/docs/engineering/2026-09-07-release-promotion.md
@@ -13,16 +13,19 @@ The pipeline now has one native package producer, `package.yml`:
    as immutable Actions artifacts for 14 days.
 3. A release tag looks for the latest main push run for that exact commit. If it
    is still queued or running, the release waits for it instead of building again.
-   A successful run started within 24 hours supplies both validation and packages.
+   A successful run supplies the packages while its artifacts remain available;
+   its validation can also be reused if the run started within 24 hours.
 4. Release assembly downloads those artifacts by run ID and artifact IDs. It
    requires all four expected files, rejects download digest mismatches, and
    verifies each package's attestation against the repository, shared package
    workflow, source commit and workflow commit. It then creates checksums and
    publishes the same files. There is no Cargo compilation in this path.
 
-The 24-hour proof limit is deliberate: an old green run does not bypass current
-dependency auditing indefinitely. Missing, expired or incomplete artifacts cause
-native builds; missing, stale or unsuccessful validation causes fresh CI. The
+The 24-hour validation limit is deliberate: an old green run does not bypass
+current dependency auditing indefinitely. Fresh validation can run while reusing
+the already built packages; age alone does not require recompilation. Missing,
+expired or incomplete artifacts cause native builds; missing, stale or
+unsuccessful validation causes fresh CI. The
 fresh validation and package builds remain concurrent. A failure to observe an
 active main run stops the release rather than launching competing work. A skipped
 job is accepted only alongside its explicit reuse proof. The fresh and reused

--- a/docs/engineering/2026-09-07-release-promotion.md
+++ b/docs/engineering/2026-09-07-release-promotion.md
@@ -1,0 +1,52 @@
+# Build merged packages once, then promote them
+
+The first release optimization reused recent main CI but still rebuilt the Arch
+packages after tagging. The Ubuntu test binaries cannot serve as release assets:
+the packages need native Arch and Arch Linux ARM libraries, release optimization,
+installation checks and matching split debug symbols.
+
+The pipeline now has one native package producer, `package.yml`:
+
+1. PRs run the existing validation jobs. They do not build release packages.
+2. A push to main runs validation and both native package builds concurrently.
+   Both packages and both debug packages are inspected and attested, then retained
+   as immutable Actions artifacts for 14 days.
+3. A release tag looks for the latest main push run for that exact commit. If it
+   is still queued or running, the release waits for it instead of building again.
+   A successful run started within 24 hours supplies both validation and packages.
+4. Release assembly downloads those artifacts by run ID and artifact IDs. It
+   requires all four expected files, rejects download digest mismatches, and
+   verifies each package's attestation against the repository, shared package
+   workflow, source commit and workflow commit. It then creates checksums and
+   publishes the same files. There is no Cargo compilation in this path.
+
+The 24-hour proof limit is deliberate: an old green run does not bypass current
+dependency auditing indefinitely. Missing, expired or incomplete artifacts cause
+native builds; missing, stale or unsuccessful validation causes fresh CI. The
+fresh validation and package builds remain concurrent. A failure to observe an
+active main run stops the release rather than launching competing work. A skipped
+job is accepted only alongside its explicit reuse proof. The fresh and reused
+paths share the same package verification before publication.
+
+Package source identities are `v<version>+git.<full commit SHA>`. Unlike
+`git describe`, this value stays unchanged when a tag is added to the commit.
+The tag, Cargo version and Arch package version/revision must agree even when no
+build is needed. A version bump therefore belongs in the merged commit being
+released; changing the version afterward creates a new commit requiring a build.
+
+This moves native packaging to each main push, including commits that are never
+released. Main CI consequently waits for the slower of validation and native
+packaging, while PR validation keeps its existing cost. It avoids a second build
+when that main commit is released. The prior package rehearsal made both
+architectures available in 16m24s; promotion itself has not yet been timed on a
+merged commit, so this change makes no measured release-duration claim.
+
+`workflow_dispatch` rehearses the complete build/download/provenance path without
+publishing a release. Only preview tags enable the final publishing step.
+
+Regression tests cover waiting for active CI, rejecting PR/wrong-commit evidence,
+newer failures, expired or incomplete package pairs, API failures, tag-independent
+identity, mismatched versions, missing debug packages and failed attestations.
+
+The workflow uses GitHub's documented [cross-run artifact downloads](https://docs.github.com/en/actions/how-tos/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow)
+and [attestation verification policies](https://cli.github.com/manual/gh_attestation_verify).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,11 @@ the path from "installed" to "mine".
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.0-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.1-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.0/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.0/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -1,0 +1,71 @@
+# ChonkStep 0.4.1 alpha
+
+ChonkStep 0.4.1 improves window capture, corrects recording orientation and
+streamlines the release pipeline.
+
+## Capture fixes
+
+- In Window mode, click the highlighted window to capture it. A camera cursor
+  marks the capture hotspot at normal, fractional and high display scales.
+  Enter also captures; dragging from toolbar padding cannot take a screenshot.
+- Screen and area recording now normalize the advertised output transform
+  before cropping. This fixes upside-down recordings with wf-recorder 0.4.1 in
+  nested sessions. The changing-content tests also pass with wf-recorder 0.6.0.
+- If MP4 conversion fails, the recoverable recording and encoder log are kept,
+  and the failure notification includes their paths.
+
+## Faster releases
+
+Main CI builds, tests and verifies the native x86-64 and ARM64 packages in
+parallel with validation. A release tag promotes the packages and matching
+debug symbols built for that same commit. It waits for an active main build
+instead of starting another. Missing artifacts trigger fresh native builds;
+old validation can refresh without recompiling available packages.
+
+Release compilation now selects the five installed binaries. The earlier
+native comparison measured 25% less release compilation time on x86-64 and
+13% less on ARM64. Full workspace tests, native package checks, debug symbols,
+checksums and provenance attestations remain. Superseded PR checks are cancelled.
+See the [pipeline description](../engineering/2026-09-07-release-promotion.md).
+
+## Validation and known limitations
+
+Qualification includes window capture at 1x, 1.5x and 2x; complete decoding of
+changing screen and area recordings with two recorder versions; failed MP4
+conversion recovery; workspace tests, strict Clippy and documentation checks;
+and the full nested Wayland suite. Release regression tests cover exact-commit
+reuse, waiting, expired artifacts, mismatched versions and failed attestations.
+Both native architectures passed package and provenance verification in the
+pipeline rehearsal.
+
+The reported issue where Omacut shows thumbnails but does not play a recording
+could not be reproduced in the available setup. Baseline 0.4.0 clips played and
+sought correctly there. The orientation correction does not establish the cause
+of that playback stall, and 0.4.1 does not claim to resolve it. A failing clip and
+the affected machine's decoder/GPU details are still needed for diagnosis.
+The [capture investigation](../engineering/2026-09-07-capture-ux.md) records the
+evidence and limits. Recording remains silent software-encoded H.264, and this
+remains an alpha release.
+
+## Install on Arch or Omarchy
+
+Choose the package for the machine's native architecture:
+
+```sh
+chonkstep_dir="$(mktemp -d)"
+chonkstep_arch="$(uname -m)"
+chonkstep_pkg="chonkstep-0.4.1-1-$chonkstep_arch.pkg.tar.zst"
+curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/$chonkstep_pkg"
+curl -fL -o "$chonkstep_dir/SHA256SUMS" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/SHA256SUMS"
+(cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
+gh attestation verify "$chonkstep_dir/$chonkstep_pkg" --repo iconidentify/chonkstep \
+  --signer-workflow iconidentify/chonkstep/.github/workflows/package.yml
+sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
+omarchy install desktop-chonkstep
+```
+
+Matching `chonkstep-debug-0.4.1-1-<arch>.pkg.tar.zst` packages carry the symbols
+needed for readable ChonkStep crash reports. They are covered by the same
+checksums and provenance checks.

--- a/packaging/arch/Dockerfile.builder
+++ b/packaging/arch/Dockerfile.builder
@@ -1,4 +1,4 @@
-# Native x86_64/aarch64 Arch package builder used by github-release.yml.
+# Native x86_64/aarch64 Arch package builder used by package.yml.
 #
 # The bootstrap shape is adapted from omacom/omarchy-pkgs' multi-architecture
 # builder (MIT): Alpine's pacman creates a minimal target-architecture rootfs,

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -112,7 +112,7 @@ build() {
   export CARGO_TARGET_DIR=target
   # Record the exact checkout, not only the workspace package version.
   export CHONKSTEP_GIT_DESCRIBE="$(git describe --tags --always --dirty)"
-  cargo build --release --frozen --workspace
+  bash scripts/build-release.sh --frozen
 }
 
 check() {

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -39,7 +39,7 @@
 # those frames into `file:line`.
 options=(strip debug)
 pkgname=chonkstep
-pkgver=0.4.0
+pkgver=0.4.1
 pkgrel=1
 pkgdesc="A traditional floating compositor for Omarchy, compatible with Hyprland workflows"
 arch=('x86_64' 'aarch64')

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -105,7 +105,8 @@ build() {
   export RUSTUP_TOOLCHAIN=stable
   export CARGO_TARGET_DIR=target
   # A tag archive has no `.git`. The release workflow passes its exact
-  # `git describe` through makepkg; a normal AUR build falls back to the
+  # version and immutable commit ID through makepkg, so tagging does not
+  # change a package already built on main. A normal AUR build falls back to the
   # tag this recipe downloads. Direct non-git Cargo builds have their
   # own explicit `+unknown-source` fallback in chonk-build-info.
   export CHONKSTEP_GIT_DESCRIBE="${CHONKSTEP_GIT_DESCRIBE:-v$pkgver}"

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -110,7 +110,7 @@ build() {
   # own explicit `+unknown-source` fallback in chonk-build-info.
   export CHONKSTEP_GIT_DESCRIBE="${CHONKSTEP_GIT_DESCRIBE:-v$pkgver}"
   # --frozen: build exactly the dependency tree the repository ships.
-  cargo build --release --frozen --workspace
+  bash scripts/build-release.sh --frozen
 }
 
 check() {

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -5,16 +5,22 @@
 package `chonkstep`.
 
 `.github/workflows/github-release.yml` is the account-independent preview
-distribution path. A `preview-v$pkgver` tag builds the same recipe natively on
-GitHub's x86-64 and ARM64 runners, verifies each package on its build
-architecture, creates `SHA256SUMS`, records GitHub provenance attestations, and
-attaches the two `.pkg.tar.zst` files to a prerelease. The AArch64 builder is
-bootstrapped from Arch Linux ARM repositories; it is not an Ubuntu-linked
-cross-build. A manual workflow dispatch performs both builds and attestations
-without creating a release, which is the pre-tag acceptance gate.
+release path. Main CI builds and tests the native x86-64 and ARM64 packages
+through `package.yml`, verifies each package on its build architecture, and
+records GitHub provenance attestations. A `preview-v$pkgver` tag reuses those
+exact artifacts from the successful main run for the same commit, creates
+`SHA256SUMS`, and publishes both packages and their matching debug packages.
+If main CI is still running, the release waits; unavailable artifacts require a
+fresh native build. Set the release version before merging so tagging can reuse
+the merged commit's packages.
+
+The AArch64 builder uses Arch Linux ARM repositories. A manual workflow dispatch
+exercises package assembly and provenance verification without publishing a
+release. See the [release pipeline](../../docs/engineering/2026-09-07-release-promotion.md)
+for validation freshness and artifact retention.
 
 Pushing a tag whose name matches the workspace version, for example
-`v0.4.0`, runs `.github/workflows/aur.yml`. The job copies the release
+`v0.4.1`, runs `.github/workflows/aur.yml`. The job copies the release
 recipe to `PKGBUILD`, replaces `SKIP` with the tag archive's real
 SHA-256 checksum, generates `.SRCINFO` with Arch's `makepkg`, and pushes
 both files to `ssh://aur@aur.archlinux.org/chonkstep.git`.

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Build only the executables installed by the Arch package. Optimizing every
+# E2E probe with thin LTO used to dominate release time; those are built and
+# exercised by the full debug test suite in PKGBUILD's check() and Wayland CI.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cargo build --release --workspace \
+  --bin chonkstep \
+  --bin chonkstep-wayland \
+  --bin chonk-netjoin \
+  --bin chonk-about \
+  --bin omarchy-export-themes \
+  "$@"

--- a/scripts/release-metadata.sh
+++ b/scripts/release-metadata.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tag-independent identity lets a release promote the bytes built on main.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+version=$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)
+package_version=$(sed -n 's/^pkgver=//p' packaging/arch/PKGBUILD-release | head -n1)
+package_release=$(sed -n 's/^pkgrel=//p' packaging/arch/PKGBUILD-release | head -n1)
+commit=$(git rev-parse HEAD)
+[[ $version =~ ^[0-9]+\.[0-9]+\.[0-9]+([+-][a-zA-Z0-9.-]+)?$ ]] || {
+  echo "invalid workspace version: $version" >&2; exit 1;
+}
+[[ $package_version == "$version" && $package_release =~ ^[1-9][0-9]*$ ]] || {
+  echo 'workspace and Arch package versions must agree, with a positive pkgrel' >&2; exit 1;
+}
+[[ $commit == "$GITHUB_SHA" ]] || {
+  echo 'checked-out commit does not match the workflow revision' >&2; exit 1;
+}
+if [[ $GITHUB_REF == refs/tags/preview-v* ]]; then
+  tag_version=${GITHUB_REF#refs/tags/preview-v}
+  tag_release=1
+  if [[ $tag_version =~ ^(.+)-r([1-9][0-9]*)$ ]]; then
+    tag_version=${BASH_REMATCH[1]}
+    tag_release=${BASH_REMATCH[2]}
+  fi
+  [[ $tag_version == "$version" && $tag_release == "$package_release" ]] || {
+    echo "tag $GITHUB_REF does not match package $version-$package_release" >&2; exit 1;
+  }
+fi
+printf 'version=%s\npackage_release=%s\nsource_id=v%s+git.%s\n' \
+  "$version" "$package_release" "$version" "$commit"

--- a/scripts/release-validation.sh
+++ b/scripts/release-validation.sh
@@ -1,28 +1,69 @@
 #!/usr/bin/env bash
-# Reuse only the latest completed push CI for this exact main-branch revision,
-# and only for one day. Missing API access, malformed data and failed runs all
-# fall back to fresh validation; an output never makes an untested revision green.
+# Reuse only the latest push CI for this exact main-branch revision, for one day.
+# A tag arriving during main CI waits for that run instead of duplicating it.
+# Packages come only from that successful run and must include both architectures.
 set -euo pipefail
 
 reusable=false
-run_url=
+package_run_id=
+package_artifact_ids=
+run=null
+# These are jq variables supplied with --arg below, not shell expansions.
+# shellcheck disable=SC2016
+select_run='select(.head_sha == $sha and .head_branch == "main"
+  and .event == "push" and .repository.full_name == $repo)'
 if runs=$(gh api --method GET \
   "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
-  -f "head_sha=$GITHUB_SHA" -f event=push -f status=completed -f per_page=100); then
-  if run_url=$(jq -er --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" '
-    [.workflow_runs[] | select(.head_sha == $sha and .head_branch == "main"
-      and .event == "push" and .repository.full_name == $repo)]
-    | sort_by(.run_started_at) | last
-    | select(.conclusion == "success"
-      and (.run_started_at | fromdateiso8601) >= now - 86400)
-    | .html_url | select(type == "string" and length > 0)
-  ' <<< "$runs"); then
-    reusable=true
+  -f "head_sha=$GITHUB_SHA" -f event=push -f per_page=100); then
+  run=$(jq -ce --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" \
+    "[.workflow_runs[] | $select_run] | sort_by(.run_started_at, .id) | last" \
+    <<< "$runs") || run=null
+fi
+
+if run_id=$(jq -er 'select(.status != "completed") | .id
+  | select(type == "number" and . > 0)' <<< "$run"); then
+  echo "Waiting for main CI $run_id to finish building and validating $GITHUB_SHA."
+  # A timeout/API failure must not start competing builds while the original
+  # run might still be active. Completed failures fall back to fresh CI below.
+  timeout 35m gh run watch "$run_id" --repo "$GITHUB_REPOSITORY" --interval 15
+  run=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id")
+fi
+
+if run_id=$(jq -er --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" \
+  "$select_run"' | select(.status == "completed" and .conclusion == "success"
+    and (.run_started_at | fromdateiso8601) >= now - 86400)
+  | .id | select(type == "number" and . > 0)' <<< "$run"); then
+  reusable=true
+  if artifacts=$(gh api --method GET \
+    "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" -f per_page=100); then
+    if package_artifact_ids=$(jq -er --arg sha "$GITHUB_SHA" --argjson run "$run_id" '
+      [.artifacts[] | select(.name == "chonkstep-package-x86_64"
+        or .name == "chonkstep-package-aarch64")]
+      | select(length == 2 and (map(.name) | unique | length) == 2)
+      | select(all(.[]; .expired == false and (.expires_at | fromdateiso8601) > now
+        and .workflow_run.id == $run and .workflow_run.head_sha == $sha
+        and .workflow_run.head_branch == "main"
+        and .workflow_run.repository_id == .workflow_run.head_repository_id
+        and (.id | type == "number" and . > 0)))
+      | sort_by(.name) | map(.id | tostring) | join(",")
+    ' <<< "$artifacts"); then
+      package_run_id=$run_id
+    else
+      package_artifact_ids=
+    fi
   fi
 fi
-printf 'reusable=%s\n' "$reusable" >> "$GITHUB_OUTPUT"
+
+printf 'reusable=%s\npackage_run_id=%s\npackage_artifact_ids=%s\n' \
+  "$reusable" "$package_run_id" "$package_artifact_ids" >> "$GITHUB_OUTPUT"
 if "$reusable"; then
-  printf 'Reusing successful CI for %s: %s\n' "$GITHUB_SHA" "$run_url"
+  printf 'Reusing successful CI for %s: https://github.com/%s/actions/runs/%s\n' \
+    "$GITHUB_SHA" "$GITHUB_REPOSITORY" "$run_id"
 else
   echo 'No recent successful main-branch CI for this exact commit; running all validation.'
+fi
+if [[ -n $package_run_id ]]; then
+  echo "Promoting both native package artifacts from run $package_run_id; no recompilation."
+else
+  echo 'No complete reusable package pair; building and verifying both architectures.'
 fi

--- a/scripts/release-validation.sh
+++ b/scripts/release-validation.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reuse only the latest completed push CI for this exact main-branch revision,
+# and only for one day. Missing API access, malformed data and failed runs all
+# fall back to fresh validation; an output never makes an untested revision green.
+set -euo pipefail
+
+reusable=false
+run_url=
+if runs=$(gh api --method GET \
+  "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yml/runs" \
+  -f "head_sha=$GITHUB_SHA" -f event=push -f status=completed -f per_page=100); then
+  if run_url=$(jq -er --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" '
+    [.workflow_runs[] | select(.head_sha == $sha and .head_branch == "main"
+      and .event == "push" and .repository.full_name == $repo)]
+    | sort_by(.run_started_at) | last
+    | select(.conclusion == "success"
+      and (.run_started_at | fromdateiso8601) >= now - 86400)
+    | .html_url | select(type == "string" and length > 0)
+  ' <<< "$runs"); then
+    reusable=true
+  fi
+fi
+printf 'reusable=%s\n' "$reusable" >> "$GITHUB_OUTPUT"
+if "$reusable"; then
+  printf 'Reusing successful CI for %s: %s\n' "$GITHUB_SHA" "$run_url"
+else
+  echo 'No recent successful main-branch CI for this exact commit; running all validation.'
+fi

--- a/scripts/release-validation.sh
+++ b/scripts/release-validation.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Reuse only the latest push CI for this exact main-branch revision, for one day.
+# Reuse only the latest successful push CI for this exact main-branch revision.
+# Validation expires after one day; the built packages last until artifact expiry.
 # A tag arriving during main CI waits for that run instead of duplicating it.
 # Packages come only from that successful run and must include both architectures.
 set -euo pipefail
@@ -30,10 +31,11 @@ if run_id=$(jq -er 'select(.status != "completed") | .id
 fi
 
 if run_id=$(jq -er --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" \
-  "$select_run"' | select(.status == "completed" and .conclusion == "success"
-    and (.run_started_at | fromdateiso8601) >= now - 86400)
+  "$select_run"' | select(.status == "completed" and .conclusion == "success")
   | .id | select(type == "number" and . > 0)' <<< "$run"); then
-  reusable=true
+  if jq -e '(.run_started_at | fromdateiso8601) >= now - 86400' <<< "$run" >/dev/null; then
+    reusable=true
+  fi
   if artifacts=$(gh api --method GET \
     "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts" -f per_page=100); then
     if package_artifact_ids=$(jq -er --arg sha "$GITHUB_SHA" --argjson run "$run_id" '

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -1,0 +1,47 @@
+"""The fast build must still provide every executable that packaging installs."""
+
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ShippingBuildTests(unittest.TestCase):
+    def test_build_matches_both_package_manifests_and_propagates_failure(self):
+        with tempfile.TemporaryDirectory(prefix="chonk-shipping-build-") as directory:
+            root = Path(directory)
+            cargo = root / "cargo"
+            log = root / "arguments.json"
+            cargo.write_text(f"#!{sys.executable}\n" + "\n".join([
+                "import json, os, sys",
+                "from pathlib import Path",
+                "Path(os.environ['CHONK_BUILD_TEST_LOG']).write_text(json.dumps(sys.argv[1:]))",
+                "sys.exit(42)",
+            ]))
+            cargo.chmod(0o755)
+            result = subprocess.run(
+                ["bash", str(ROOT / "scripts/build-release.sh"), "--frozen"],
+                cwd=root, timeout=10, capture_output=True, text=True,
+                env={**os.environ, "PATH": f"{root}:{os.environ['PATH']}",
+                     "CHONK_BUILD_TEST_LOG": str(log)},
+            )
+            self.assertEqual(result.returncode, 42, result.stderr)
+            args = json.loads(log.read_text())
+            binaries = {args[i + 1] for i, value in enumerate(args) if value == "--bin"}
+            for recipe in ("PKGBUILD", "PKGBUILD-release"):
+                installed = set(re.findall(r"install -Dm755 target/release/([\w-]+)",
+                                          (ROOT / "packaging/arch" / recipe).read_text()))
+                self.assertTrue(installed)
+                self.assertEqual(binaries, installed)
+            self.assertIn("--frozen", args)
+            self.assertIn("--release", args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_metadata.py
+++ b/scripts/tests/test_release_metadata.py
@@ -1,0 +1,117 @@
+"""A tag must promote the same commit identity and the complete verified asset set."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class ReleaseMetadataTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory(prefix="chonk-release-metadata-")
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        (self.root / "scripts").mkdir()
+        (self.root / "packaging/arch").mkdir(parents=True)
+        for script in ("release-metadata.sh", "verify-release-assets.sh"):
+            shutil.copyfile(ROOT / "scripts" / script, self.root / "scripts" / script)
+        (self.root / "Cargo.toml").write_text('[workspace.package]\nversion = "0.4.1"\n')
+        self.recipe = self.root / "packaging/arch/PKGBUILD-release"
+        self.recipe.write_text("pkgver=0.4.1\npkgrel=1\n")
+        self.git("init", "-q")
+        self.git("add", ".")
+        self.git("-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "fixture")
+        self.sha = self.git("rev-parse", "HEAD").strip()
+        self.env = {**os.environ, "GITHUB_SHA": self.sha, "GITHUB_REF": "refs/heads/main",
+                    "GITHUB_REPOSITORY": "owner/project"}
+
+    def git(self, *args):
+        return subprocess.run(["git", *args], cwd=self.root, check=True, capture_output=True,
+                              text=True, timeout=10).stdout
+
+    def run_script(self, name="release-metadata.sh", *args, expected_exit=0):
+        result = subprocess.run(["bash", str(self.root / "scripts" / name), *args],
+                                cwd=self.root, env=self.env, capture_output=True, text=True, timeout=10)
+        self.assertEqual(result.returncode, expected_exit, result.stderr)
+        return result.stdout
+
+    def test_adding_a_release_tag_preserves_the_built_source_identity(self):
+        before = self.run_script()
+        self.git("tag", "preview-v0.4.1")
+        self.env["GITHUB_REF"] = "refs/tags/preview-v0.4.1"
+        after = self.run_script()
+        self.assertEqual(before, after)
+        self.assertIn(f"source_id=v0.4.1+git.{self.sha}", after)
+
+    def test_tag_version_and_package_revision_must_match(self):
+        for tag in ("preview-v0.4.0", "preview-v0.4.1-r2", "preview-v0.4.1-r0"):
+            with self.subTest(tag=tag):
+                self.env["GITHUB_REF"] = f"refs/tags/{tag}"
+                self.run_script(expected_exit=1)
+        self.recipe.write_text("pkgver=0.4.1\npkgrel=2\n")
+        self.env["GITHUB_REF"] = "refs/tags/preview-v0.4.1-r2"
+        self.assertIn("package_release=2", self.run_script())
+        self.env["GITHUB_REF"] = "refs/tags/preview-v0.4.1"
+        self.run_script(expected_exit=1)
+
+    def test_mismatched_recipe_or_checkout_is_rejected_before_build_or_promotion(self):
+        self.recipe.write_text("pkgver=0.4.0\npkgrel=1\n")
+        self.run_script(expected_exit=1)
+        self.recipe.write_text("pkgver=0.4.1\npkgrel=1\n")
+        self.env["GITHUB_SHA"] = "b" * 40
+        self.run_script(expected_exit=1)
+
+    def prepare_assets(self):
+        assets = self.root / "dist"
+        assets.mkdir()
+        for arch in ("x86_64", "aarch64"):
+            for package in ("chonkstep", "chonkstep-debug"):
+                (assets / f"{package}-0.4.1-1-{arch}.pkg.tar.zst").write_bytes(b"test asset")
+        log = self.root / "attestation-calls.jsonl"
+        gh = self.root / "gh"
+        gh.write_text(f"#!{sys.executable}\n" + "\n".join([
+            "import json, os, sys",
+            "with open(os.environ['CHONK_ATTEST_LOG'], 'a') as f: f.write(json.dumps(sys.argv[1:]) + '\\n')",
+            "sys.exit(1 if os.environ.get('CHONK_ATTEST_FAIL') in sys.argv[3] else 0)",
+        ]))
+        gh.chmod(0o755)
+        self.env.update(PATH=f"{self.root}:{os.environ['PATH']}", CHONK_ATTEST_LOG=str(log), CHONK_ATTEST_FAIL="__none__")
+        return assets, log
+
+    def test_all_four_assets_require_the_exact_source_and_signer_digest(self):
+        assets, log = self.prepare_assets()
+        self.run_script("verify-release-assets.sh", str(assets))
+        calls = [json.loads(line) for line in log.read_text().splitlines()]
+        self.assertEqual(len(calls), 4)
+        for call in calls:
+            self.assertEqual(call[:2], ["attestation", "verify"])
+            for flag in ("--source-digest", "--signer-digest"):
+                self.assertEqual(call[call.index(flag) + 1], self.sha)
+            self.assertEqual(call[call.index("--signer-workflow") + 1], "owner/project/.github/workflows/package.yml")
+            self.assertIn("--deny-self-hosted-runners", call)
+
+    def test_missing_symbols_or_wrong_version_prevents_promotion(self):
+        assets, log = self.prepare_assets()
+        package = assets / "chonkstep-debug-0.4.1-1-aarch64.pkg.tar.zst"
+        package.rename(assets / "chonkstep-debug-0.4.0-1-aarch64.pkg.tar.zst")
+        self.run_script("verify-release-assets.sh", str(assets), expected_exit=1)
+        (assets / "chonkstep-debug-0.4.0-1-aarch64.pkg.tar.zst").unlink()
+        log.unlink()
+        self.run_script("verify-release-assets.sh", str(assets), expected_exit=1)
+        self.assertFalse(log.exists())
+
+    def test_failed_attestation_stops_promotion(self):
+        assets, log = self.prepare_assets()
+        self.env["CHONK_ATTEST_FAIL"] = "debug"
+        self.run_script("verify-release-assets.sh", str(assets), expected_exit=1)
+        self.assertEqual(len(log.read_text().splitlines()), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_validation.py
+++ b/scripts/tests/test_release_validation.py
@@ -1,0 +1,82 @@
+"""A release can reuse proof, never another revision's or a failed validation."""
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SHA = "a" * 40
+REPO = "owner/project"
+
+
+def run_record(**overrides):
+    return {
+        "head_sha": SHA, "head_branch": "main", "event": "push",
+        "repository": {"full_name": REPO}, "conclusion": "success",
+        "run_started_at": (datetime.now(timezone.utc) - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "html_url": f"https://github.com/{REPO}/actions/runs/123",
+        **overrides,
+    }
+
+
+class ReleaseValidationTests(unittest.TestCase):
+    def proof(self, runs, api_exit=0):
+        with tempfile.TemporaryDirectory(prefix="chonk-release-proof-") as directory:
+            root = Path(directory)
+            response = root / "response.json"
+            response.write_text(runs if isinstance(runs, str) else json.dumps({"workflow_runs": runs}))
+            gh = root / "gh"
+            gh.write_text(f"#!{sys.executable}\n" + "\n".join([
+                "import os, sys",
+                "from pathlib import Path",
+                "print(Path(os.environ['CHONK_PROOF_RESPONSE']).read_text())",
+                "sys.exit(int(os.environ['CHONK_PROOF_EXIT']))",
+            ]))
+            gh.chmod(0o755)
+            output = root / "outputs"
+            result = subprocess.run(
+                ["bash", str(ROOT / "scripts/release-validation.sh")],
+                capture_output=True, text=True, timeout=10,
+                env={**os.environ, "PATH": f"{root}:{os.environ['PATH']}",
+                     "GITHUB_REPOSITORY": REPO, "GITHUB_SHA": SHA,
+                     "GITHUB_OUTPUT": str(output), "CHONK_PROOF_RESPONSE": str(response),
+                     "CHONK_PROOF_EXIT": str(api_exit)},
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return output.read_text().strip(), result.stdout
+
+    def test_recent_exact_main_commit_is_reused_with_traceable_run(self):
+        output, log = self.proof([run_record()])
+        self.assertEqual(output, "reusable=true")
+        self.assertIn("/actions/runs/123", log)
+
+    def test_wrong_revision_context_stale_or_unsuccessful_run_requires_fresh_ci(self):
+        for override in [
+            {"head_sha": "b" * 40}, {"head_branch": "feature"}, {"event": "pull_request"},
+            {"repository": {"full_name": "someone/fork"}}, {"conclusion": "failure"},
+            {"conclusion": "cancelled"}, {"conclusion": None},
+            {"run_started_at": "2020-01-01T00:00:00Z"}, {"html_url": None},
+        ]:
+            with self.subTest(override=override):
+                output, _ = self.proof([run_record(**override)])
+                self.assertEqual(output, "reusable=false")
+
+    def test_latest_failure_cannot_be_hidden_by_an_earlier_success(self):
+        earlier = run_record(run_started_at=(datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+        output, _ = self.proof([run_record(conclusion="failure"), earlier])
+        self.assertEqual(output, "reusable=false")
+
+    def test_missing_or_malformed_api_data_falls_back_to_all_validation(self):
+        for response, exit_code in [("not json", 0), ([], 0), ("{}", 0), ([run_record()], 1)]:
+            with self.subTest(response=response, exit_code=exit_code):
+                output, _ = self.proof(response, exit_code)
+                self.assertEqual(output, "reusable=false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_release_validation.py
+++ b/scripts/tests/test_release_validation.py
@@ -84,17 +84,21 @@ class ReleaseValidationTests(unittest.TestCase):
         self.assertIn(f"head_sha={SHA}", calls[0])
         self.assertNotIn("status=completed", calls[0])
 
-    def test_wrong_revision_context_stale_or_unsuccessful_run_requires_fresh_ci(self):
+    def test_wrong_revision_context_or_unsuccessful_run_requires_fresh_ci_and_packages(self):
         for override in [
             {"head_sha": "b" * 40}, {"head_branch": "feature"}, {"event": "pull_request"},
             {"repository": {"full_name": "someone/fork"}}, {"conclusion": "failure"},
             {"conclusion": "cancelled"}, {"conclusion": None},
-            {"run_started_at": "2020-01-01T00:00:00Z"}, {"id": None},
+            {"id": None},
         ]:
             with self.subTest(override=override):
                 output, _, _ = self.proof([run_record(**override)])
                 self.assertEqual(output["reusable"], "false")
                 self.assertEqual(output["package_run_id"], "")
+
+    def test_old_validation_is_refreshed_without_recompiling_available_packages(self):
+        output, _, _ = self.proof([run_record(run_started_at=timestamp(days=-3))])
+        self.assertEqual(output, {"reusable": "false", "package_run_id": "123", "package_artifact_ids": "789,456"})
 
     def test_latest_failure_cannot_be_hidden_by_an_earlier_success(self):
         earlier = run_record(run_started_at=timestamp(hours=-1))

--- a/scripts/tests/test_release_validation.py
+++ b/scripts/tests/test_release_validation.py
@@ -1,4 +1,4 @@
-"""A release can reuse proof, never another revision's or a failed validation."""
+"""Release promotion reuses only complete, recent evidence for the exact commit."""
 
 from datetime import datetime, timedelta, timezone
 import json
@@ -14,28 +14,54 @@ SHA = "a" * 40
 REPO = "owner/project"
 
 
+def timestamp(**delta):
+    return (datetime.now(timezone.utc) + timedelta(**delta)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def run_record(**overrides):
     return {
-        "head_sha": SHA, "head_branch": "main", "event": "push",
-        "repository": {"full_name": REPO}, "conclusion": "success",
-        "run_started_at": (datetime.now(timezone.utc) - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "html_url": f"https://github.com/{REPO}/actions/runs/123",
+        "id": 123, "head_sha": SHA, "head_branch": "main", "event": "push",
+        "repository": {"full_name": REPO, "id": 55},
+        "status": "completed", "conclusion": "success",
+        "run_started_at": timestamp(minutes=-5),
+        **overrides,
+    }
+
+
+def artifact(arch="x86_64", **overrides):
+    return {
+        "id": 456 if arch == "x86_64" else 789,
+        "name": f"chonkstep-package-{arch}", "expired": False,
+        "expires_at": timestamp(days=14),
+        "workflow_run": {"id": 123, "head_sha": SHA, "head_branch": "main",
+                         "repository_id": 55, "head_repository_id": 55},
         **overrides,
     }
 
 
 class ReleaseValidationTests(unittest.TestCase):
-    def proof(self, runs, api_exit=0):
+    def proof(self, runs, artifacts=None, completed=None, fail=None, expected_exit=0):
         with tempfile.TemporaryDirectory(prefix="chonk-release-proof-") as directory:
             root = Path(directory)
-            response = root / "response.json"
-            response.write_text(runs if isinstance(runs, str) else json.dumps({"workflow_runs": runs}))
+            responses = {
+                "runs": runs if isinstance(runs, str) else {"workflow_runs": runs},
+                "artifacts": {"artifacts": artifacts if artifacts is not None else [artifact(), artifact("aarch64")]},
+                "completed": completed if completed is not None else run_record(),
+            }
+            response = root / "responses.json"
+            response.write_text(json.dumps(responses))
+            log = root / "calls.jsonl"
             gh = root / "gh"
             gh.write_text(f"#!{sys.executable}\n" + "\n".join([
-                "import os, sys",
+                "import json, os, sys",
                 "from pathlib import Path",
-                "print(Path(os.environ['CHONK_PROOF_RESPONSE']).read_text())",
-                "sys.exit(int(os.environ['CHONK_PROOF_EXIT']))",
+                "args = sys.argv[1:]",
+                "with open(os.environ['CHONK_PROOF_LOG'], 'a') as f: f.write(json.dumps(args) + '\\n')",
+                "key = 'watch' if args[:2] == ['run', 'watch'] else ('runs' if any('/workflows/' in a for a in args) else ('artifacts' if any(a.endswith('/artifacts') for a in args) else 'completed'))",
+                "if key == os.environ.get('CHONK_PROOF_FAIL'): sys.exit(7)",
+                "if key == 'watch': sys.exit(0)",
+                "result = json.loads(Path(os.environ['CHONK_PROOF_RESPONSE']).read_text())[key]",
+                "print(result if isinstance(result, str) else json.dumps(result))",
             ]))
             gh.chmod(0o755)
             output = root / "outputs"
@@ -45,37 +71,81 @@ class ReleaseValidationTests(unittest.TestCase):
                 env={**os.environ, "PATH": f"{root}:{os.environ['PATH']}",
                      "GITHUB_REPOSITORY": REPO, "GITHUB_SHA": SHA,
                      "GITHUB_OUTPUT": str(output), "CHONK_PROOF_RESPONSE": str(response),
-                     "CHONK_PROOF_EXIT": str(api_exit)},
+                     "CHONK_PROOF_LOG": str(log), "CHONK_PROOF_FAIL": fail or ""},
             )
-            self.assertEqual(result.returncode, 0, result.stderr)
-            return output.read_text().strip(), result.stdout
+            self.assertEqual(result.returncode, expected_exit, result.stderr)
+            outputs = dict(line.split("=", 1) for line in output.read_text().splitlines()) if output.exists() else {}
+            return outputs, result.stdout, [json.loads(line) for line in log.read_text().splitlines()]
 
-    def test_recent_exact_main_commit_is_reused_with_traceable_run(self):
-        output, log = self.proof([run_record()])
-        self.assertEqual(output, "reusable=true")
+    def test_recent_exact_main_commit_promotes_both_immutable_artifacts(self):
+        output, log, calls = self.proof([run_record()])
+        self.assertEqual(output, {"reusable": "true", "package_run_id": "123", "package_artifact_ids": "789,456"})
         self.assertIn("/actions/runs/123", log)
+        self.assertIn(f"head_sha={SHA}", calls[0])
+        self.assertNotIn("status=completed", calls[0])
 
     def test_wrong_revision_context_stale_or_unsuccessful_run_requires_fresh_ci(self):
         for override in [
             {"head_sha": "b" * 40}, {"head_branch": "feature"}, {"event": "pull_request"},
             {"repository": {"full_name": "someone/fork"}}, {"conclusion": "failure"},
             {"conclusion": "cancelled"}, {"conclusion": None},
-            {"run_started_at": "2020-01-01T00:00:00Z"}, {"html_url": None},
+            {"run_started_at": "2020-01-01T00:00:00Z"}, {"id": None},
         ]:
             with self.subTest(override=override):
-                output, _ = self.proof([run_record(**override)])
-                self.assertEqual(output, "reusable=false")
+                output, _, _ = self.proof([run_record(**override)])
+                self.assertEqual(output["reusable"], "false")
+                self.assertEqual(output["package_run_id"], "")
 
     def test_latest_failure_cannot_be_hidden_by_an_earlier_success(self):
-        earlier = run_record(run_started_at=(datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"))
-        output, _ = self.proof([run_record(conclusion="failure"), earlier])
-        self.assertEqual(output, "reusable=false")
+        earlier = run_record(run_started_at=timestamp(hours=-1))
+        output, _, _ = self.proof([run_record(conclusion="failure"), earlier])
+        self.assertEqual(output["reusable"], "false")
+
+    def test_tag_waits_for_active_main_instead_of_starting_competing_builds(self):
+        for status in ("queued", "in_progress", "waiting"):
+            with self.subTest(status=status):
+                earlier = run_record(id=122, run_started_at=timestamp(hours=-1))
+                output, _, calls = self.proof([earlier, run_record(status=status, conclusion=None)])
+                self.assertEqual(output["package_run_id"], "123")
+                self.assertEqual(calls[1][:3], ["run", "watch", "123"])
+                self.assertIn(f"repos/{REPO}/actions/runs/123", calls[2])
+
+    def test_failed_main_after_wait_cannot_be_promoted(self):
+        output, _, _ = self.proof([run_record(status="in_progress", conclusion=None)],
+                                  completed=run_record(conclusion="failure"))
+        self.assertEqual(output["reusable"], "false")
+        self.assertEqual(output["package_artifact_ids"], "")
+
+    def test_failed_wait_or_status_refresh_stops_release_with_no_reuse_outputs(self):
+        for fail in ("watch", "completed"):
+            with self.subTest(fail=fail):
+                output, _, _ = self.proof([run_record(status="in_progress", conclusion=None)],
+                                          fail=fail, expected_exit=7)
+                self.assertEqual(output, {})
 
     def test_missing_or_malformed_api_data_falls_back_to_all_validation(self):
-        for response, exit_code in [("not json", 0), ([], 0), ("{}", 0), ([run_record()], 1)]:
-            with self.subTest(response=response, exit_code=exit_code):
-                output, _ = self.proof(response, exit_code)
-                self.assertEqual(output, "reusable=false")
+        for response, fail in [("not json", None), ([], None), ("{}", None), ([run_record()], "runs")]:
+            with self.subTest(response=response, fail=fail):
+                output, _, _ = self.proof(response, fail=fail)
+                self.assertEqual(output["reusable"], "false")
+                self.assertEqual(output["package_run_id"], "")
+
+    def test_partial_expired_duplicate_or_wrong_source_artifacts_rebuild_packages_only(self):
+        bad_pairs = [[], [artifact()], [artifact(), artifact()],
+                     [artifact(), artifact("aarch64", expired=True)],
+                     [artifact(), artifact("aarch64", expires_at=timestamp(minutes=-1))]]
+        for field, value in [("id", 999), ("head_sha", "b" * 40), ("head_branch", "feature"), ("head_repository_id", 99)]:
+            wrong = artifact("aarch64")
+            wrong["workflow_run"][field] = value
+            bad_pairs.append([artifact(), wrong])
+        for artifacts in bad_pairs:
+            with self.subTest(artifacts=artifacts):
+                output, _, _ = self.proof([run_record()], artifacts=artifacts)
+                self.assertEqual(output, {"reusable": "true", "package_run_id": "", "package_artifact_ids": ""})
+
+    def test_artifact_api_failure_preserves_validation_but_requires_package_builds(self):
+        output, _, _ = self.proof([run_record()], fail="artifacts")
+        self.assertEqual(output, {"reusable": "true", "package_run_id": "", "package_artifact_ids": ""})
 
 
 if __name__ == "__main__":

--- a/scripts/verify-release-assets.sh
+++ b/scripts/verify-release-assets.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The native producer already checked ELF, runtime dependencies and symbols.
+# Promotion checks every immutable package's signer and exact source commit.
+set -euo pipefail
+if [[ $# != 1 ]]; then
+  echo "usage: $0 ASSET_DIRECTORY" >&2; exit 2
+fi
+assets=$(realpath "$1")
+cd "$(dirname "$0")/.."
+metadata=$(bash scripts/release-metadata.sh)
+version=$(sed -n 's/^version=//p' <<< "$metadata")
+package_release=$(sed -n 's/^package_release=//p' <<< "$metadata")
+shopt -s nullglob
+files=("$assets"/*)
+[[ ${#files[@]} == 4 ]] || {
+  echo 'release must contain exactly two native packages and their two debug packages' >&2; exit 1;
+}
+for arch in x86_64 aarch64; do
+  for name in chonkstep chonkstep-debug; do
+    package="$assets/$name-$version-$package_release-$arch.pkg.tar.zst"
+    [[ -f $package && ! -L $package ]] || {
+      echo "missing release package: $package" >&2; exit 1;
+    }
+    gh attestation verify "$package" --repo "$GITHUB_REPOSITORY" \
+      --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/package.yml" \
+      --source-digest "$GITHUB_SHA" --signer-digest "$GITHUB_SHA" \
+      --deny-self-hosted-runners
+  done
+done


### PR DESCRIPTION
Prepare ChonkStep 0.4.1 alpha, including the workspace/Arch version bump, updated installation links, changelog and release notes.

Toolbar window capture now finishes by clicking the highlighted window, with a camera cursor at 1×, 1.5× and 2×. Dragging from toolbar padding cannot capture a window, capture clicks remain isolated from client input, and failed MP4 export preserves the muxer log beside the recoverable recording.

Recording now normalizes the advertised output transform before cropping. The layout transform omitted the nested backend's EGL flip: wf-recorder 0.4.1 produced upside-down video, while 0.6.0's automatic correction concealed the defect and occurred after cropping. Corrected screen and area recordings pass against both recorder versions. Tests require multiple red/blue scene transitions across decoded frames.

Merged commits now build, test, inspect and attest the x86-64 and ARM64 packages in parallel with CI, through one shared package workflow. A release tag promotes those exact package and debug files instead of rebuilding them. It waits if main CI is still running, accepts only artifacts from the latest successful main run for the identical commit, and verifies all four files against their source and signer digests before publication. Package source IDs include the version and full commit SHA, so adding a tag does not change the binaries. PRs retain their existing validation without native packaging.

Validation can be reused for 24 hours; packages remain reusable until their artifacts expire (14-day retention). Older validation runs again without forcing package recompilation. Missing packages trigger native builds; missing or unsuccessful validation triggers full CI. Publication requires both proofs or successful fresh jobs. Superseded PR checks are cancelled. Full workspace tests, debug symbols, package checks, checksums and attestations remain. Main builds packages even for commits that are never released; the benefit is immediate reuse when that commit is tagged.

The optimized Arch build selects only the five installed binaries. The earlier native rehearsal measured x86-64 release compilation at 13m08s → 9m52s (25% less) and ARM64 at 6m42s → 5m49s (13% less). Both package jobs completed within 16m24s of workflow start. These are compilation/package measurements, not a measured duration for the new promotion path.

Validation: strict workspace Clippy and documentation; 2,049 Rust unit/doc tests; the 15-test capture E2E suite plus a muxer-failure regression; corrected recording tests against wf-recorder 0.4.1 and 0.6.0. All 65 Python harness tests, Actionlint and ShellCheck pass. The implementation CI passed on `239d9de` before the version/documentation-only release preparation: https://github.com/iconidentify/chonkstep/actions/runs/34156557973.

The native build/download/provenance rehearsal passed on `e6e161b`: https://github.com/iconidentify/chonkstep/actions/runs/34156444623. Both architectures passed workspace tests, package inspection and attestations. Final assembly downloaded the four package files and verified their source and signer digests in a 21-second job; the publishing step was correctly skipped. The rehearsal took 14m08s including its fresh builds and full validation. The only later implementation change separates validation freshness from package retention, covered by regression tests and that implementation CI. The 0.4.1 preparation checks are shown below. Promotion from an actual merged main run will first execute after merge; its wait/reuse/fallback decisions are covered by the release regression tests.

Known limitation documented in the 0.4.1 release notes: the reported Omacut playback stall remains unconfirmed. Both a baseline 0.4.0 area clip and the actual worker-launched Omacut screen-recording flow played and sought correctly in the available setup. The confirmed orientation fix does not establish the cause of that stall; a failing clip and affected-machine details remain necessary for diagnosis.

See `docs/engineering/2026-09-07-capture-ux.md` for capture evidence and `docs/engineering/2026-09-07-release-promotion.md` for the release pipeline and limits.
