### PR TITLE
Fix Steam scaling and Big Picture fullscreen; prepare 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ crate and both session binaries carry the same number.
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-09-07
+
+- Fullscreen publishes zero frame extents, and XWayland sends the settled
+  resize after border changes. This fixes Steam Big Picture rendering into
+  its old window size with black space around it, including SDL clients that
+  wait for borders to disappear before accepting a fullscreen resize.
+- Wayland startup clears inherited GTK scaling overrides from the compositor
+  and activation environment, preventing Steam from multiplying a 2x desktop
+  by `GDK_SCALE=2` and starting at 4x.
+- Imported Hyprland rules now match the entire class and title. Omarchy's size
+  rule for `Steam` no longer catches Big Picture or sign-in windows, and its
+  floating rule no longer catches `steam_app_*` game windows.
+
 ## [0.4.2] - 2026-09-07
 
 - Game pointer capture suspends touchpad "disable while typing", allowing held

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-about"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-btpair"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -434,21 +434,21 @@ dependencies = [
 
 [[package]]
 name = "chonk-build-info"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "object",
 ]
 
 [[package]]
 name = "chonk-dock-proto"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "chonk-dock-widget"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cosmic-text",
  "tracing",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockapp-torture"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -467,14 +467,14 @@ dependencies = [
 
 [[package]]
 name = "chonk-dockclock"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-ui",
 ]
 
 [[package]]
 name = "chonk-hyprland-ipc"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "serde",
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-instruments"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-widget",
  "chonk-test-support",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-netjoin"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-ui",
  "cosmic-text",
