### PR TITLE
Fix game touchpad input, screensavers and capture previews for 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ crate and both session binaries carry the same number.
 
 ## [0.4.2] - 2026-09-07
 
+- Game pointer capture suspends touchpad "disable while typing", allowing held
+  movement keys and camera motion together in Wayland and XWayland games.
+  Normal typing suppression returns when capture ends. The preference is also
+  supported in TOML and imported Hyprland input configuration.
+- Omarchy's screensaver opens fullscreen on fresh accounts without imported
+  window rules, instead of inheriting the generic utility-window size.
+  Explicit imported fullscreen rules still take precedence.
+
 - Capture notifications show the saved screenshot or a thumbnail from the
   recording, fixing the missing camera icon shown as a pink checkerboard.
   Video preview failures fall back to a video icon without delaying capture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ crate and both session binaries carry the same number.
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-09-07
+
+- Capture notifications show the saved screenshot or a thumbnail from the
+  recording, fixing the missing camera icon shown as a pink checkerboard.
+  Video preview failures fall back to a video icon without delaying capture.
+
 ## [0.4.1] - 2026-09-07
 
 - Window capture now finishes by clicking the highlighted window. A camera

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-about"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-btpair"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -434,21 +434,21 @@ dependencies = [
 
 [[package]]
 name = "chonk-build-info"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "object",
 ]
 
 [[package]]
 name = "chonk-dock-proto"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "chonk-dock-widget"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cosmic-text",
  "tracing",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockapp-torture"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockclock"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-ui",
 ]
 
 [[package]]
 name = "chonk-hyprland-ipc"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "serde",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-instruments"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-widget",
  "chonk-test-support",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-netjoin"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shelf"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shell"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "chonk-dock-widget",