@@ -507,7 +507,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shelf"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "chonk-ui",
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-shell"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "chonk-dock-widget",
@@ -539,11 +539,11 @@ dependencies = [
 
 [[package]]
 name = "chonk-test-support"
-version = "0.4.2"
+version = "0.4.3"
 
 [[package]]
 name = "chonk-testkit"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "chonk-hyprland-ipc",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-toplevel"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "wayland-client",
  "wayland-protocols-wlr",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-ui"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-dock-proto",
  "tiny-skia",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "chonk-xsettings"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -612,7 +612,7 @@ dependencies = [
 
 [[package]]
 name = "chonkstep-wayland"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-build-info",
  "chonk-shell",
@@ -3409,7 +3409,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wm-config"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "regex",
  "serde",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "wm-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bitflags 2.13.1",
  "chonk-test-support",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wm-theme"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "chonk-test-support",
  "cosmic-text",
@@ -3445,14 +3445,14 @@ dependencies = [
 
 [[package]]
 name = "wm-theme-api"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "wm-wayland"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "calloop 0.14.4",
  "chonk-build-info",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "wm-x11"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "thiserror 2.0.20",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = ["examples/chonk-switch", "examples/layer-role-repro", "vendor/smithay
 smithay = { path = "vendor/smithay-0.7.0" }
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "GPL-3.0-only"
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ in place. ChonkStep translates the Hyprland IPC and `hyprctl` calls that
 Omarchy relies on into a classic stacking-window model with real minimize,
 maximize, shade, fullscreen, snapping, workspaces, Alt-Tab, and Overview.
 
-Version 0.4.2 is an **alpha**. It is ready for adventurous users and bug
+Version 0.4.3 is an **alpha**. It is ready for adventurous users and bug
 reports, not machines where a compositor failure would be costly. Hyprland
 stays installed, so ChonkStep is easy to evaluate and easy to leave.
 
 ![ChonkStep replacing Hyprland beneath the Ristretto Omarchy desktop](site/shots/omarchy-desktop.png)
 
-## Install ChonkStep 0.4.2 alpha
+## Install ChonkStep 0.4.3 alpha
 
 Native packages are available for `x86_64` and `aarch64` (including M1 Macs
 running an Arch Linux ARM/Omarchy environment):
 
 ```sh
-curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/chonkstep-0.4.2-1-$(uname -m).pkg.tar.zst"
-sudo pacman -U "./chonkstep-0.4.2-1-$(uname -m).pkg.tar.zst"
+curl -fLO "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/chonkstep-0.4.3-1-$(uname -m).pkg.tar.zst"
+sudo pacman -U "./chonkstep-0.4.3-1-$(uname -m).pkg.tar.zst"
 omarchy install desktop-chonkstep
 ```
 
@@ -237,11 +237,11 @@ the local file to pacman:
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.2-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.3-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/crates/chonk-shell/src/startup.rs
+++ b/crates/chonk-shell/src/startup.rs
@@ -882,6 +882,25 @@ pub fn apply_session_env(env: &[(String, String)]) {
     }
 }
 
+/// Let Wayland output scale and XSETTINGS provide GTK's scale exactly once.
+/// Session launchers and hot restarts can inherit these variables even though
+/// the Hyprland importer correctly refuses them. Steam, for example, multiplies
+/// inherited GDK_SCALE=2 by the X11 desktop's 2x DPI and starts its UI at 4x.
+/// An application can still opt into an override in its own launch command.
+///
+/// # Safety
+/// Call only during single-threaded process startup, before starting clients.
+pub fn clear_inherited_gtk_scale_env() {
+    for name in ["GDK_SCALE", "GDK_DPI_SCALE"] {
+        if std::env::var_os(name).is_some() {
+            tracing::info!(name, "discarding inherited GTK scale; display protocols provide the output scale");
+            // SAFETY: the Wayland startup caller runs before any other thread
+            // exists, under the same contract as apply_session_env.
+            unsafe { std::env::remove_var(name) };
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/chonk-testkit/src/bin/chonk-x11-autostart-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-x11-autostart-probe.rs
@@ -8,6 +8,13 @@ use x11rb::wrapper::ConnectionExt as _;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let marker = std::env::args().nth(1).ok_or("expected marker path")?;
+    if std::env::args().nth(2).as_deref() == Some("check-scale-env") {
+        for name in ["GDK_SCALE", "GDK_DPI_SCALE"] {
+            if std::env::var_os(name).is_some() {
+                return Err(format!("inherited {name} would double-apply desktop scaling").into());
+            }
+        }
+    }
     let display = std::env::var("DISPLAY")?;
     let (connection, screen_number) = x11rb::connect(None)?;
     let screen = &connection.setup().roots[screen_number];

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -136,6 +136,12 @@ fn window_click_workflow(scale: f32, name: &str) {
     let window = session.wait_for_window("input-probe").unwrap();
     let at = ((window.x + 50) as f64, (window.y + 60) as f64);
     session.door().click(at.0, at.1).unwrap();
+    // The compositor barrier does not wait for the client's event loop or
+    // log write. Observe the setup click before taking the baseline, or its
+    // delayed release can be mistaken for a capture click leaking through.
+    poll_until(Duration::from_secs(5), "the probe receives the setup click", || {
+        session.client_log("chonk-input-probe").contains(" release ").then_some(())
+    }).unwrap();
     let releases = session
         .client_log("chonk-input-probe")
         .matches(" release ")
@@ -190,14 +196,6 @@ fn window_click_workflow(scale: f32, name: &str) {
     let frame = world.frame_of(window.id).unwrap();
     assert_eq!((image.width, image.height), (frame.w, frame.h));
     reviews_opened(&session, &[("xdg-open", &path)]);
-    assert_eq!(
-        session
-            .client_log("chonk-input-probe")
-            .matches(" release ")
-            .count(),
-        releases,
-        "the capture click must not reach the target app"
-    );
     session.door().tap_key(30).unwrap();
     poll_until(
         Duration::from_secs(5),
@@ -210,6 +208,16 @@ fn window_click_workflow(scale: f32, name: &str) {
         },
     )
     .unwrap();
+    // Seeing the subsequent key also proves the client has drained any
+    // earlier pointer events before we assert that capture consumed them.
+    assert_eq!(
+        session
+            .client_log("chonk-input-probe")
+            .matches(" release ")
+            .count(),
+        releases,
+        "the capture click must not reach the target app"
+    );
 }
 
 #[test]

--- a/crates/chonk-testkit/tests/supervisor.rs
+++ b/crates/chonk-testkit/tests/supervisor.rs
@@ -303,6 +303,8 @@ fn direct_session_owns_graphical_targets_and_publishes_only_curated_environment(
         .env("CHONKSTEP_SESSION_CONTINUES", "1")
         .env("CHONKSTEP_TEST_SOCKET", "/tmp/stale-test-door.sock")
         .env("XCURSOR_SIZE", "96")
+        .env("GDK_SCALE", "2")
+        .env("GDK_DPI_SCALE", "1.5")
         .env("CARGO_POISON", "must-not-be-published")
         .env("LD_LIBRARY_PATH", "/also/not/published")
         .stdout(Stdio::null())
@@ -348,6 +350,10 @@ fn direct_session_owns_graphical_targets_and_publishes_only_curated_environment(
     );
     assert!(!started.contains("CARGO_POISON"));
     assert!(!started.contains("LD_LIBRARY_PATH"));
+    assert!(started.lines().any(|line| line.contains("--user unset-environment")
+        && line.split_whitespace().any(|name| name == "GDK_SCALE")
+        && line.split_whitespace().any(|name| name == "GDK_DPI_SCALE")),
+        "activation must not hand Steam the previous desktop's GTK scale");
 
     // SAFETY: the child was spawned by this test, has not been reaped, and
     // `kill` only passes its numeric pid and a valid signal to the kernel.

--- a/crates/chonk-testkit/tests/xwayland_input.rs
+++ b/crates/chonk-testkit/tests/xwayland_input.rs
@@ -24,15 +24,86 @@ const TITLE: &str = "xwayland-input-probe";
 
 #[test]
 #[ignore = "needs a nested Wayland session: scripts/e2e.sh --headless --release"]
+fn fullscreen_publishes_border_changes_before_a_settled_resize() {
+    use x11rb::protocol::xproto::PropMode;
+
+    for scale in [1.0, 1.5, 2.0] {
+        let mut session = Session::boot(&format!("x11-fullscreen-borders-{scale}"), SessionOptions {
+            scale: Some(scale),
+            ..Default::default()
+        }).unwrap();
+        let (conn, screen_num) = x11rb::connect(Some(&format!(":{}", xwayland_display(&session)))).unwrap();
+        let root = conn.setup().roots[screen_num].root;
+        let xid = conn.generate_id().unwrap();
+        conn.create_window(COPY_DEPTH_FROM_PARENT, xid, root, 40, 30, 400, 240, 0,
+            WindowClass::INPUT_OUTPUT, COPY_FROM_PARENT,
+            &CreateWindowAux::new().background_pixel(0x406080)
+                .event_mask(EventMask::STRUCTURE_NOTIFY | EventMask::PROPERTY_CHANGE)).unwrap();
+        conn.change_property8(PropMode::REPLACE, xid, AtomEnum::WM_NAME, AtomEnum::STRING,
+            b"SDL fullscreen border handshake").unwrap();
+        conn.map_window(xid).unwrap();
+        conn.flush().unwrap();
+        let extents = intern(&conn, b"_NET_FRAME_EXTENTS");
+        let net_state = intern(&conn, b"_NET_WM_STATE");
+        let fullscreen = intern(&conn, b"_NET_WM_STATE_FULLSCREEN");
+        let original = poll_until(EVENT, "the decorated X11 window's borders", || {
+            let values = property_values(&conn, xid, extents, AtomEnum::CARDINAL.into());
+            (values.len() == 4 && values[2] > 0).then_some(values)
+        }).unwrap();
+        session.door().barrier().unwrap();
+        let world = session.world().unwrap();
+        let output = (world.output_w, world.output_h);
+
+        // SDL holds back size events until the WM announces the new borders.
+        // Assert both halves on the actual X wire, including the event order;
+        // checking the compositor's fullscreen rectangle alone missed Steam's
+        // browser staying at its old size inside a fullscreen X window.
+        for enter in [true, false, true, false] {
+            while conn.poll_for_event().unwrap().is_some() {}
+            conn.send_event(false, root, EventMask::SUBSTRUCTURE_REDIRECT | EventMask::SUBSTRUCTURE_NOTIFY,
+                ClientMessageEvent::new(32, xid, net_state,
+                    [u32::from(enter), fullscreen, 0, 1, 0])).unwrap();
+            conn.flush().unwrap();
+            let expected_extents = if enter { vec![0; 4] } else { original.clone() };
+            let expected_size = if enter { output } else { (400, 240) };
+            let mut borders_announced = false;
+            poll_until(EVENT, "a resize after the fullscreen border transition", || {
+                while let Some(event) = conn.poll_for_event().ok()? {
+                    match event {
+                        Event::PropertyNotify(event) if event.atom == extents => {
+                            borders_announced = property_values(&conn, xid, extents, AtomEnum::CARDINAL.into()) == expected_extents;
+                        }
+                        Event::ConfigureNotify(event) if borders_announced
+                            && (u32::from(event.width), u32::from(event.height)) == expected_size => {
+                            let states = property_values(&conn, xid, net_state, AtomEnum::ATOM.into());
+                            if states.contains(&fullscreen) == enter { return Some(()); }
+                        }
+                        _ => {}
+                    }
+                }
+                None
+            }).unwrap_or_else(|error| panic!("{error}; enter={enter}, scale={scale}\n{}", session.log()));
+            let geometry = conn.get_geometry(xid).unwrap().reply().unwrap();
+            assert_eq!((u32::from(geometry.width), u32::from(geometry.height)), expected_size);
+        }
+    }
+}
+
+#[test]
+#[ignore = "needs a nested Wayland session: scripts/e2e.sh --headless --release"]
 fn x11_autostart_connects_to_the_nested_display_before_the_first_dispatch() {
     let probe = profile_binary("chonk-x11-autostart-probe").expect("probe is built");
     let marker = session_dir("x11-autostart").join("inherited-display");
     let mut session = Session::boot("x11-autostart", SessionOptions {
-        config_extra: format!("autostart = [[{:?}, {:?}]]\n", probe, marker),
+        config_extra: format!("autostart = [[{:?}, {:?}, \"check-scale-env\"]]\n", probe, marker),
         // A nested compositor must replace even a stale inherited X11
         // display. Using an invalid number also keeps the regression
         // incapable of opening its window on the real desktop.
-        env: vec![("DISPLAY".into(), ":65534".into())],
+        env: vec![
+            ("DISPLAY".into(), ":65534".into()),
+            ("GDK_SCALE".into(), "2".into()),
+            ("GDK_DPI_SCALE".into(), "1.5".into()),
+        ],
         ..Default::default()
     }).expect("nested session boots");
     let expected = format!("DISPLAY=:{}\n", xwayland_display(&session));

--- a/crates/wm-config/src/hyprland/rules.rs
+++ b/crates/wm-config/src/hyprland/rules.rs
@@ -73,7 +73,7 @@ impl Pattern {
     /// size limit caps that; a pattern over it is refused like any
     /// other malformed one.
     fn compile(pattern: &str) -> Option<Self> {
-        RegexBuilder::new(pattern)
+        RegexBuilder::new(&format!(r"\A(?:{pattern})\z"))
             .size_limit(1 << 20)
             .dfa_size_limit(1 << 20)
             .build()
@@ -84,13 +84,10 @@ impl Pattern {
             })
     }
 
-    /// Hyprland matches window rules by *search*, not by full match:
-    /// `o.window("localsend", …)` is what floats a window whose class
-    /// is `localsend_app`, and half of Omarchy's own patterns carry an
-    /// explicit `^…$` precisely because the default is unanchored.
-    /// `Regex::is_match` is already a search, so this is the default
-    /// behaviour rather than a decision — but it is the decision that
-    /// makes fifteen of Omarchy's rules work, so it is written down.
+    /// Hyprland's CRegexMatchEngine uses RE2::FullMatch. Anchoring the
+    /// whole expression at compile time preserves alternation and explicit
+    /// anchors while preventing a rule for title `Steam` from resizing
+    /// `Steam Big Picture Mode` or `Sign in to Steam` as a desktop window.
     fn matches(&self, text: &str) -> bool {
         self.regex.is_match(text)
     }

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -641,14 +641,20 @@ fn the_sizes_the_hardcoded_rule_could_not_express_come_through() {
             .and_then(|d| d.size),
         Some(wm_core::Size::new(920, 480))
     );
-    // `apps/localsend.lua`, whose pattern has no anchors — Hyprland
-    // matches by search, so it catches the real class `localsend_app`.
+    // Hyprland requires a full match even without explicit anchors.
     assert_eq!(
         policy
-            .decision_for("localsend_app", "")
+            .decision_for("localsend", "")
             .and_then(|d| d.size),
         Some(wm_core::Size::new(1100, 700))
     );
+    assert!(policy.decision_for("localsend_app", "").is_none());
+    for title in ["Steam Big Picture Mode", "Sign in to Steam"] {
+        assert_eq!(policy.decision_for("steam", title).and_then(|d| d.size), None,
+            "the desktop size rule must not resize {title}");
+    }
+    assert!(policy.decision_for("steam_app_123", "Steam").is_none(),
+        "Steam's floating rule must not turn a game's window into the launcher");
 }
 
 /// A rule this reader only half-understands is dropped whole and says

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -2801,6 +2801,7 @@ impl<B: Backend> WindowManager<B> {
             }
             self.backend.position_client(window, Point::new(0, 0));
             self.backend.resize_client(window, monitor.size);
+            self.publish_frame_extents(id);
             return;
         }
         // A client-decorated window has no chrome to lay out and no
@@ -6748,6 +6749,13 @@ mod tests {
         // or a client reasoning from them lands off by the difference.
         assert_eq!(left + 800 + right, layout.frame_size.w);
         assert_eq!(top + 600 + bottom, layout.frame_size.h);
+
+        wm.fullscreen(id);
+        assert_eq!(wm.backend().frame_extents[&window], (0, 0, 0, 0),
+            "fullscreen must publish the removal of every border; SDL waits for it before resizing");
+        wm.unfullscreen(id);
+        assert_eq!(wm.backend().frame_extents[&window], (left, right, top, bottom),
+            "leaving fullscreen restores the actual decoration extents");
 
         wm.backend_mut().set_client_draws_own_chrome(window, true);
         wm.dispatch(BackendEvent::ChromeChanged(window));

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -3992,6 +3992,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // Empty on a session that reads no such configuration, which is
     // most of them.
     chonk_shell::startup::apply_session_env(&state.session_env);
+    chonk_shell::startup::clear_inherited_gtk_scale_env();
     let theme = state.theme();
     tracing::info!(theme = %theme.id, "theme loaded");
     // The font database is built out here rather than inside the engine

--- a/crates/wm-wayland/src/xewmh.rs
+++ b/crates/wm-wayland/src/xewmh.rs
@@ -485,8 +485,31 @@ impl XEwmh {
         for &(window, desktop) in &writes.window_desktops {
             self.conn.change_property32(PropMode::REPLACE, window, self.atoms.net_wm_desktop, AtomEnum::CARDINAL, &[desktop])?;
         }
-        for &(window, extents) in &writes.frame_extents {
+        for &(window, extents, content) in &writes.frame_extents {
             self.conn.change_property32(PropMode::REPLACE, window, self.atoms.net_frame_extents, AtomEnum::CARDINAL, &extents)?;
+            // SDL suppresses resize events while fullscreen still advertises
+            // borders (and while windowed mode waits for borders to return).
+            // The XWM's resize may already have arrived on its connection.
+            // Send the settled geometry AFTER the extents on this connection
+            // so PropertyNotify always releases that gate before this event.
+            self.conn.send_event(
+                false,
+                window,
+                x11rb::protocol::xproto::EventMask::STRUCTURE_NOTIFY,
+                x11rb::protocol::xproto::ConfigureNotifyEvent {
+                    response_type: x11rb::protocol::xproto::CONFIGURE_NOTIFY_EVENT,
+                    sequence: 0,
+                    event: window,
+                    window,
+                    above_sibling: x11rb::NONE,
+                    x: content.pos.x as i16,
+                    y: content.pos.y as i16,
+                    width: content.size.w as u16,
+                    height: content.size.h as u16,
+                    border_width: 0,
+                    override_redirect: false,
+                },
+            )?;
         }
         for &(window, state) in &writes.window_states {
             // ICCCM 4.1.3.1: two 32-bit values, state and icon window
@@ -556,7 +579,7 @@ struct Writes {
     workspaces: Option<(u32, u32)>,
     workarea: Option<Vec<u32>>,
     window_desktops: Vec<(XWindow, u32)>,
-    frame_extents: Vec<(XWindow, [u32; 4])>,
+    frame_extents: Vec<(XWindow, [u32; 4], Rect)>,
     window_states: Vec<(XWindow, u32)>,
     window_modal: Vec<(XWindow, bool)>,
 }
@@ -641,7 +664,7 @@ fn take_writes(backend: &mut WaylandBackend) -> Writes {
         frame_extents: ledger
             .frame_extents
             .drain()
-            .filter_map(|(id, (l, r, t, b))| Some((x11_id(windows, id)?, [l, r, t, b])))
+            .filter_map(|(id, (l, r, t, b))| Some((x11_id(windows, id)?, [l, r, t, b], windows.get(&id)?.content)))
             .collect(),
         window_states: ledger
             .window_iconic

--- a/docs/hyprland-config.md
+++ b/docs/hyprland-config.md
@@ -111,8 +111,8 @@ windowrule   = float on, match:class steam               # 0.53+
 The supported properties are `float`, `size`, `center`, `idle_inhibit`,
 `pin`, `no_focus`, `no_initial_focus`, `focus_on_activate`,
 `fullscreen`, and `maximize`. They match `class` and `title` as regular
-expressions, unanchored (a *search*, which is how Hyprland matches and
-why `o.window("localsend", …)` catches `localsend_app`). Last matching
+expressions, matched against the entire class or title, as in Hyprland's
+`RE2::FullMatch`. Use `.*` when a substring is intended. Last matching
 rule wins independently for each property.
 
 `idle_inhibit` follows the mapped/visible interpretation: a matching
@@ -178,6 +178,11 @@ and logged:
 | `XDG_CURRENT_DESKTOP`, `XDG_SESSION_DESKTOP` | Omarchy sets both to `Hyprland`, which under chonkstep is false. Carrying them routes xdg-desktop-portal at `xdg-desktop-portal-hyprland`, which would then try to talk to a compositor that is not there — and break screen sharing rather than one key. |
 | `WAYLAND_DISPLAY`, `DISPLAY`, `XDG_SESSION_TYPE`, `XDG_RUNTIME_DIR`, `HYPRLAND_INSTANCE_SIGNATURE` | They name *this* session, which the compositor sets for itself. A stale value out of a file points every child at a display that does not exist. |
 | `GDK_SCALE`, `GDK_DPI_SCALE`, `QT_SCALE_FACTOR`, `ELM_SCALE` | Global toolkit scaling can disagree with per-output Wayland scale. Monitor rules and fractional scale are the single scale path. |
+
+Wayland startup also removes inherited `GDK_SCALE` and `GDK_DPI_SCALE`, including
+stale values in the activation environment. GTK and Steam receive scale through
+Wayland or XSETTINGS/X resources. Per-application launch commands can still set
+an explicit override when needed.
 
 Blanket activation-environment commands are never admitted as
 autostart. In particular, `systemctl --user import-environment $(env

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,11 +13,11 @@ the path from "installed" to "mine".
 ```sh
 chonkstep_dir="$(mktemp -d)"
 chonkstep_arch="$(uname -m)"
-chonkstep_pkg="chonkstep-0.4.2-1-$chonkstep_arch.pkg.tar.zst"
+chonkstep_pkg="chonkstep-0.4.3-1-$chonkstep_arch.pkg.tar.zst"
 curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/$chonkstep_pkg"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/$chonkstep_pkg"
 curl -fL -o "$chonkstep_dir/SHA256SUMS" \
-  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.2/SHA256SUMS"
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/SHA256SUMS"
 (cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
 sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
 omarchy install desktop-chonkstep

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -1,0 +1,66 @@
+# ChonkStep 0.4.3 alpha
+
+ChonkStep 0.4.3 fixes Steam's oversized startup UI and Big Picture leaving
+black space around its content on scaled displays.
+
+Fullscreen now publishes zero frame extents. XWayland follows border changes
+with a configure event carrying the final content rectangle, on the same X11
+connection. Previously the compositor and X server had the correct fullscreen
+size while still advertising a titlebar and borders. Steam's SDL layer suppressed
+resize events while waiting for those borders to disappear, leaving its browser
+at the old window size. The fix applies to every X11 client, including SDL games,
+and restores the decoration information when leaving fullscreen.
+
+Wayland startup also clears inherited `GDK_SCALE` and `GDK_DPI_SCALE`, including
+stale values in the activation environment. Display protocols already publish
+scale; Steam inherited `GDK_SCALE=2` and multiplied a 2x desktop into 4x at startup.
+Applications can still request an override in their own launch command.
+
+Imported Hyprland rules now match the entire class and title, following
+Hyprland's `RE2::FullMatch` behavior. Omarchy's size rule for `Steam` no longer
+resizes `Steam Big Picture Mode` or `Sign in to Steam`, and its `steam` floating
+rule no longer catches `steam_app_*` games. Patterns that intentionally match a
+substring should include `.*`.
+
+## Validation
+
+- Reproduced with the real Steam client on i9beef's 3840×2160, scale-2 display:
+  a fullscreen X window contained a browser still rendering at 2200×1400.
+- Verified a fresh Big Picture launch in an isolated compositor at 3840×2160
+  with zero frame extents and content filling the output, without a window rule
+  forcing Big Picture fullscreen or a manual property repair. Switching to the
+  desktop client and back to Big Picture also restores the full output size.
+- The new X11 regression checks border announcements, subsequent resize events,
+  actual X geometry, and repeated fullscreen entry/exit at 1x, 1.5x, and 2x.
+  It passes with the fix and fails against the published 0.4.2 executable.
+- An autostart regression verifies that an X11 application connects to the new
+  display and does not inherit stale GTK scale overrides.
+- Local validation passed strict Clippy and documentation checks, 2,055 Rust
+  tests, 65 harness tests, all 13 XWayland input tests, all five fullscreen tests,
+  and the installed Omarchy menu and theme fixtures.
+
+This remains an alpha release. These checks cover Steam's desktop and Big
+Picture window behavior; they are not a claim that every game or overlay has
+been qualified. A launch of the installed ChonkBlocker build stopped before
+creating a game window because its AppImage extraction returned "Permission
+denied", so game launch and overlay behavior remain unverified in this run.
+
+## Install on Arch or Omarchy
+
+```sh
+chonkstep_dir="$(mktemp -d)"
+chonkstep_arch="$(uname -m)"
+chonkstep_pkg="chonkstep-0.4.3-1-$chonkstep_arch.pkg.tar.zst"
+curl -fL -o "$chonkstep_dir/$chonkstep_pkg" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/$chonkstep_pkg"
+curl -fL -o "$chonkstep_dir/SHA256SUMS" \
+  "https://github.com/iconidentify/chonkstep/releases/download/preview-v0.4.3/SHA256SUMS"
+(cd "$chonkstep_dir" && sha256sum --ignore-missing --check SHA256SUMS)
+gh attestation verify "$chonkstep_dir/$chonkstep_pkg" --repo iconidentify/chonkstep \
+  --signer-workflow iconidentify/chonkstep/.github/workflows/package.yml
+sudo pacman -U "$chonkstep_dir/$chonkstep_pkg"
+omarchy install desktop-chonkstep
+```
+
+Matching `chonkstep-debug-0.4.3-1-<arch>.pkg.tar.zst` packages provide debug symbols
+and carry the same checksum and provenance verification.

--- a/docs/releases/0.4.3.md
+++ b/docs/releases/0.4.3.md
@@ -38,12 +38,14 @@ substring should include `.*`.
 - Local validation passed strict Clippy and documentation checks, 2,055 Rust
   tests, 65 harness tests, all 13 XWayland input tests, all five fullscreen tests,
   and the installed Omarchy menu and theme fixtures.
+- Launched ChonkBlocker from Big Picture, delivered keyboard input to the game,
+  and closed its window to return to fullscreen Steam. The first launch was
+  blocked by a partial AppImage extraction left in `/tmp`; archiving that
+  temporary directory allowed the game to launch.
 
 This remains an alpha release. These checks cover Steam's desktop and Big
 Picture window behavior; they are not a claim that every game or overlay has
-been qualified. A launch of the installed ChonkBlocker build stopped before
-creating a game window because its AppImage extraction returned "Permission
-denied", so game launch and overlay behavior remain unverified in this run.
+been qualified. Steam's in-game overlay remains unverified in this run.
 
 ## Install on Arch or Omarchy
 

--- a/docs/xwayland-compatibility.md
+++ b/docs/xwayland-compatibility.md
@@ -381,10 +381,11 @@ the X11 session everything is an X11 client.
 | JetBrains IDEs (IntelliJ, CLion) | XWayland | Framed by chonkstep — JBR does not set the Motif hint | `Xft.dpi` from `RESOURCE_MANAGER` | Java reads the resource when opening the display; restart after a live scale change. Unverified with a real IDE |
 | GIMP | XWayland or native GTK | Framed; GIMP asks for server-side chrome | XSETTINGS (X11); the output scale (Wayland) | Multi-window mode leans on `_NET_WM_WINDOW_TYPE_UTILITY` and `_DIALOG`, both handled |
 | Qt applications (VLC, Krita, qBittorrent) | Native Wayland or XWayland | Framed, single titlebar either way | `QT_SCALE_FACTOR` at launch (X11); the output scale (Wayland) | Qt defers to server-side decorations when offered, and the compositor always offers |
-| Steam | XWayland | Mixed — Steam's own windows ask for various chrome | 1× unless Steam is told otherwise | Its Chromium-embedded UI, overlay and Big Picture mode are all unverified here |
+| Steam | XWayland | Mixed — Steam's own windows ask for various chrome | Desktop DPI from XSETTINGS/X resources | Desktop and Big Picture are covered by the 0.4.3 fullscreen/scaling validation; see the release notes for the tested scope |
 | Wine / Proton applications | XWayland | Depends on winecfg's "allow the window manager to decorate the windows"; Wine sets the Motif hint when it decorates itself | Wine's own DPI setting | Fullscreen games depend on `_NET_WM_STATE_FULLSCREEN`, which works in the X11 session; see the state caveat below for the Wayland one |
 
-Every row is **From the code** or weaker. None has been run.
+Except for the Steam validation linked above, these rows are **From the code**
+or weaker and have not been checked with the real applications.
 
 ## Known not to work
 

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -39,7 +39,7 @@
 # those frames into `file:line`.
 options=(strip debug)
 pkgname=chonkstep
-pkgver=0.4.2
+pkgver=0.4.3
 pkgrel=1
 pkgdesc="A traditional floating compositor for Omarchy, compatible with Hyprland workflows"
 arch=('x86_64' 'aarch64')

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -20,7 +20,7 @@ release. See the [release pipeline](../../docs/engineering/2026-09-07-release-pr
 for validation freshness and artifact retention.
 
 Pushing a tag whose name matches the workspace version, for example
-`v0.4.2`, runs `.github/workflows/aur.yml`. The job copies the release
+`v0.4.3`, runs `.github/workflows/aur.yml`. The job copies the release
 recipe to `PKGBUILD`, replaces `SKIP` with the tag archive's real
 SHA-256 checksum, generates `.SRCINFO` with Arch's `makepkg`, and pushes
 both files to `ssh://aur@aur.archlinux.org/chonkstep.git`.

--- a/scripts/wayland-session.sh
+++ b/scripts/wayland-session.sh
@@ -144,6 +144,10 @@ _CHONKSTEP_STALE_ENV=(
     CHONKSTEP_TEST_RUST_LOG
     CHONKSTEP_TEST_SOCKET
     CHONKSTEP_WAYLAND_BIN
+    # Display protocols already publish scale. Inheriting these from another
+    # desktop doubles GTK/Steam scaling, including in D-Bus activated clients.
+    GDK_SCALE
+    GDK_DPI_SCALE
 )
 _CHONKSTEP_STALE_OWNED_CURSOR=0
 if [ -n "${CHONKSTEP_OWNS_XCURSOR_SIZE:-}" ]; then


### PR DESCRIPTION
Steam on a 2x desktop could start at 4x, and Big Picture kept rendering at its old window size inside a correctly sized fullscreen X window. Clear inherited GTK scale overrides, match imported Hyprland class/title rules in full, and publish fullscreen border removal followed by the settled X11 configure event that SDL needs before delivering resize events. Decoration extents return when leaving fullscreen. Prepare version 0.4.3 and document the tested scope.

Validation:
- Real Steam at 3840×2160, scale 2: fresh Big Picture launch, desktop mode, and Big Picture reentry fill the output; startup scale is 2x rather than 4x.
- New X11 border/resize ordering regression passes at 1x, 1.5x, and 2x with repeated fullscreen transitions and fails against the published 0.4.2 binary.
- Strict Clippy and documentation checks; 2,055 Rust tests; 65 harness tests; 13 XWayland and five fullscreen integration tests; installed Omarchy fixtures all passed.
- Launched ChonkBlocker through Big Picture, delivered keyboard input, and closed the game to return to fullscreen Steam. Its first launch was blocked by a partial AppImage extraction left in /tmp; archiving that temporary directory resolved the launch failure. The in-game overlay remains unverified.

Additional validation: all six browser selection/repeat cases passed locally using normal rendering and CI software-rendering flags, across native Wayland and XWayland at 1x, 1.5x, and 2x. All 17 capture integration tests passed. CI exposed a capture-test synchronization race: its baseline was read before the setup click reached the client log. The test now waits for that click and a subsequent keyboard event before checking that capture clicks were consumed; the event-count assertion remains unchanged.