@@ -539,11 +539,11 @@ dependencies = [
 
 [[package]]
 name = "chonk-test-support"
-version = "0.4.1"
+version = "0.4.2"
 
 [[package]]
 name = "chonk-testkit"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "chonk-hyprland-ipc",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-toplevel"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "wayland-client",
  "wayland-protocols-wlr",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-ui"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-dock-proto",
  "tiny-skia",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-xsettings"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep-wayland"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -3409,7 +3409,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wm-config"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "regex",
  "serde",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "wm-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bitflags 2.13.1",
  "chonk-test-support",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wm-theme"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chonk-test-support",
  "cosmic-text",
@@ -3445,14 +3445,14 @@ dependencies = [
 
 [[package]]
 name = "wm-theme-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "wm-wayland"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "calloop 0.14.4",
  "chonk-build-info",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "wm-x11"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["examples/chonk-switch", "examples/layer-role-repro", "vendor/smithay
 smithay = { path = "vendor/smithay-0.7.0" }
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ in place. ChonkStep translates the Hyprland IPC and `hyprctl` calls that
 Omarchy relies on into a classic stacking-window model with real minimize,
 maximize, shade, fullscreen, snapping, workspaces, Alt-Tab, and Overview.
 
-Version 0.4.1 is an **alpha**. It is ready for adventurous users and bug
+Version 0.4.2 is an **alpha**. It is ready for adventurous users and bug
 reports, not machines where a compositor failure would be costly. Hyprland
 stays installed, so ChonkStep is easy to evaluate and easy to leave.
 
 ![ChonkStep replacing Hyprland beneath the Ristretto Omarchy desktop](site/shots/omarchy-desktop.png)
 
-## Install ChonkStep 0.4.1 alpha
+## Install ChonkStep 0.4.2 alpha
 
 Native packages are available for `x86_64` and `aarch64` (including M1 Macs
 running an Arch Linux ARM/Omarchy environment):
 
 ```sh
-curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/chonkstep-0.4.1-1-$(uname -m).pkg.tar.zst"
-sudo pacman -U "./chonkstep-0.4.1-1-$(uname -m).pkg.tar.zst"
+curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/chonkstep-0.4.2-1-$(uname -m).pkg.tar.zst"
+sudo pacman -U "./chonkstep-0.4.2-1-$(uname -m).pkg.tar.zst"
 omarchy install desktop-chonkstep
 ```
 
@@ -237,11 +237,11 @@ the local file to pacman:
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.1-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.2-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/crates/chonk-shell/src/shell.rs
+++ b/crates/chonk-shell/src/shell.rs
@@ -1462,6 +1462,7 @@ impl<B: Backend + PopupHost<PopupId = B::ShellId>> Shell<B> {
             sensitivity: next.input.sensitivity,
             natural_scroll: next.input.natural_scroll,
             tap_to_click: next.input.tap_to_click,
+            disable_while_typing: next.input.disable_while_typing,
             clickfinger_behavior: next.input.clickfinger_behavior,
             scroll_factor: next.input.scroll_factor,
             left_handed: next.input.left_handed,

--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1654,6 +1654,17 @@ impl Door {
         MemoryStatistics::parse(&self.read_line()?)
     }
 
+    /// Whether active pointer capture is suspending touchpad typing suppression.
+    pub fn touchpad_captured(&mut self) -> Result<bool, String> {
+        self.send("touchpad-capture")?;
+        let line = self.read_line()?;
+        match line.as_str() {
+            "touchpad-capture true" => Ok(true),
+            "touchpad-capture false" => Ok(false),
+            _ => Err(format!("unexpected touchpad-capture reply: {line}")),
+        }
+    }
+
     /// Reads and resets compositor frame/pass timings. Histogram buckets
     /// use power-of-two microsecond ceilings and always contain 16 entries.
     pub fn frame_stats(&mut self) -> Result<FrameStats, String> {

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -56,6 +56,7 @@ fn boot(name: &str, scale: f32) -> Session {
     // Never launch real review apps against the developer's desktop in E2E.
     // Record argument boundaries and whether publication preceded the launch.
     let wrapper = "#!/bin/sh\npublished=missing\nif [ \"$#\" -eq 1 ] && [ -s \"$1\" ]; then published=published; fi\nprintf '%s\\0' \"${0##*/}\" \"$#\" \"$@\" \"$published\" >> \"$CHONK_TEST_CAPTURE_REVIEW_LOG\"\n";
+    let notification = "#!/bin/sh\npublished=missing\nif [ -s \"$3\" ]; then published=published; fi\nprintf '%s\\0' \"$#\" \"$@\" \"$published\" >> \"$CHONK_TEST_CAPTURE_NOTIFICATION_LOG\"\n";
     let session = Session::boot(
         name,
         SessionOptions {
@@ -68,7 +69,7 @@ fn boot(name: &str, scale: f32) -> Session {
             config_files: ["xdg-open", "omacut"]
                 .into_iter()
                 .map(|program| (format!("fixture-bin/{program}"), wrapper.into()))
-                .chain(std::iter::once(("fixture-bin/notify-send".into(), "#!/bin/sh\nexit 0\n".into())))
+                .chain(std::iter::once(("fixture-bin/notify-send".into(), notification.into())))
                 .collect(),
             env: vec![
                 (
@@ -80,6 +81,11 @@ fn boot(name: &str, scale: f32) -> Session {
                     "CHONK_TEST_CAPTURE_REVIEW_LOG".into(),
                     root.join("capture-review.log").display().to_string(),
                 ),
+                (
+                    "CHONK_TEST_CAPTURE_NOTIFICATION_LOG".into(),
+                    root.join("capture-notification.log").display().to_string(),
+                ),
+                ("XDG_CACHE_HOME".into(), root.join("cache").display().to_string()),
                 ("OMARCHY_SCREENSHOT_DIR".into(), dir.display().to_string()),
                 ("OMARCHY_SCREENRECORD_DIR".into(), dir.display().to_string()),
             ],
@@ -97,6 +103,29 @@ fn boot(name: &str, scale: f32) -> Session {
         .unwrap();
     }
     session
+}
+
+fn notification_preview(session: &Session, capture: &Path, title: &str) -> PathBuf {
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    poll_until(Duration::from_secs(10), "capture notification has a readable preview", || {
+        let log = std::fs::read(session.dir.join("capture-notification.log")).ok()?;
+        let arguments: Vec<_> = log.split(|byte| *byte == 0).collect();
+        for record in arguments.as_chunks::<8>().0 {
+            if !record[5].starts_with(title.as_bytes()) || record[6] != capture.as_os_str().as_bytes() {
+                continue;
+            }
+            assert_eq!(record[0], b"6");
+            assert_eq!(record[1], b"--app-name=Chonkstep Capture");
+            assert_eq!(record[2], b"--icon");
+            assert_eq!(record[4], b"--");
+            assert_eq!(record[7], b"published", "preview must exist before notify-send starts");
+            let path = PathBuf::from(std::ffi::OsString::from_vec(record[3].to_vec()));
+            Screenshot::load(&path).expect("notification icon is a decodable PNG");
+            assert_eq!(std::fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+            return Some(path);
+        }
+        None
+    }).unwrap()
 }
 
 fn window_click_workflow(scale: f32, name: &str) {
@@ -307,6 +336,7 @@ fn screenshot_workflow(scale: f32, name: &str) {
     shortcut(&mut session, 3);
     let path = saved(&exports, 1, "png");
     reviews_opened(&session, &[("xdg-open", &path)]);
+    assert_eq!(notification_preview(&session, &path, "Screenshot saved"), path);
     let full = Screenshot::load(&path).unwrap();
     assert_eq!((full.width, full.height), (before.width, before.height));
     assert_eq!(full.pixel(0, 0), before.pixel(0, 0));
@@ -344,6 +374,7 @@ fn screenshot_workflow(scale: f32, name: &str) {
     session.door().barrier().unwrap();
     let area_path = saved(&exports, 2, "png");
     reviews_opened(&session, &[("xdg-open", &path), ("xdg-open", &area_path)]);
+    assert_eq!(notification_preview(&session, &area_path, "Screenshot saved"), area_path);
     let area = Screenshot::load(&area_path).unwrap();
     assert_eq!(
         (area.width, area.height),
@@ -563,6 +594,10 @@ fn recording_odd_area_is_playable_and_controls_are_excluded() {
     shortcut(&mut session, 5); // Stop / finish
     let path = saved(&exports, 1, "mp4");
     reviews_opened(&session, &[("omacut", &path)]);
+    let preview_path = notification_preview(&session, &path, "Recording saved");
+    assert!(preview_path.starts_with(session.dir.join("cache/chonkstep/capture-previews")));
+    let preview = Screenshot::load(&preview_path).unwrap();
+    assert_eq!((preview.width, preview.height), (256, 171));
     let probe = Command::new("ffprobe")
         .args([
             "-v",
@@ -611,6 +646,11 @@ fn recording_odd_area_is_playable_and_controls_are_excluded() {
             actual[channel].abs_diff(expected[channel]) < 12,
             "no dim overlay encoded: {actual:?} vs {expected:?}"
         );
+    }
+    let thumbnail_pixel = preview.pixel(70 * preview.width / frame.width, 15 * preview.height / frame.height);
+    for channel in 0..3 {
+        assert!(thumbnail_pixel[channel].abs_diff(actual[channel]) < 12,
+            "thumbnail contains the recorded scene: {thumbnail_pixel:?} vs {actual:?}");
     }
     shortcut(&mut session, 4);
     session.door().tap_key(1).unwrap(); // Tool can be reopened after finalization.
@@ -744,6 +784,38 @@ fn failed_mp4_export_preserves_video_and_muxer_diagnostics() {
     );
     shortcut(&mut session, 4);
     session.door().tap_key(1).unwrap();
+}
+
+#[test]
+#[ignore = "needs nested Wayland, wf-recorder and ffmpeg"]
+fn failed_video_preview_uses_glyph_and_preserves_saved_recording() {
+    let mut session = boot("capture-preview-failure", 1.0);
+    let ffmpeg = session.dir.join("config/chonkstep/fixture-bin/ffmpeg");
+    std::fs::write(&ffmpeg,
+        "#!/bin/sh\nfor arg do\n  if [ \"$arg\" = pipe:1 ]; then printf 'incomplete PNG'; exit 7; fi\ndone\nexec /usr/bin/ffmpeg \"$@\"\n"
+    ).unwrap();
+    std::fs::set_permissions(ffmpeg, std::fs::Permissions::from_mode(0o700)).unwrap();
+    shortcut(&mut session, 5);
+    session.door().tap_key(5).unwrap(); // record display
+    session.door().tap_key(28).unwrap();
+    std::thread::sleep(Duration::from_secs(2));
+    shortcut(&mut session, 5);
+    let path = saved(&session.dir.join("exports"), 1, "mp4");
+    reviews_opened(&session, &[("omacut", &path)]);
+    poll_until(Duration::from_secs(10), "video fallback notification", || {
+        let log = std::fs::read(session.dir.join("capture-notification.log")).ok()?;
+        let arguments: Vec<_> = log.split(|byte| *byte == 0).collect();
+        arguments.as_chunks::<8>().0.iter().find(|record| record[5] == b"Recording saved").map(|record| {
+            assert_eq!(record[2], b"--hint", "no missing themed icon lookup");
+            assert_eq!(record[3], "string:omarchy-glyph:\u{f03d}".as_bytes());
+            assert_eq!(record[6], path.to_str().unwrap().as_bytes());
+        })
+    }).unwrap();
+    assert!(files(&session.dir.join("cache/chonkstep/capture-previews"), "png").is_empty());
+    assert!(Command::new("ffprobe").args(["-v", "error"]).arg(path).status().unwrap().success());
+    shortcut(&mut session, 3);
+    let screenshot = saved(&session.dir.join("exports"), 1, "png");
+    assert_eq!(notification_preview(&session, &screenshot, "Screenshot saved"), screenshot);
 }
 
 #[test]
@@ -971,6 +1043,9 @@ fn toolbar_screen_modes_work_without_moving_off_the_toolbar_and_badge_stops() {
         .unwrap();
     let path = saved(&exports, 1, "mp4");
     let screenshot_path = files(&exports, "png").pop().unwrap();
+    assert_eq!(notification_preview(&session, &screenshot_path, "Screenshot saved"), screenshot_path);
+    let preview = Screenshot::load(&notification_preview(&session, &path, "Recording saved")).unwrap();
+    assert!(preview.width <= 256 && preview.height <= 256);
     reviews_opened(
         &session,
         &[("xdg-open", &screenshot_path), ("omacut", &path)],

--- a/crates/chonk-testkit/tests/fullscreen.rs
+++ b/crates/chonk-testkit/tests/fullscreen.rs
@@ -422,3 +422,28 @@ fn a_clients_maximize_control_is_answered_with_maximized() {
     );
     assert!(!log.contains("answer REFUSED"), "no request in this test was refused:\n{log}");
 }
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless --release"]
+fn screensaver_covers_the_output_without_any_imported_window_rules() {
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(&format!("screensaver-default-{scale}"), SessionOptions {
+            scale: Some(scale),
+            config_extra: "hyprland_config = false\n".into(),
+            ..Default::default()
+        }).unwrap();
+        let probe = profile_binary("chonk-fullscreen-probe").unwrap();
+        // Like Omarchy's launcher, supply only the service identity. There is
+        // deliberately no client request or keypress to enter fullscreen.
+        session.launch(probe.to_str().unwrap(), &["screensaver", "org.omarchy.screensaver"]).unwrap();
+        session.wait_for_window("org.omarchy.screensaver").unwrap();
+        poll_until(Duration::from_secs(10), "screensaver fullscreen geometry and committed pixels", || {
+            let world = session.world().ok()?;
+            let saver = world.window_matching("org.omarchy.screensaver")?;
+            if (saver.x, saver.y, saver.w, saver.h) != (0, 0, world.output_w, world.output_h) { return None; }
+            let shot = session.screenshot("screensaver-fullscreen").ok()?;
+            [(8, 8), (world.output_w - 24, 8), (8, world.output_h - 24), (world.output_w - 24, world.output_h - 24)]
+                .iter().all(|&(x,y)| near(shot.mean_rgb(x, y, 16, 16), PROBE_RGB)).then_some(())
+        }).unwrap();
+    }
+}

--- a/crates/chonk-testkit/tests/pointer_constraints.rs
+++ b/crates/chonk-testkit/tests/pointer_constraints.rs
@@ -319,6 +319,44 @@ fn full_surface_confinement_does_not_reenter_the_surface_state_lock() {
 
 #[test]
 #[ignore = "needs a nested session: scripts/e2e.sh --headless --release"]
+fn held_movement_key_keeps_camera_motion_and_capture_restores_typing_policy() {
+    for mode in ["lock-full", "confine-full"] {
+        let (mut session, _) = boot_named(mode, 2.0, "-typing");
+        assert!(!session.door().touchpad_captured().unwrap());
+        fence_key(&mut session, 59);
+        poll_until(EVENT, "capture to suspend typing suppression", || {
+            session.door().touchpad_captured().ok()?.then_some(())
+        }).unwrap();
+        session.door().key(17, true).unwrap(); // Hold W throughout camera motion.
+        wait_line(&session, "keyboard key 17 down", 1);
+        for _ in 0..8 {
+            let before = latest(&session, "relative").map_or(0, |event| event.sequence);
+            session.door().motion_relative(3.0, 2.0).unwrap();
+            poll_until(EVENT, "relative camera motion while W remains held", || {
+                latest(&session, "relative").filter(|event| event.sequence > before)
+            }).unwrap();
+        }
+        assert_eq!(count(&session, "keyboard key 17 up"), 0);
+        session.door().key(17, false).unwrap();
+        fence_key(&mut session, 61); // Destroy the protocol object without mouse motion.
+        poll_until(EVENT, "destroying capture to restore typing suppression", || {
+            (!session.door().touchpad_captured().ok()?).then_some(())
+        }).unwrap();
+        fence_key(&mut session, 59);
+        assert!(session.door().touchpad_captured().unwrap());
+        session.door().chord(chonk_testkit::keys::LEFTMETA, chonk_testkit::keys::UP).unwrap();
+        poll_until(EVENT, "overview to restore typing suppression", || {
+            (!session.door().touchpad_captured().ok()?).then_some(())
+        }).unwrap();
+        session.door().tap_key(chonk_testkit::keys::ESC).unwrap();
+        poll_until(EVENT, "returning to the captured client", || {
+            session.door().touchpad_captured().ok()?.then_some(())
+        }).unwrap();
+    }
+}
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless --release"]
 fn locked_relative_burst_preserves_all_scaled_clients_raw_deltas() {
     const REPORTS: usize = 8192;
     let (mut session, _) = boot("lock-full", 2.0);

--- a/crates/chonk-testkit/tests/xwayland_input.rs
+++ b/crates/chonk-testkit/tests/xwayland_input.rs
@@ -1079,3 +1079,31 @@ fn an_x11_keyboard_grab_keeps_the_combos_the_desktop_binds() {
         "a grabbing X11 client must receive the combo instead of the desktop running its binding"
     );
 }
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless --release"]
+fn x11_pointer_grab_suspends_typing_suppression_until_ungrab() {
+    use x11rb::protocol::xproto::{GrabMode, GrabStatus};
+    let mut session = Session::boot("xwayland-pointer-typing", SessionOptions::default()).unwrap();
+    let (conn, screen_num) = x11rb::connect(Some(&format!(":{}", xwayland_display(&session)))).unwrap();
+    let (xid, id) = map_probe_window(&mut session, &conn, screen_num, "game-grab-probe", None);
+    let window = session.world().unwrap().windows.into_iter().find(|w| w.id == id).unwrap();
+    session.door().click(f64::from(window.x + window.w as i32 / 2), f64::from(window.y + window.h as i32 / 2)).unwrap();
+    session.door().barrier().unwrap();
+    assert!(!session.door().touchpad_captured().unwrap());
+    let grab = conn.grab_pointer(false, xid, EventMask::POINTER_MOTION | EventMask::BUTTON_PRESS | EventMask::BUTTON_RELEASE,
+        GrabMode::ASYNC, GrabMode::ASYNC, xid, x11rb::NONE, x11rb::CURRENT_TIME).unwrap().reply().unwrap();
+    assert_eq!(grab.status, GrabStatus::SUCCESS);
+    conn.flush().unwrap();
+    poll_until(EVENT, "XWayland confinement to suspend typing suppression", || {
+        session.door().touchpad_captured().ok()?.then_some(())
+    }).unwrap();
+    session.door().key(17, true).unwrap();
+    for _ in 0..8 { session.door().motion_relative(3.0, 2.0).unwrap(); }
+    session.door().key(17, false).unwrap();
+    conn.ungrab_pointer(x11rb::CURRENT_TIME).unwrap();
+    conn.flush().unwrap();
+    poll_until(EVENT, "XWayland ungrab to restore typing suppression", || {
+        (!session.door().touchpad_captured().ok()?).then_some(())
+    }).unwrap();
+}

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -1011,6 +1011,9 @@ fn input(reading: &mut Reading, name: &str, value: &str) {
         "tap_to_click" | "touchpad:tap_to_click" => {
             parse_input_bool(reading, name, &value, |input, enabled| input.tap_to_click = Some(enabled))
         }
+        "disable_while_typing" | "touchpad:disable_while_typing" => {
+            parse_input_bool(reading, name, &value, |input, enabled| input.disable_while_typing = Some(enabled))
+        }
         "clickfinger_behavior" | "touchpad:clickfinger_behavior" => {
             parse_input_bool(reading, name, &value, |input, enabled| input.clickfinger_behavior = Some(enabled))
         }

--- a/crates/wm-config/src/hyprland/rules.rs
+++ b/crates/wm-config/src/hyprland/rules.rs
@@ -244,7 +244,7 @@ impl FloatPolicy for FloatRules {
     }
 
     fn window_decision_for(&self, class: &str, title: &str) -> WindowRuleDecision {
-        let mut decision = WindowRuleDecision::default();
+        let mut decision = WindowRuleDecision::for_identity(class);
         for rule in &self.rules {
             if !rule.matches(class, title) {
                 continue;

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -478,7 +478,7 @@ hl.config({ input = {
   kb_options = "compose:caps", repeat_rate = 40, repeat_delay = 250,
   follow_mouse = 1, sensitivity = -0.25, accel_profile = "flat",
   touchpad = {
-    natural_scroll = true, tap_to_click = false,
+    natural_scroll = true, tap_to_click = false, disable_while_typing = false,
     clickfinger_behavior = true, scroll_factor = 0.4,
   },
 } })
@@ -499,6 +499,7 @@ o.bind("SUPER + SHIFT + code:201", "Menu", "omarchy-menu")
     assert_eq!(reading.input.accel_profile.as_deref(), Some("flat"));
     assert_eq!(reading.input.natural_scroll, Some(true));
     assert_eq!(reading.input.tap_to_click, Some(false));
+    assert_eq!(reading.input.disable_while_typing, Some(false));
     assert_eq!(reading.input.clickfinger_behavior, Some(true));
     assert_eq!(reading.input.scroll_factor, Some(0.4));
     assert!(
@@ -2102,4 +2103,20 @@ fn the_numbers_the_documents_quote_are_the_numbers_this_machine_produces() {
             && GUIDE.contains("float_rules=45 monitors=1 skipped=165"),
         "the guide's sample log line no longer matches what this machine reports"
     );
+}
+
+#[test]
+fn screensaver_defaults_survive_unrelated_rules_and_allow_explicit_opt_out() {
+    let root = scratch("screensaver-defaults");
+    let path = root.join(".config/hypr/hyprland.conf");
+    write(&path, "windowrule = float on, match:class ^notes$\ninput {\n touchpad {\n  disable_while_typing = false\n }\n}\n");
+    let reading = read(&Roots::under(&root));
+    assert_eq!(reading.input.disable_while_typing, Some(false));
+    assert!(reading.float_rules.window_decision_for("org.omarchy.screensaver", "foot").fullscreen);
+    for other in ["foot", "org.omarchy.btop", "org.omarchy.screensaver.settings"] {
+        assert!(!reading.float_rules.window_decision_for(other, "org.omarchy.screensaver").fullscreen);
+    }
+    write(&path, "windowrule = fullscreen off, match:class ^org\\.omarchy\\.screensaver$\n");
+    let reading = read(&Roots::under(&root));
+    assert!(!reading.float_rules.window_decision_for("org.omarchy.screensaver", "foot").fullscreen);
 }

--- a/crates/wm-config/src/lib.rs
+++ b/crates/wm-config/src/lib.rs
@@ -267,6 +267,7 @@ pub struct InputConfig {
     pub sensitivity: Option<f64>,
     pub natural_scroll: Option<bool>,
     pub tap_to_click: Option<bool>,
+    pub disable_while_typing: Option<bool>,
     pub clickfinger_behavior: Option<bool>,
     pub scroll_factor: Option<f64>,
     pub left_handed: Option<bool>,
@@ -1168,6 +1169,10 @@ fn apply_input_table(config: &mut InputConfig, entries: &toml::Table, prefix: &s
             },
             "tap_to_click" => match value.as_bool() {
                 Some(enabled) => config.tap_to_click = Some(enabled),
+                None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
+            },
+            "disable_while_typing" => match value.as_bool() {
+                Some(enabled) => config.disable_while_typing = Some(enabled),
                 None => tracing::warn!(key = %setting, value = ?value, "config: input setting must be a boolean, ignoring it"),
             },
             "clickfinger_behavior" => match value.as_bool() {
@@ -2203,10 +2208,12 @@ mod tests {
 sensitivity = -0.35
 accel_profile = "FLAT"
 left_handed = true
+disable_while_typing = true
 
 [input.touchpad]
 natural_scroll = true
 tap_to_click = true
+disable_while_typing = false
 clickfinger_behavior = true
 scroll_factor = 0.4
 "#,
@@ -2218,12 +2225,23 @@ scroll_factor = 0.4
         assert_eq!(config.input.left_handed, Some(true));
         assert_eq!(config.input.natural_scroll, Some(true));
         assert_eq!(config.input.tap_to_click, Some(true));
+        assert_eq!(config.input.disable_while_typing, Some(false));
         assert_eq!(config.input.clickfinger_behavior, Some(true));
         assert_eq!(config.input.scroll_factor, Some(0.4));
         assert_eq!(
             config.provenance.get("input").map(String::as_str),
             Some("config file")
         );
+    }
+
+    #[test]
+    fn typing_suppression_requires_a_boolean() {
+        for input in ["true", "false"] {
+            let config = parse(&format!("[input]\ndisable_while_typing = {input}")).unwrap();
+            assert_eq!(config.input.disable_while_typing, Some(input == "true"));
+        }
+        let config = parse("[input.touchpad]\ndisable_while_typing = 'false'").unwrap();
+        assert_eq!(config.input.disable_while_typing, None);
     }
 
     #[test]

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -1659,7 +1659,7 @@ impl<B: Backend> WindowManager<B> {
             .float_policy
             .as_deref()
             .map(|policy| policy.window_decision_for(&client.class, &client.title))
-            .unwrap_or_default();
+            .unwrap_or_else(|| placement::WindowRuleDecision::for_identity(&client.class));
         if window_rule.pin {
             client.flags.insert(ClientFlags::STICKY);
         }

--- a/crates/wm-core/src/placement.rs
+++ b/crates/wm-core/src/placement.rs
@@ -296,6 +296,18 @@ pub struct WindowRuleDecision {
     pub maximize: bool,
 }
 
+impl WindowRuleDecision {
+    /// Compatibility defaults for desktop services that rely on window rules
+    /// instead of requesting their own state. Explicit imported rules override
+    /// these defaults, including an explicit `fullscreen = false`.
+    pub fn for_identity(class: &str) -> Self {
+        Self {
+            fullscreen: class == "org.omarchy.screensaver",
+            ..Self::default()
+        }
+    }
+}
+
 /// A source of per-window float rules, supplied by the shell.
 ///
 /// A trait rather than a data type because the rules this desktop
@@ -315,8 +327,8 @@ pub trait FloatPolicy: std::fmt::Debug + Send + Sync {
     /// Answers the non-placement half of the same identity rules.
     /// Existing/custom policies remain source-compatible and simply
     /// make no such decisions.
-    fn window_decision_for(&self, _class: &str, _title: &str) -> WindowRuleDecision {
-        WindowRuleDecision::default()
+    fn window_decision_for(&self, class: &str, _title: &str) -> WindowRuleDecision {
+        WindowRuleDecision::for_identity(class)
     }
 }
 

--- a/crates/wm-core/src/types.rs
+++ b/crates/wm-core/src/types.rs
@@ -438,6 +438,9 @@ pub struct PointerConfig {
     pub sensitivity: Option<f64>,
     pub natural_scroll: Option<bool>,
     pub tap_to_click: Option<bool>,
+    /// Typing suppression outside application pointer capture; None restores
+    /// each device's libinput default. Active locks/confinement suspend it.
+    pub disable_while_typing: Option<bool>,
     pub clickfinger_behavior: Option<bool>,
     pub scroll_factor: Option<f64>,
     pub left_handed: Option<bool>,

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -3,6 +3,7 @@
 // no renderer, input callback or shell tick waits for these children.
 #![allow(clippy::disallowed_methods)]
 use std::collections::VecDeque;
+use std::ffi::OsStr;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::os::unix::fs::OpenOptionsExt;
@@ -71,10 +72,12 @@ struct Review {
 struct Background {
     reviews: Vec<Review>,
     notifications: Vec<(Child, Instant)>,
+    previews: Vec<RecordingPreview>,
 }
 
 const MAX_REVIEWS: usize = 16;
 const MAX_NOTIFICATIONS: usize = 8;
+const MAX_PREVIEWS: usize = 2;
 const MAX_CLIPBOARD_JOBS: usize = 2;
 const CLIPBOARD_PROBE: Duration = Duration::from_millis(100);
 
@@ -237,21 +240,122 @@ fn review_command(kind: ReviewKind, path: &Path) -> Result<Command, String> {
     Ok(command)
 }
 
+struct RecordingPreview {
+    child: Child,
+    video: PathBuf,
+    image: PathBuf,
+    deadline: Instant,
+}
+
+impl RecordingPreview {
+    fn start(video: &Path, directory: &Path) -> std::io::Result<Self> {
+        std::fs::create_dir_all(directory)?;
+        let mut name = video.file_name().unwrap_or_default().to_os_string();
+        name.push(".png");
+        let image = directory.join(name);
+        let output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&image)?;
+        // Decode just the first frame, including recordings shorter than 0.1s.
+        // This child is polled alongside notifications: a slow decoder cannot
+        // delay another screenshot, recording, or review launch.
+        let child = Command::new("ffmpeg")
+            .args(["-nostdin", "-v", "error", "-threads", "1", "-i"])
+            .arg(video)
+            .args([
+                "-frames:v", "1", "-vf",
+                "scale=256:256:force_original_aspect_ratio=decrease",
+                "-filter_threads", "1", "-threads", "1",
+                "-f", "image2pipe", "-c:v", "png", "pipe:1",
+            ])
+            .stdin(Stdio::null())
+            .stdout(output)
+            .stderr(Stdio::null())
+            .spawn();
+        match child {
+            Ok(child) => Ok(Self {
+                child,
+                video: video.to_owned(),
+                image,
+                deadline: Instant::now() + Duration::from_secs(3),
+            }),
+            Err(error) => {
+                let _ = std::fs::remove_file(image);
+                Err(error)
+            }
+        }
+    }
+
+    /// None while pending; failed or timed-out previews use the media icon.
+    fn poll(&mut self, now: Instant) -> Option<bool> {
+        let ready = match self.child.try_wait() {
+            Ok(None) if now < self.deadline => return None,
+            Ok(Some(status)) => status.success()
+                && tiny_skia::Pixmap::load_png(&self.image).is_ok(),
+            _ => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+                false
+            }
+        };
+        if !ready {
+            let _ = std::fs::remove_file(&self.image);
+        }
+        Some(ready)
+    }
+}
+
+fn preview_directory() -> Option<PathBuf> {
+    std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .map(|home| PathBuf::from(home).join(".cache"))
+                .filter(|path| path.is_absolute())
+        })
+        .map(|base| base.join("chonkstep/capture-previews"))
+}
+
+enum NotificationIcon<'a> {
+    Image(&'a Path),
+    Video,
+    Warning,
+}
+
+impl NotificationIcon<'_> {
+    fn argument(&self) -> (&'static str, &OsStr) {
+        match self {
+            Self::Image(path) => ("--icon", path.as_os_str()),
+            // Quickshell's icon provider can return its pink checkerboard as
+            // Image.Ready for missing themed names. Omarchy's glyph slot avoids
+            // that provider entirely; other notification servers ignore the
+            // hint and still show the result text.
+            Self::Video => ("--hint", OsStr::new("string:omarchy-glyph:\u{f03d}")),
+            Self::Warning => ("--hint", OsStr::new("string:omarchy-glyph:\u{f071}")),
+        }
+    }
+}
+
 impl Background {
     fn notify(&mut self, title: &str, message: &str) {
+        self.notify_with_icon(title, message, NotificationIcon::Warning);
+    }
+
+    fn notify_with_icon(&mut self, title: &str, message: &str, icon: NotificationIcon<'_>) {
         tracing::info!(title, message, "capture result");
         // A broken notification service must not stall capture or accumulate
         // unlimited helper processes. The log always retains the result.
         if self.notifications.len() >= MAX_NOTIFICATIONS {
             return;
         }
+        let (option, value) = icon.argument();
         if let Ok(child) = Command::new("notify-send")
-            .args([
-                "--app-name=Chonkstep Capture",
-                "--icon=camera-photo",
-                title,
-                message,
-            ])
+            .args(["--app-name=Chonkstep Capture", option])
+            .arg(value)
+            .args(["--", title, message])
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
@@ -260,6 +364,22 @@ impl Background {
             self.notifications
                 .push((child, Instant::now() + Duration::from_secs(2)));
         }
+    }
+
+    fn recording_saved(&mut self, video: &Path) {
+        if self.previews.len() < MAX_PREVIEWS {
+            if let Some(preview) = preview_directory()
+                .and_then(|directory| RecordingPreview::start(video, &directory).ok())
+            {
+                self.previews.push(preview);
+                return;
+            }
+        }
+        self.notify_with_icon(
+            "Recording saved",
+            &video.display().to_string(),
+            NotificationIcon::Video,
+        );
     }
 
     fn review(&mut self, kind: ReviewKind, path: PathBuf) {
@@ -296,6 +416,21 @@ impl Background {
 
     fn poll(&mut self) {
         let now = Instant::now();
+        let mut finished = Vec::new();
+        self.previews.retain_mut(|preview| {
+            let Some(ready) = preview.poll(now) else { return true };
+            finished.push((preview.video.clone(), ready.then(|| preview.image.clone())));
+            false
+        });
+        for (video, image) in finished {
+            // Keep successful previews in the cache so notification history
+            // can reload them after the toast or notification helper exits.
+            self.notify_with_icon(
+                "Recording saved",
+                &video.display().to_string(),
+                image.as_deref().map_or(NotificationIcon::Video, NotificationIcon::Image),
+            );
+        }
         self.notifications
             .retain_mut(|(child, deadline)| match child.try_wait() {
                 Ok(Some(_)) => false,
@@ -334,6 +469,7 @@ impl Background {
 
     fn interval(&self, recording: bool, clipboard: bool) -> Option<Duration> {
         if recording
+            || !self.previews.is_empty()
             || !self.notifications.is_empty()
             || self
                 .reviews
@@ -349,6 +485,11 @@ impl Background {
     }
 
     fn stop_notifications(&mut self) {
+        for mut preview in self.previews.drain(..) {
+            let _ = preview.child.kill();
+            let _ = preview.child.wait();
+            let _ = std::fs::remove_file(preview.image);
+        }
         for (child, _) in &mut self.notifications {
             let _ = child.kill();
             let _ = child.wait();
@@ -374,13 +515,14 @@ pub(super) fn start() -> (
             background.poll();
             for result in clipboard.poll(Instant::now(), spawn_clipboard) {
                 let _ = updates.try_send(Update::ScreenshotDone);
-                background.notify(
+                background.notify_with_icon(
                     if result.copied {
                         "Screenshot saved and copied"
                     } else {
                         "Screenshot saved (clipboard unavailable)"
                     },
                     &result.path.display().to_string(),
+                    NotificationIcon::Image(&result.path),
                 );
             }
             let mut interval =
@@ -404,9 +546,10 @@ pub(super) fn start() -> (
                             background.review(ReviewKind::Screenshot, path.clone());
                             if let Err(path) = clipboard.enqueue(path) {
                                 let _ = updates.try_send(Update::ScreenshotDone);
-                                background.notify(
+                                background.notify_with_icon(
                                     "Screenshot saved (clipboard unavailable)",
                                     &path.display().to_string(),
+                                    NotificationIcon::Image(&path),
                                 );
                             }
                         }
@@ -829,7 +972,7 @@ fn finish(mut active: Recording, background: &mut Background, review: bool) {
         let _ = std::fs::remove_file(&temporary);
         let _ = std::fs::remove_file(&active.partial);
         let _ = std::fs::remove_file(&active.log);
-        background.notify("Recording saved", &active.destination.display().to_string());
+        background.recording_saved(&active.destination);
         if review {
             background.review(ReviewKind::Recording, active.destination);
         }
@@ -1103,5 +1246,62 @@ mod tests {
             .try_wait()
             .unwrap()
             .is_none());
+    }
+
+    #[test]
+    fn recording_preview_requires_successful_decode_and_keeps_valid_images_for_history() {
+        for (valid_png, exit_code) in [(true, 0), (false, 0), (true, 7)] {
+            let mut fixture = Fixture::new();
+            let image = fixture.directory.join("preview.png");
+            if valid_png {
+                tiny_skia::Pixmap::new(8, 4).unwrap().save_png(&image).unwrap();
+            } else {
+                std::fs::write(&image, b"incomplete PNG").unwrap();
+            }
+            let video = fixture.directory.join("saved.mp4");
+            std::fs::write(&video, b"saved video").unwrap();
+            let child = Command::new("/bin/sh")
+                .args(["-c", &format!("exit {exit_code}")])
+                .spawn().unwrap();
+            let mut preview = RecordingPreview {
+                child, video: video.clone(), image: image.clone(),
+                deadline: Instant::now() + Duration::from_secs(3),
+            };
+            let mut ready = None;
+            fixture.wait_until(|_| {
+                ready = preview.poll(Instant::now());
+                ready.is_some()
+            });
+            assert_eq!(ready, Some(valid_png && exit_code == 0));
+            assert_eq!(image.exists(), ready.unwrap());
+            assert_eq!(std::fs::read(video).unwrap(), b"saved video");
+        }
+    }
+
+    #[test]
+    fn recording_preview_timeout_and_shutdown_reap_decoder_and_remove_partial_image() {
+        for shutdown in [false, true] {
+            let mut fixture = Fixture::new();
+            let image = fixture.directory.join("partial.png");
+            std::fs::write(&image, b"incomplete PNG").unwrap();
+            let child = Command::new("/usr/bin/sleep").arg("30").spawn().unwrap();
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let mut preview = RecordingPreview {
+                child, video: fixture.directory.join("saved.mp4"), image: image.clone(), deadline,
+            };
+            assert_eq!(preview.poll(deadline - Duration::from_secs(1)), None);
+            assert!(image.exists());
+            if shutdown {
+                fixture.background.previews.push(preview);
+                assert_eq!(fixture.background.interval(false, false), Some(Duration::from_millis(100)));
+                fixture.background.stop_notifications();
+                assert!(fixture.background.previews.is_empty());
+                assert_eq!(fixture.background.interval(false, false), None);
+            } else {
+                assert_eq!(preview.poll(deadline), Some(false));
+                assert!(preview.child.try_wait().unwrap().is_some());
+            }
+            assert!(!image.exists());
+        }
     }
 }

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -1553,10 +1553,27 @@ pub(crate) fn release_pointer_constraint(state: &mut Compositor) {
         }
         constraint.deactivate();
     });
+    sync_touchpad_typing(state);
     if let Some(target) = warp_to {
         let position = confine_to_outputs(&state.wm.backend().monitors, target);
         let time = state.start_time.elapsed().as_millis() as u32;
         pointer_moved(state, position, time, None, PointerDelivery::Motion);
+    }
+}
+
+/// Apply capture transitions before the next hardware dispatch. The settled
+/// scene also calls this after resource destruction, unmap, focus and lock
+/// changes, which need not produce another pointer-motion event.
+pub(crate) fn sync_touchpad_typing(state: &mut Compositor) {
+    let captured = constraints::is_captured(state);
+    if state.touchpad_pointer_captured != captured {
+        state.touchpad_pointer_captured = captured;
+        crate::session::apply_touchpad_typing(
+            &mut state.graphics,
+            state.wm.backend().pointer_config.disable_while_typing,
+            captured,
+        );
+        tracing::debug!(captured, "touchpad typing suppression follows pointer capture");
     }
 }
 

--- a/crates/wm-wayland/src/input/constraints.rs
+++ b/crates/wm-wayland/src/input/constraints.rs
@@ -68,6 +68,16 @@ pub(super) fn is_locked(state: &Compositor) -> bool {
     })
 }
 
+/// Both relative-camera locks and confinement (including XWayland grabs)
+/// indicate that the client needs simultaneous keyboard and pointer input.
+pub(super) fn is_captured(state: &Compositor) -> bool {
+    let Some(pointer) = state.seat.get_pointer() else { return false };
+    let Some(surface) = pointer.current_focus() else { return false };
+    with_pointer_constraint(surface.surface(), &pointer, |constraint| {
+        constraint.is_some_and(|constraint| constraint.is_active())
+    })
+}
+
 /// Apply only an already-active constraint. Pending constraints activate after
 /// motion reaches their region, so the client observes its entry coordinate
 /// before being told the pointer is locked there.
@@ -129,7 +139,7 @@ pub(super) fn apply(state: &mut Compositor, proposed: Position) -> Constrained {
 
 /// Activate only at an already-delivered, visible surface-local position that
 /// belongs to both input regions. No mouse warp or focus change is implied.
-pub(super) fn activate_for_current_focus(state: &Compositor) {
+pub(super) fn activate_for_current_focus(state: &mut Compositor) {
     let Some(pointer) = state.seat.get_pointer() else {
         return;
     };
@@ -154,6 +164,7 @@ pub(super) fn activate_for_current_focus(state: &Compositor) {
             }
         }
     });
+    super::sync_touchpad_typing(state);
 }
 
 impl PointerConstraintsHandler for Compositor {

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -58,6 +58,8 @@
 //! - **No DRM leasing.** A crtc is never handed to another process,
 //!   so a VR headset cannot take one over.
 
+mod touchpad;
+
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::path::{Path, PathBuf};
@@ -2236,7 +2238,7 @@ fn note_libinput_device(comp: &mut Compositor, event: &InputEvent<LibinputInputB
         InputEvent::DeviceAdded { device } => {
             let config = comp.wm.backend().pointer_config.clone();
             let mut device = device.clone();
-            configure_libinput_device(&mut device, &config);
+            configure_libinput_device(&mut device, &config, comp.touchpad_pointer_captured);
             if let Graphics::Session(session) = &mut comp.graphics {
                 if !session.input_devices.iter().any(|held| held.sysname() == device.sysname()) {
                     session.input_devices.push(device);
@@ -2252,19 +2254,31 @@ fn note_libinput_device(comp: &mut Compositor, event: &InputEvent<LibinputInputB
     }
 }
 
-pub(crate) fn apply_pointer_config(graphics: &mut Graphics, config: &wm_core::PointerConfig) {
+pub(crate) fn apply_pointer_config(graphics: &mut Graphics, config: &wm_core::PointerConfig, captured: bool) {
     let Graphics::Session(session) = graphics else {
         return;
     };
     for device in &mut session.input_devices {
-        configure_libinput_device(device, config);
+        configure_libinput_device(device, config, captured);
     }
 }
 
-fn configure_libinput_device(device: &mut libinput_crate::Device, config: &wm_core::PointerConfig) {
+pub(crate) fn apply_touchpad_typing(graphics: &mut Graphics, requested: Option<bool>, captured: bool) {
+    let Graphics::Session(session) = graphics else { return };
+    for device in &session.input_devices {
+        if let Err(error) = touchpad::configure(device, requested, captured) {
+            tracing::warn!(device = device.name(), ?error, "could not update touchpad typing suppression");
+        }
+    }
+}
+
+fn configure_libinput_device(device: &mut libinput_crate::Device, config: &wm_core::PointerConfig, captured: bool) {
     use libinput_crate::{AccelProfile, ClickMethod};
 
     let mut rejected = Vec::new();
+    if let Err(error) = touchpad::configure(device, config.disable_while_typing, captured) {
+        rejected.push(format!("disable_while_typing: {error:?}"));
+    }
     if let Some(speed) = config.sensitivity {
         if !device.config_accel_is_available() {
             rejected.push("sensitivity: unsupported".to_string());

--- a/crates/wm-wayland/src/session/touchpad.rs
+++ b/crates/wm-wayland/src/session/touchpad.rs
@@ -1,0 +1,120 @@
+//! Apply typing suppression per device, retaining libinput's other palm
+//! rejection mechanisms. Pointer capture temporarily suspends DWT for games
+//! and other clients that need keyboard and touchpad motion together.
+
+pub(super) trait TypingDevice {
+    type Error;
+    fn supported(&self) -> bool;
+    fn default_enabled(&self) -> bool;
+    fn enabled(&self) -> bool;
+    fn set_enabled(&self, enabled: bool) -> Result<(), Self::Error>;
+}
+
+impl TypingDevice for smithay::reexports::input::Device {
+    type Error = smithay::reexports::input::DeviceConfigError;
+    fn supported(&self) -> bool {
+        self.config_dwt_is_available()
+    }
+    fn default_enabled(&self) -> bool {
+        self.config_dwt_default_enabled()
+    }
+    fn enabled(&self) -> bool {
+        self.config_dwt_enabled()
+    }
+    fn set_enabled(&self, enabled: bool) -> Result<(), Self::Error> {
+        self.config_dwt_set_enabled(enabled)
+    }
+}
+
+pub(super) fn configure<D: TypingDevice>(
+    device: &D,
+    requested: Option<bool>,
+    captured: bool,
+) -> Result<(), D::Error> {
+    if device.supported() {
+        let enabled = !captured && requested.unwrap_or_else(|| device.default_enabled());
+        if enabled != device.enabled() {
+            device.set_enabled(enabled)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    struct Touchpad {
+        supported: bool,
+        default: bool,
+        enabled: Cell<bool>,
+        changes: RefCell<Vec<bool>>,
+    }
+
+    impl Touchpad {
+        fn new(default: bool) -> Self {
+            Self {
+                supported: true,
+                default,
+                enabled: Cell::new(default),
+                changes: RefCell::default(),
+            }
+        }
+    }
+
+    impl TypingDevice for Touchpad {
+        type Error = ();
+        fn supported(&self) -> bool {
+            self.supported
+        }
+        fn default_enabled(&self) -> bool {
+            self.default
+        }
+        fn enabled(&self) -> bool {
+            self.enabled.get()
+        }
+        fn set_enabled(&self, enabled: bool) -> Result<(), ()> {
+            self.changes.borrow_mut().push(enabled);
+            self.enabled.set(enabled);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn capture_hotplug_and_reload_restore_each_devices_own_typing_policy() {
+        for default in [false, true] {
+            let device = Touchpad::new(default);
+            // A newly connected/resumed touchpad must already allow motion
+            // during a capture; no later mouse report can recover lost input.
+            configure(&device, None, true).unwrap();
+            assert!(!device.enabled.get());
+            // Reloading an explicit typing preference cannot interrupt a game.
+            configure(&device, Some(true), true).unwrap();
+            assert!(!device.enabled.get());
+            configure(&device, Some(true), false).unwrap();
+            assert!(device.enabled.get());
+            configure(&device, Some(false), false).unwrap();
+            assert!(!device.enabled.get());
+            // Removing the override restores the device default, not the
+            // temporarily disabled value left over from gameplay.
+            configure(&device, None, false).unwrap();
+            assert_eq!(device.enabled.get(), default);
+            let transitions = device.changes.borrow().len();
+            for _ in 0..100 {
+                configure(&device, None, false).unwrap();
+            }
+            assert_eq!(device.changes.borrow().len(), transitions);
+        }
+    }
+
+    #[test]
+    fn keyboards_and_mice_without_dwt_are_untouched() {
+        let mut device = Touchpad::new(false);
+        device.supported = false;
+        for captured in [true, false] {
+            configure(&device, Some(true), captured).unwrap();
+        }
+        assert!(device.changes.borrow().is_empty());
+    }
+}

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -2457,6 +2457,8 @@ pub struct Compositor {
     /// `input.rs` — the renderer draws the cursor here, and hit-tests
     /// run against it.
     pub pointer_location: SPoint<f64, Logical>,
+    /// Last pointer-capture policy applied to physical touchpads.
+    pub(crate) touchpad_pointer_captured: bool,
     /// What the cursor should look like, per the focused client's
     /// `wl_pointer.set_cursor` (maintained by `input.rs`'s
     /// `SeatHandler::cursor_image`). Honored only while the pointer is
@@ -2531,7 +2533,7 @@ impl Compositor {
         self.apply_pending_keyboard();
         if let Some(config) = self.wm.backend_mut().pending_pointer.take() {
             self.wm.backend_mut().scroll_factor = config.scroll_factor.unwrap_or(1.0);
-            crate::session::apply_pointer_config(&mut self.graphics, &config);
+            crate::session::apply_pointer_config(&mut self.graphics, &config, self.touchpad_pointer_captured);
         }
         tracing::debug_span!("dispatch_phase", phase = "connector_hotplug")
             .in_scope(|| crate::session::service_connector_hotplug(self));
@@ -2848,6 +2850,7 @@ impl Compositor {
         crate::lock::refresh(self);
         crate::gesture_scene::validate(self);
         crate::input::keyboard::sync_modal_focus(self);
+        crate::input::sync_touchpad_typing(self);
 
         // Timed commits are independent of presentation, and an invisible
         // surface cannot ever satisfy a FIFO presentation barrier. Visibility
@@ -4129,6 +4132,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         _virtual_keyboard: virtual_keyboard,
         _virtual_pointer: virtual_pointer,
         pointer_location: (0.0, 0.0).into(),
+        touchpad_pointer_captured: false,
         cursor_status: CursorImageStatus::default_named(),
         cursors: CursorSet::build(scale),
         start_time: Instant::now(),

--- a/crates/wm-wayland/src/test_door.rs
+++ b/crates/wm-wayland/src/test_door.rs
@@ -761,6 +761,9 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                 fonts.outline_entries, fonts.outline_payload_bytes,
             ).as_bytes());
         }
+        Some("touchpad-capture") => {
+            let _ = stream.write_all(format!("touchpad-capture {}\n", comp.touchpad_pointer_captured).as_bytes());
+        }
         Some("frame-stats") => {
             let stats = std::mem::take(&mut comp.frame_stats);
             let micros = |duration: std::time::Duration| duration.as_micros();

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -76,6 +76,12 @@ screenshot opens in the default image viewer through `xdg-open` (imv on a
 standard Omarchy installation). Your chosen default is respected. An unavailable
 viewer does not undo the saved file or clipboard copy.
 
+Saved-capture notifications show the screenshot itself or a small first-frame
+preview of the recording. Video previews are generated asynchronously and kept
+in the XDG cache under `chonkstep/capture-previews` so notification history can
+reload them. If a preview cannot be generated, the recording notification uses
+a video icon; the saved recording and review window are unaffected.
+
 ## Recording
 
 Select a display or an area within one display, then press Record or Enter.

--- a/docs/config.example.toml
+++ b/docs/config.example.toml
@@ -155,6 +155,9 @@
 # "flat". `scroll_factor` is a positive multiplier applied to both smooth and
 # wheel scrolling. `[input.touchpad]` is an optional nested spelling for the
 # touchpad-oriented controls; it overrides the corresponding flat key.
+# disable_while_typing defaults to each device’s libinput preference. Active
+# pointer locks/confinement temporarily disable it so games can accept keyboard
+# and touchpad input together; releasing capture restores the preference.
 #[input]
 #sensitivity = 0.0
 #accel_profile = "adaptive"
@@ -163,6 +166,7 @@
 #[input.touchpad]
 #natural_scroll = true
 #tap_to_click = false
+#disable_while_typing = true
 #clickfinger_behavior = true
 #scroll_factor = 0.4
 

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -265,11 +265,17 @@ default usable keymap instead of aborting the login.
 Pointer configuration is also carried from both classic `input {}` /
 `touchpad {}` blocks and Omarchy's Lua tables. `sensitivity` and
 `accel_profile` configure libinput acceleration; `natural_scroll`,
-`tap_to_click`, `clickfinger_behavior`, and `left_handed` are applied
+`tap_to_click`, `disable_while_typing`, `clickfinger_behavior`, and `left_handed` are applied
 where the device advertises them. `scroll_factor` multiplies continuous
 and wheel-axis motion after libinput so the configured speed also works
 on the nested backend. Unsupported capabilities are named per device
 without rejecting the rest of the configuration.
+
+Active pointer locks and confinement temporarily suspend `disable_while_typing`
+so games can receive keyboard and touchpad motion together. This includes
+XWayland pointer grabs. Releasing capture, changing focus, or opening the
+overview restores the configured preference (or each device’s libinput default).
+Hotplug and live reload honor the current capture state.
 
 Binding flags retain their behavior: `bindl`/`locked` actions may run
 on the lock screen, `binde`/`repeating` actions repeat after the

--- a/docs/omarchy-integration.md
+++ b/docs/omarchy-integration.md
@@ -147,6 +147,12 @@ have persistent one-based numeric wire names derived from their internal
 indices, with no independent mutable-name field. It is therefore an
 intentional model boundary, not an omitted command handler.
 
+Chonkstep also gives the exact `org.omarchy.screensaver` identity a fullscreen
+map default, even in a fresh account with no Chonkstep configuration or imported
+Hyprland rules. Omarchy's launcher supplies the identity but does not request
+fullscreen itself. An explicit imported fullscreen rule can override the default;
+other Omarchy utilities retain their normal window placement.
+
 The screensaver launcher can open its terminal clients because long-bracket
 Lua commands and `openwindow` events are supported. Chonkstep does not have
 Hyprland's independent per-monitor workspace/focus model, so requests that

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,11 @@ the path from "installed" to "mine".
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.1-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.2-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.1/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/docs/releases/0.4.2.md
+++ b/docs/releases/0.4.2.md
@@ -1,0 +1,46 @@
+# ChonkStep 0.4.2 alpha
+
+ChonkStep 0.4.2 fixes the pink-and-black checkerboard in capture notifications.
+Screenshot notifications now show the saved image, and recording notifications
+show a thumbnail from the video's first frame.
+
+Recording previews run asynchronously, with at most two decoders and a
+three-second timeout. A failed preview leaves the saved recording and its
+Omacut review intact. Omarchy uses a video glyph in that case, and a warning
+glyph for capture errors, avoiding the missing themed-icon lookup responsible
+for the checkerboard. Other notification servers still show the result text.
+Successful video thumbnails remain in the XDG cache for notification history;
+failed or interrupted previews are removed.
+
+## Validation
+
+- All 17 nested Wayland capture tests pass, including screenshots at 1x, 1.5x
+  and 2x, recorded-scene thumbnail pixels, and recovery from preview failure.
+- All 19 capture-worker tests pass, including decoder timeout, shutdown cleanup
+  and rejection of incomplete PNGs. The manual PNG benchmark was not run.
+- Strict Clippy passes for the Wayland backend and capture test harness.
+- The real `notify-send` client and Quickshell image loader accept both preview
+  types, and Omarchy's notification logic accepts the fallback glyphs without
+  requesting a themed icon.
+
+Recording remains silent, software-encoded H.264. This remains an alpha release.
+
+## Install on Arch or Omarchy
+
+```sh
+chonkstep_dir="$(mktemp -d)"
+chonkstep_arch="$(uname -m)"
+chonkstep_pkg="chonkstep-0.4.2-1-$chonkstep_arch.pkg.tar.zst"
+curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/$chonkstep_pkg"
+curl -fL -o "$chonkstep_dir/SHA256SUMS" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/SHA256SUMS"
+(cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
+gh attestation verify "$chonkstep_dir/$chonkstep_pkg" --repo iconidentify/chonkstep \
+  --signer-workflow iconidentify/chonkstep/.github/workflows/package.yml
+sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
+omarchy install desktop-chonkstep
+```
+
+Matching `chonkstep-debug-0.4.2-1-<arch>.pkg.tar.zst` packages provide crash-report
+symbols and carry the same checksum and provenance verification.

--- a/docs/releases/0.4.2.md
+++ b/docs/releases/0.4.2.md
@@ -1,8 +1,23 @@
 # ChonkStep 0.4.2 alpha
 
-ChonkStep 0.4.2 fixes the pink-and-black checkerboard in capture notifications.
-Screenshot notifications now show the saved image, and recording notifications
-show a thumbnail from the video's first frame.
+ChonkStep 0.4.2 fixes touchpad camera movement while holding game movement
+keys, Omarchy screensavers opening in a small window, and checkerboard capture
+notification previews.
+
+Pointer locks and confinement now temporarily suspend libinput's "disable while
+typing" setting, including XWayland pointer grabs used by games. Releasing
+capture restores the configured preference or the device's default. Hotplug
+and live reload respect the current capture state. The setting is also supported
+in TOML and imported Hyprland input configuration. Other palm detection remains
+under libinput's control.
+
+Omarchy's screensaver now has a fullscreen map default even in accounts with no
+Chonkstep configuration or imported window rules. Its launcher supplies an app
+identity but does not request fullscreen; previously the generic Omarchy utility
+window size applied. Explicit imported fullscreen rules still take precedence.
+
+Screenshot notifications show the saved image, and recording notifications show
+a thumbnail from the video's first frame.
 
 Recording previews run asynchronously, with at most two decoders and a
 three-second timeout. A failed preview leaves the saved recording and its
@@ -13,6 +28,18 @@ Successful video thumbnails remain in the XDG cache for notification history;
 failed or interrupted previews are removed.
 
 ## Validation
+
+- Reproduced the screensaver failure on an M1 MacBook Air: a 1740×1152 floating
+  window with fullscreen off on its 2560×1600 panel. The account had no Chonkstep
+  config and did not import Omarchy's fullscreen rule. The Apple SPI Trackpad
+  also reported "disable while typing" enabled by default.
+- All 13 pointer-constraint, 12 XWayland input, and 5 fullscreen nested tests pass.
+  New regressions cover held-key camera motion, capture destruction and overview
+  transitions, a real X11 pointer grab/ungrab, and screensaver pixels at 1x,
+  1.5x and 2x without imported window rules.
+- Configuration and core unit tests pass, including input preference parsing
+  and explicit fullscreen overrides. Device-policy tests cover hotplug, reload,
+  restoring device defaults, and devices without typing suppression.
 
 - All 17 nested Wayland capture tests pass, including screenshots at 1x, 1.5x
   and 2x, recorded-scene thumbnail pixels, and recovery from preview failure.

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -39,7 +39,7 @@
 # those frames into `file:line`.
 options=(strip debug)
 pkgname=chonkstep
-pkgver=0.4.1
+pkgver=0.4.2
 pkgrel=1
 pkgdesc="A traditional floating compositor for Omarchy, compatible with Hyprland workflows"
 arch=('x86_64' 'aarch64')

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -20,7 +20,7 @@ release. See the [release pipeline](../../docs/engineering/2026-09-07-release-pr
 for validation freshness and artifact retention.
 
 Pushing a tag whose name matches the workspace version, for example
-`v0.4.1`, runs `.github/workflows/aur.yml`. The job copies the release
+`v0.4.2`, runs `.github/workflows/aur.yml`. The job copies the release
 recipe to `PKGBUILD`, replaces `SKIP` with the tag archive's real
 SHA-256 checksum, generates `.SRCINFO` with Arch's `makepkg`, and pushes
 both files to `ssh://aur@aur.archlinux.org/chonkstep.git`.


### PR DESCRIPTION
Holding a movement key on the M1 Air suppresses trackpad camera motion because
libinput's default disable-while-typing policy stays enabled during pointer
capture. Suspend it during active locks/confinement, including XWayland grabs,
and restore each device's configured preference/default afterward. Carry the
preference through TOML, Hyprland imports, reload and hotplug.

Omarchy's screensaver launcher supplies an app identity without requesting
fullscreen. In accounts without imported window rules it inherited Chonkstep's
generic utility-window size. Give that exact service identity a fullscreen
map default, with explicit imported rules retaining precedence. The reported
Mac reproduced a 1740×1152 floating saver on a 2560×1600 panel.

Capture toasts now use the saved screenshot or a bounded asynchronous video
thumbnail. Failed previews use Omarchy's glyph hint to avoid the themed-icon
provider's checkerboard placeholder. Prepare workspace/package version 0.4.2
and document all three fixes.

Validation: 17 capture, 13 pointer-constraint, 12 XWayland input and 5 fullscreen
nested tests pass; configuration/core and capture-worker unit tests pass;
strict backend/testkit Clippy passes. New cases verify held-key camera motion,
X11 grab/ungrab policy, capture release/overview, fresh-account fullscreen
pixels at 1x/1.5x/2x, private thumbnail files and preview failure recovery. Real
Quickshell/notify-send preview and glyph handling was also checked. Physical
Minecraft play testing remains a user check after installation.
