### PR TITLE
fix(wayland): restore client resize handles and logout signal delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.13.1",
- "nix",
  "polling",
  "rustix 1.1.4",
  "slab",
@@ -1583,18 +1582,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2361,16 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -3465,6 +3462,7 @@ dependencies = [
  "libc",
  "png 0.18.1",
  "profiling",
+ "signal-hook",
  "smithay",
  "tiny-skia",
  "tracing",

--- a/crates/chonk-testkit/src/bin/chonk-input-probe.rs
+++ b/crates/chonk-testkit/src/bin/chonk-input-probe.rs
@@ -649,9 +649,22 @@ fn main() {
         .unwrap_or_else(|| "input-probe".into());
     toplevel.set_title(name.clone());
     toplevel.set_app_id(name);
-    toplevel.set_min_size(400, 300);
+    // GTK-style shadow buffer with an explicit resize band and a hole in
+    // the interior. Deliberately asymmetric: window geometry is not an
+    // input region, and its top-left offset cannot predict the other edges.
+    let csd_region = std::env::args().any(|arg| arg == "--csd-input-region");
+    let (content_w, content_h) = if csd_region { (340, 230) } else { (400, 300) };
+    if csd_region {
+        xdg.set_window_geometry(25, 30, content_w, content_h);
+        let region = probe.compositor.as_ref().unwrap().create_region(&qh, ());
+        region.add(13, 18, 364, 254);
+        region.subtract(180, 130, 20, 20);
+        surface.set_input_region(Some(&region));
+        region.destroy();
+    }
+    toplevel.set_min_size(content_w, content_h);
     if !probe.interactive.enabled() {
-        toplevel.set_max_size(400, 300);
+        toplevel.set_max_size(content_w, content_h);
     }
     surface.commit();
     queue.roundtrip(&mut probe).expect("initial configure");

--- a/crates/chonk-testkit/tests/client_input_regions.rs
+++ b/crates/chonk-testkit/tests/client_input_regions.rs
@@ -1,0 +1,237 @@
+//! Window geometry excludes shadows; wl_surface input regions include the
+//! client's resize handles. Exercise that distinction through real pointer
+//! events at integer and fractional scales, without depending on a GTK theme.
+
+use std::time::Duration;
+
+use chonk_testkit::{keys, poll_until, profile_binary, Session, SessionOptions, WindowInfo};
+
+const EVENT: Duration = Duration::from_secs(10);
+const PROBE: &str = "chonk-input-probe";
+const APP: &str = "csd-region-probe";
+
+fn window(session: &mut Session) -> WindowInfo {
+    session
+        .world()
+        .unwrap()
+        .window_matching(APP)
+        .unwrap()
+        .clone()
+}
+
+fn boot(scale: f32, scenario: &str) -> (Session, WindowInfo) {
+    let mut session = Session::boot(
+        &format!("client-input-region-{scenario}-{scale}"),
+        SessionOptions {
+            scale: Some(scale),
+            config_extra: format!(
+                "show_dock = false\nomarchy_menu = false\nhyprland_config = false\n\
+                 [decorations]\nclient_side = [\"{APP}\"]\n"
+            ),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let binary = profile_binary(PROBE).unwrap();
+    session
+        .launch_isolated(
+            binary.to_str().unwrap(),
+            &[
+                &scale.to_string(),
+                "--csd-input-region",
+                "--interactive=resize",
+                &format!("--app-id={APP}"),
+            ],
+        )
+        .unwrap();
+    session.wait_for_window(APP).unwrap();
+    let before = poll_until(EVENT, "committed window geometry", || {
+        let w = window(&mut session);
+        (w.offset_x == (25.0 * scale).round() as i32 && w.w == (340.0 * scale) as u32).then_some(w)
+    })
+    .unwrap();
+    assert!(session.world().unwrap().frame_of(before.id).is_none());
+    // Keep all four shadow bands inside the output, including at 2x.
+    let start = (f64::from(before.x + 40), f64::from(before.y + 40));
+    session.door().key(keys::LEFTALT, true).unwrap();
+    session.door().drag_to(start, (250.0, 200.0)).unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().key(keys::LEFTALT, false).unwrap();
+    session.door().barrier().unwrap();
+    let w = window(&mut session);
+    assert_eq!((w.x, w.y), (210, 160));
+    (session, w)
+}
+
+fn last_sequence(session: &Session) -> u64 {
+    session
+        .client_log(PROBE)
+        .lines()
+        .rev()
+        .find_map(|line| {
+            line.strip_prefix("input ")?
+                .split_whitespace()
+                .next()?
+                .parse()
+                .ok()
+        })
+        .unwrap_or(0)
+}
+
+fn wait_input(session: &Session, after: u64, kind: &str) -> (f64, f64) {
+    poll_until(EVENT, kind, || {
+        session.client_log(PROBE).lines().rev().find_map(|line| {
+            let mut fields = line.strip_prefix("input ")?.split_whitespace();
+            let sequence: u64 = fields.next()?.parse().ok()?;
+            let event = fields.next()?;
+            let x = fields.next()?.parse().ok()?;
+            let y = fields.next()?.parse().ok()?;
+            (sequence > after && event == kind).then_some((x, y))
+        })
+    })
+    .unwrap_or_else(|error| panic!("{error}\n{}", session.client_log(PROBE)))
+}
+
+fn exercise_region(scale: f32) {
+    let (mut session, w) = boot(scale, "bands");
+    let global = |x: f64, y: f64| {
+        (
+            f64::from(w.x - w.offset_x) + x * f64::from(scale),
+            f64::from(w.y - w.offset_y) + y * f64::from(scale),
+        )
+    };
+    // Ten logical pixels outside every edge/corner, inside the client's
+    // 12px input band. The old hard-coded 8 *physical* pixels miss all eight.
+    for (x, y) in [
+        (15.0, 20.0),
+        (190.0, 20.0),
+        (375.0, 20.0),
+        (15.0, 140.0),
+        (375.0, 140.0),
+        (15.0, 270.0),
+        (190.0, 270.0),
+        (375.0, 270.0),
+    ] {
+        let (gx, gy) = global(x, y);
+        assert_eq!(
+            session.door().hit(gx as i32, gy as i32).unwrap(),
+            "content",
+            "scale={scale} grip=({x},{y})"
+        );
+        let sequence = last_sequence(&session);
+        session.door().motion(gx, gy).unwrap();
+        session.door().button("left", true).unwrap();
+        let position = wait_input(&session, sequence, "press");
+        assert!(
+            (position.0 - x).abs() < 0.01 && (position.1 - y).abs() < 0.01,
+            "scale={scale} expected ({x},{y}), got {position:?}"
+        );
+        session.door().button("left", false).unwrap();
+        wait_input(&session, sequence, "release");
+    }
+    // Outside the input region, including a deliberately punched hole
+    // inside the visible window: no fallback to the root wl_surface.
+    for (x, y) in [
+        (12.0, 140.0),
+        (190.0, 17.0),
+        (378.0, 140.0),
+        (190.0, 273.0),
+        (190.0, 140.0),
+        (410.0, 140.0),
+    ] {
+        let (gx, gy) = global(x, y);
+        assert_eq!(
+            session.door().hit(gx as i32, gy as i32).unwrap(),
+            "root",
+            "scale={scale} excluded=({x},{y})"
+        );
+    }
+    // A real authorized xdg resize can begin in the newly reachable band.
+    let (gx, gy) = global(375.0, 270.0);
+    let sequence = last_sequence(&session);
+    session.door().motion(gx, gy).unwrap();
+    session.door().button("left", true).unwrap();
+    wait_input(&session, sequence, "press");
+    session.door().tap_key(59).unwrap(); // F1 spends the actual press serial.
+    poll_until(EVENT, "client resize request processed", || {
+        session
+            .client_log(PROBE)
+            .contains("interactive fence 59 ")
+            .then_some(())
+    })
+    .unwrap();
+    session.door().barrier().unwrap();
+    session.door().motion(gx + 60.0, gy + 40.0).unwrap();
+    let resized = poll_until(EVENT, "resize from the CSD input band", || {
+        let now = window(&mut session);
+        (now.w > w.w && now.h > w.h).then_some(now)
+    })
+    .unwrap();
+    session.door().button("left", false).unwrap();
+    assert_eq!((resized.w - w.w, resized.h - w.h), (60, 40));
+    session.door().motion(gx + 90.0, gy + 70.0).unwrap();
+    session.door().barrier().unwrap();
+    let after_release = window(&mut session);
+    assert_eq!((after_release.w, after_release.h), (resized.w, resized.h));
+}
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless"]
+fn client_resize_handles_and_input_holes_at_1x() {
+    exercise_region(1.0);
+}
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless"]
+fn client_resize_handles_and_input_holes_at_2x() {
+    exercise_region(2.0);
+}
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless"]
+fn client_resize_handles_and_input_holes_at_fractional_scale() {
+    exercise_region(1.5);
+}
+
+#[test]
+#[ignore = "needs a nested session: scripts/e2e.sh --headless"]
+fn shadows_and_input_holes_deliver_clicks_to_the_window_underneath() {
+    let (mut session, w) = boot(1.0, "overlap");
+    let binary = profile_binary(PROBE).unwrap();
+    session
+        .launch_isolated(binary.to_str().unwrap(), &["1", "--app-id=under-region"])
+        .unwrap();
+    let underneath = session.wait_for_window("under-region").unwrap();
+    // Put the second window's content beneath the entire first buffer.
+    session.door().key(keys::LEFTALT, true).unwrap();
+    session
+        .door()
+        .drag_to(
+            (f64::from(underneath.x + 40), f64::from(underneath.y + 40)),
+            (
+                f64::from(w.x - w.offset_x + 40),
+                f64::from(w.y - w.offset_y + 40),
+            ),
+        )
+        .unwrap();
+    session.door().button("left", false).unwrap();
+    session.door().key(keys::LEFTALT, false).unwrap();
+    for (x, y) in [(12, 140), (190, 140)] {
+        // Raise the CSD window first; clicking through must focus the one
+        // beneath it, even when the hole lies inside its window geometry.
+        session.door().chord(keys::LEFTALT, 15).unwrap(); // Alt+Tab
+        session.door().barrier().unwrap();
+        assert_eq!(session.world().unwrap().logical_focus, Some(w.id));
+        let sequence = last_sequence(&session); // newest probe is underneath
+        session
+            .door()
+            .click(
+                f64::from(w.x - w.offset_x + x),
+                f64::from(w.y - w.offset_y + y),
+            )
+            .unwrap();
+        let position = wait_input(&session, sequence, "press");
+        assert_eq!(position, (f64::from(x), f64::from(y)));
+        assert_eq!(session.world().unwrap().logical_focus, Some(underneath.id));
+    }
+}

--- a/crates/chonk-testkit/tests/e2e.rs
+++ b/crates/chonk-testkit/tests/e2e.rs
@@ -400,8 +400,7 @@ fn scale_2_composition_stays_intact() {
 /// own chrome has no server-side resize borders, so grabbing its edge
 /// means the pointer is over the client's *shadow* — outside the
 /// ledger's content rectangle — and the whole path only works if the
-/// hit test extends a frameless window's claim into that margin (see
-/// `frameless_claims` in `wm-wayland/src/input.rs`) and the
+/// hit test honors the surface's input region in that margin and the
 /// client-initiated `xdg_toplevel.resize` then drives `wm-core`'s
 /// resize machinery. A resizable zenity (--text-info) is the guinea
 /// pig; the corner drag must make it bigger.

--- a/crates/chonk-testkit/tests/logout.rs
+++ b/crates/chonk-testkit/tests/logout.rs
@@ -1,0 +1,173 @@
+//! Exercise signal delivery through real compositor launches and upgrades.
+//! These tests never stop the developer's graphical session or user manager.
+
+#![cfg(target_os = "linux")]
+
+use std::path::Path;
+use std::time::Duration;
+
+use chonk_testkit::{keys, poll_until, session_dir, Session, SessionOptions};
+
+const EVENT: Duration = Duration::from_secs(5);
+const TERMINATION_MASK: u64 = (1 << (libc::SIGTERM - 1)) | (1 << (libc::SIGHUP - 1)) | (1 << (libc::SIGINT - 1));
+
+/// Model an upgrade from the old signalfd compositor, which execed with
+/// these signals blocked. This changes only the test's calling thread.
+struct BlockedSignals(libc::sigset_t);
+
+impl BlockedSignals {
+    fn new() -> Self {
+        // SAFETY: both sets are valid local storage. pthread_sigmask writes
+        // the previous mask to `old` and only changes this calling thread.
+        unsafe {
+            let mut signals = std::mem::zeroed();
+            let mut old = std::mem::zeroed();
+            libc::sigemptyset(&mut signals);
+            for signal in [libc::SIGTERM, libc::SIGHUP, libc::SIGINT] {
+                libc::sigaddset(&mut signals, signal);
+            }
+            assert_eq!(libc::pthread_sigmask(libc::SIG_BLOCK, &signals, &mut old), 0);
+            Self(old)
+        }
+    }
+}
+
+impl Drop for BlockedSignals {
+    fn drop(&mut self) {
+        // SAFETY: the stored mask came from pthread_sigmask on this thread.
+        unsafe { libc::pthread_sigmask(libc::SIG_SETMASK, &self.0, std::ptr::null_mut()); }
+    }
+}
+
+fn blocked(pid: u32) -> u64 {
+    let status = std::fs::read_to_string(format!("/proc/{pid}/status")).unwrap();
+    let mask = status.lines().find_map(|line| line.strip_prefix("SigBlk:\t")).unwrap();
+    u64::from_str_radix(mask, 16).unwrap()
+}
+
+fn signal(pid: u32, signal: i32) {
+    // SAFETY: these are live processes launched in this test's private
+    // session, and the only effect is delivering a valid numeric signal.
+    assert_eq!(unsafe { libc::kill(pid as i32, signal) }, 0);
+}
+
+/// Owns cleanup even when a mask or delivery assertion fails. The real
+/// shell reaps the process; this test only waits for /proc to disappear.
+struct Sleeper(Option<u32>);
+
+impl Sleeper {
+    fn ready(path: &Path) -> Self {
+        let pid = poll_until(EVENT, "the shell-launched application's PID", || {
+            std::fs::read_to_string(path).ok()?.trim().parse().ok()
+        }).unwrap();
+        let sleeper = Self(Some(pid));
+        poll_until(EVENT, "the launcher shell to exec sleep", || {
+            (std::fs::read_to_string(format!("/proc/{pid}/comm")).ok()?.trim() == "sleep").then_some(())
+        }).unwrap();
+        sleeper
+    }
+
+    fn pid(&self) -> u32 {
+        self.0.unwrap()
+    }
+
+    fn terminate(mut self, termination: i32) {
+        let pid = self.pid();
+        signal(pid, termination);
+        poll_until(EVENT, "the application to honor termination and be reaped", || {
+            (!Path::new(&format!("/proc/{pid}")).exists()).then_some(())
+        }).unwrap();
+        self.0 = None;
+    }
+}
+
+impl Drop for Sleeper {
+    fn drop(&mut self) {
+        let Some(pid) = self.0 else { return };
+        if Path::new(&format!("/proc/{pid}")).exists() {
+            // SAFETY: cleanup is restricted to the child this guard owns.
+            unsafe { libc::kill(pid as i32, libc::SIGKILL); }
+            let _ = poll_until(EVENT, "probe cleanup", || {
+                (!Path::new(&format!("/proc/{pid}")).exists()).then_some(())
+            });
+        }
+    }
+}
+
+fn sleeper_command(path: &Path) -> String {
+    // Positional arguments keep paths out of shell syntax. exec deliberately
+    // leaves signal setup untouched, just as background desktop helpers do.
+    serde_json::to_string(&[
+        "sh", "-c", "echo $$ > \"$1\"; exec sleep 60", "logout-probe", path.to_str().unwrap(),
+    ]).unwrap()
+}
+
+#[test]
+#[ignore = "needs an isolated Wayland host; scripts/e2e.sh --headless --test logout"]
+fn applications_and_library_children_keep_termination_signals_deliverable() {
+    let name = "logout-child-signals";
+    let dir = session_dir(name);
+    let pid_file = dir.join("child.pid");
+    let command = sleeper_command(&pid_file);
+    let config = format!(
+        "autostart = [{command}]\n[commands]\nprobe = {command}\n[keybindings]\n\"super+space\" = \"run probe\"\n"
+    );
+    let mut session = Session::boot(name, SessionOptions { config_extra: config, ..Default::default() }).unwrap();
+    let first = Sleeper::ready(&pid_file);
+    assert_eq!(blocked(first.pid()) & TERMINATION_MASK, 0, "autostart inherited the compositor's blocked signals");
+    first.terminate(libc::SIGTERM);
+
+    // A later interactive launch must be healthy too, after all compositor
+    // services and their workers have started.
+    for termination in [libc::SIGHUP, libc::SIGINT] {
+        std::fs::remove_file(&pid_file).unwrap();
+        session.door().chord(keys::LEFTMETA, keys::SPACE).unwrap();
+        let child = Sleeper::ready(&pid_file);
+        assert_eq!(blocked(child.pid()) & TERMINATION_MASK, 0);
+        child.terminate(termination);
+        session.door().barrier().unwrap();
+    }
+
+    // XWayland is spawned inside Smithay, outside the shell's launch helpers.
+    // Fixing only Command construction in chonk-shell misses this boundary.
+    let compositor = session.compositor_pid();
+    let xwayland = poll_until(EVENT, "the library-spawned XWayland process", || {
+        std::fs::read_to_string(format!("/proc/{compositor}/task/{compositor}/children")).ok()?
+            .split_whitespace().filter_map(|pid| pid.parse::<u32>().ok()).find(|pid| {
+                std::fs::read_to_string(format!("/proc/{pid}/comm")).is_ok_and(|name| name.trim() == "Xwayland")
+            })
+    }).unwrap();
+    assert_eq!(blocked(xwayland) & TERMINATION_MASK, 0, "library-spawned child inherited blocked signals");
+}
+
+#[test]
+#[ignore = "needs an isolated Wayland host; scripts/e2e.sh --headless --test logout"]
+fn inherited_termination_masks_are_repaired_before_children_and_logout() {
+    let name = "logout-inherited-mask";
+    let dir = session_dir(name);
+    let pid_file = dir.join("child.pid");
+    let config = format!("autostart = [{}]\n", sleeper_command(&pid_file));
+    let inherited_mask = BlockedSignals::new();
+    let mut session = Session::boot(name, SessionOptions { config_extra: config, ..Default::default() }).unwrap();
+    drop(inherited_mask);
+    let child = Sleeper::ready(&pid_file);
+    assert_eq!(blocked(child.pid()) & TERMINATION_MASK, 0, "upgrade must clear the old compositor's inherited mask");
+    child.terminate(libc::SIGTERM);
+
+    signal(session.compositor_pid(), libc::SIGTERM);
+    let status = session.wait_for_compositor_exit(EVENT).unwrap();
+    assert!(status.success(), "logout after repairing an inherited mask must be clean: {status}");
+    assert!(session.log().contains("session termination requested; logging out cleanly"));
+}
+
+#[test]
+#[ignore = "needs an isolated Wayland host; scripts/e2e.sh --headless --test logout"]
+fn each_session_termination_signal_exits_the_compositor_cleanly() {
+    for termination in [libc::SIGTERM, libc::SIGHUP, libc::SIGINT] {
+        let mut session = Session::boot(&format!("logout-signal-{termination}"), SessionOptions::default()).unwrap();
+        signal(session.compositor_pid(), termination);
+        let status = session.wait_for_compositor_exit(EVENT).unwrap();
+        assert!(status.success(), "signal {termination} must request logout, not crash: {status}");
+        assert!(session.log().contains("session termination requested; logging out cleanly"));
+    }
+}

--- a/crates/chonk-testkit/tests/supervisor.rs
+++ b/crates/chonk-testkit/tests/supervisor.rs
@@ -538,7 +538,7 @@ fn terminating_the_real_compositor_is_a_clean_logout() {
     unsafe { libc::kill(session.compositor_pid() as i32, libc::SIGTERM) };
     let status = session
         .wait_for_compositor_exit(Duration::from_secs(10))
-        .expect("the signalfd handler must end the event loop");
+        .expect("the termination handler must end the event loop");
     assert!(status.success(), "SIGTERM is a requested logout, not a crash: {status}");
     assert!(
         session.log().contains("session termination requested; logging out cleanly"),

--- a/crates/wm-core/src/manager.rs
+++ b/crates/wm-core/src/manager.rs
@@ -81,19 +81,17 @@ struct ActiveMove {
     grab_offset: Point,
 }
 
-/// An in-progress edge/corner resize drag. `start_frame` is the frame's
-/// own geometry at press time — every motion event recomputes the new
-/// size fresh from it and the current pointer position rather than
-/// accumulating deltas
-/// (same "no drift" reasoning as `ActiveMove::grab_offset`), anchored
-/// at whichever corner/edge doesn't move for `edge`: the theme this WM
-/// ships only ever offers south-facing handles (`South`/`SouthEast`/
-/// `SouthWest`), so the top edge is always the fixed anchor and only
-/// which horizontal edge is fixed varies.
+/// An edge/corner resize drag. Every motion recomputes geometry from the
+/// starting frame, preserving the opposite edge rather than accumulating
+/// deltas. Client requests also retain the pointer's offset from the edge.
 struct ActiveResize {
     client: ClientId,
     edge: ResizeEdge,
     start_frame: Rect,
+    /// Client resize handles may sit inside or outside window geometry.
+    /// Preserve that offset instead of jumping the edge under the pointer.
+    /// Server chrome and modifier drags retain their edge-position behavior.
+    start_pointer: Option<Point>,
 }
 
 /// A titlebar button currently held down (pressed but not yet
@@ -2418,7 +2416,7 @@ impl<B: Backend> WindowManager<B> {
                     ),
                     size: client.layout.frame_size,
                 };
-                self.active_resize = Some(ActiveResize { client: id, edge, start_frame });
+                self.active_resize = Some(ActiveResize { client: id, edge, start_frame, start_pointer: None });
                 self.begin_drag_grab();
             }
             _ => {}
@@ -2630,6 +2628,22 @@ impl<B: Backend> WindowManager<B> {
         let overhead_h = client.layout.frame_size.h.saturating_sub(client.geometry.size.h);
         let start_right = start_frame.pos.x + start_frame.size.w as i32;
         let start_bottom = start_frame.pos.y + start_frame.size.h as i32;
+        let root = if let Some(pointer) = active.start_pointer {
+            let dx = root.x.saturating_sub(pointer.x);
+            let dy = root.y.saturating_sub(pointer.y);
+            Point::new(
+                match edge {
+                    ResizeEdge::West | ResizeEdge::NorthWest | ResizeEdge::SouthWest => start_frame.pos.x.saturating_add(dx),
+                    _ => start_right.saturating_add(dx),
+                },
+                match edge {
+                    ResizeEdge::North | ResizeEdge::NorthWest | ResizeEdge::NorthEast => start_frame.pos.y.saturating_add(dy),
+                    _ => start_bottom.saturating_add(dy),
+                },
+            )
+        } else {
+            root
+        };
         let anchor = Point::new(
             start_frame.pos.x + start_frame.size.w as i32 / 2,
             start_frame.pos.y + start_frame.size.h as i32 / 2,
@@ -4144,7 +4158,7 @@ impl<B: Backend> WindowManager<B> {
                     Point::new(local.x + offset.x, local.y + offset.y),
                 );
                 self.active_resize =
-                    Some(ActiveResize { client: id, edge, start_frame: Rect { pos: frame_pos, size: frame_size } });
+                    Some(ActiveResize { client: id, edge, start_frame: Rect { pos: frame_pos, size: frame_size }, start_pointer: None });
                 self.begin_drag_grab();
                 tracing::debug!(?id, ?edge, "modifier-drag resize begun");
             }
@@ -4269,6 +4283,9 @@ impl<B: Backend> WindowManager<B> {
         let Some(&id) = self.window_index.get(&window) else {
             return;
         };
+        let Some(pointer) = self.backend.pointer_position().or(self.last_pointer) else {
+            return;
+        };
         let Some(client) = self.clients.get(id) else {
             return;
         };
@@ -4282,7 +4299,7 @@ impl<B: Backend> WindowManager<B> {
             ),
             size: client.layout.frame_size,
         };
-        self.active_resize = Some(ActiveResize { client: id, edge, start_frame });
+        self.active_resize = Some(ActiveResize { client: id, edge, start_frame, start_pointer: Some(pointer) });
         // Without the grab this resize could start but never end — the
         // client asked precisely because the pointer is over its own
         // chrome, where neither the motion nor the release reach us.
@@ -6911,6 +6928,60 @@ mod tests {
     }
 
     #[test]
+    fn client_resize_preserves_the_grab_offset_at_every_edge() {
+        use ResizeEdge::*;
+        for framed in [false, true] {
+            for gap in [-6, 12] {
+                for edge in [North, NorthEast, East, SouthEast, South, SouthWest, West, NorthWest] {
+                    let mut backend = FakeBackend::new();
+                    let window = backend.create_window();
+                    backend.set_geometry(window, Rect::new(Point::new(100, 100), Size::new(400, 300)));
+                    backend.set_client_draws_own_chrome(window, !framed);
+                    let mut wm = wm(backend);
+                    wm.dispatch(BackendEvent::MapRequest(window));
+                    let id = wm.client_for_window(window).unwrap();
+                    let before = wm.client(id).unwrap().geometry;
+                    let frame = client_frame_rect(wm.client(id).unwrap());
+                    let west = matches!(edge, West | NorthWest | SouthWest);
+                    let east = matches!(edge, East | NorthEast | SouthEast);
+                    let north = matches!(edge, North | NorthWest | NorthEast);
+                    let south = matches!(edge, South | SouthWest | SouthEast);
+                    let pointer = Point::new(
+                        frame.pos.x + if west { -gap } else if east { frame.size.w as i32 + gap } else { 100 },
+                        frame.pos.y + if north { -gap } else if south { frame.size.h as i32 + gap } else { 100 },
+                    );
+                    wm.dispatch(BackendEvent::PointerMotion { root: pointer, surface_local: None });
+                    wm.dispatch(BackendEvent::ResizeRequest { window, edge });
+                    wm.dispatch(BackendEvent::PointerMotion { root: pointer, surface_local: None });
+                    assert_eq!(wm.client(id).unwrap().geometry, before, "no jump: {edge:?}, gap={gap}, framed={framed}");
+                    wm.dispatch(BackendEvent::PointerMotion {
+                        root: Point::new(pointer.x + 30, pointer.y + 20), surface_local: None,
+                    });
+                    let expected = Rect::new(
+                        Point::new(before.pos.x + if west { 30 } else { 0 }, before.pos.y + if north { 20 } else { 0 }),
+                        Size::new(
+                            (before.size.w as i32 + if west { -30 } else if east { 30 } else { 0 }) as u32,
+                            (before.size.h as i32 + if north { -20 } else if south { 20 } else { 0 }) as u32,
+                        ),
+                    );
+                    assert_eq!(wm.client(id).unwrap().geometry, expected, "{edge:?}, gap={gap}, framed={framed}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn client_resize_without_a_pointer_position_cannot_start() {
+        let mut backend = FakeBackend::new();
+        let window = backend.create_window();
+        let mut wm = wm(backend);
+        wm.dispatch(BackendEvent::MapRequest(window));
+        wm.dispatch(BackendEvent::ResizeRequest { window, edge: ResizeEdge::SouthEast });
+        assert!(!wm.interactive_drag_active());
+        assert_eq!(wm.backend().outstanding_pointer_grabs, 0);
+    }
+
+    #[test]
     fn a_drag_whose_window_disappears_gives_the_pointer_back() {
         // The other way a leaked grab happens: the dragged client dies
         // mid-drag. A pointer grab with nothing left to move is a
@@ -7532,6 +7603,10 @@ mod tests {
         wm.set_workarea(Rect::new(Point::new(0, 40), Size::new(800, 560)));
         let window = wm.client(id).unwrap().window;
         let before = wm.backend().last_frame_geometry[&frame];
+        wm.dispatch(BackendEvent::PointerMotion {
+            root: Point::new(100, before.pos.y - 12),
+            surface_local: None,
+        });
         wm.dispatch(BackendEvent::ResizeRequest {
             window,
             edge: ResizeEdge::North,

--- a/crates/wm-wayland/Cargo.toml
+++ b/crates/wm-wayland/Cargo.toml
@@ -13,13 +13,13 @@ default = []
 profile = ["dep:profiling", "profiling/profile-with-tracing"]
 # Diagnostic builds only: Rust allocation accounting and allocator/cache
 # snapshots over the opt-in test door. Never use these builds for timing claims.
-memory-profile = ["dep:libc"]
+memory-profile = []
 
 # Linux-only by nature: on other hosts this crate compiles to an empty
 # library (see lib.rs's cfg gate) so the whole workspace still builds
 # and tests on a macOS dev machine.
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = { version = "0.2", optional = true }
+libc = "0.2"
 wm-core = { path = "../wm-core" }
 wm-theme = { path = "../wm-theme" }
 wm-theme-api = { path = "../wm-theme-api" }
@@ -57,10 +57,10 @@ profiling = { version = "1.0", default-features = false, optional = true }
 # its blocking facade owns a small off-loop service thread and sends
 # only policy edges into calloop (see `inhibit_bus.rs`).
 zbus = "5.19"
-# Smithay reexports this same version; enabling its Linux signalfd
-# source lets TERM/HUP/INT enter the compositor event loop and receive
-# orderly logout teardown.
-calloop = { version = "0.14", features = ["signals"] }
+# Self-pipe signal handlers wake calloop without blocking termination
+# signals in every application and helper the compositor launches.
+calloop = "0.14"
+signal-hook = { version = "0.4", default-features = false }
 # Screenshot encoding (see `capture.rs`) - the same rasterizer the
 # theme engine draws with, so no second image stack enters the graph.
 tiny-skia = "0.11"

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -878,9 +878,9 @@ fn record(output: &str, geometry: &str, filter: &str) -> Result<Recording, Strin
     };
     // Software H.264 is intentional: no VAAPI/NVIDIA assumption on Apple
     // Silicon / Asahi. Pad odd selections instead of dropping their last row.
-    // calloop uses signalfd, so children inherit blocked INT/TERM/HUP. GNU env
-    // resets their disposition AND mask before exec; otherwise Stop would hang
-    // until the hard timeout despite delivering SIGINT to the correct process.
+    // Keep the recorder's explicit signal defaults for its SIGINT stop path.
+    // General child signal delivery is established by termination.rs; this
+    // older recorder-specific boundary also resets ignored dispositions.
     let child = Command::new("env")
         .args(["--default-signal=INT,TERM,HUP", "wf-recorder"])
         .args([

--- a/crates/wm-wayland/src/input.rs
+++ b/crates/wm-wayland/src/input.rs
@@ -2863,7 +2863,12 @@ fn hit_at(backend: &WaylandBackend, at: Point, position: LogicalPoint<f64, Logic
             if let Some(hit) = popup_hit(backend, None, *window, record, position) {
                 return hit;
             }
-            if frameless_claims(record.content, record.content_offset, at) {
+            // Native clients declare their input region independently of
+            // window geometry. GTK's resize handles live outside that
+            // geometry; the rest of its shadow explicitly declines input.
+            // Let the surface tree decide, at the client's actual scale.
+            // XWayland retains its X11 window-rectangle boundary.
+            if matches!(&record.surface, ManagedSurface::Xdg(_)) || record.content.contains(at) {
                 if let Some(hit) = content_hit(backend, None, *window, position) {
                     return hit;
                 }
@@ -3137,44 +3142,11 @@ enum Hit {
     Root,
 }
 
-/// How far outside its declared window geometry a client-decorated
-/// window still owns the pointer, so its own resize grips are
-/// grabbable at the visible edge rather than only strictly inside it.
-/// GTK puts the grip band for `xdg_toplevel.resize` in the shadow
-/// margin just *outside* the window geometry; a boundary drawn exactly
-/// at the geometry would make edge-resize of such a window a
-/// pixel-hunt for the sliver of grip that overlaps the window itself.
-const RESIZE_MARGIN: i32 = 8;
-
-/// Whether a client-decorated window owns the point `at` — the
-/// boundary of ownership for a window whose buffer is larger than the
-/// window it declared.
-///
-/// The declared `xdg_surface.set_window_geometry` rect (`content`) is
-/// the boundary, give or take the resize margin above; the rest of the
-/// buffer is drop shadow, and a shadow that answered the hit-test
-/// would both start drags anchored up to its width away from the
-/// visible edge and swallow clicks meant for whatever the shadow is
-/// painted over. `shadow` is the window's `content_offset` — how much
-/// buffer extends past the geometry — and clamps the margin, so a
-/// window with no shadow claims exactly its own rectangle and never a
-/// band of its neighbour's pixels: the margin is only ever carved out
-/// of space the client is already drawing (translucently) into.
-fn frameless_claims(content: Rect, shadow: Point, at: Point) -> bool {
-    let margin_x = RESIZE_MARGIN.min(shadow.x.max(0));
-    let margin_y = RESIZE_MARGIN.min(shadow.y.max(0));
-    at.x >= content.pos.x - margin_x
-        && at.y >= content.pos.y - margin_y
-        && at.x < content.pos.x + content.size.w as i32 + margin_x
-        && at.y < content.pos.y + content.size.h as i32 + margin_y
-}
-
-/// Content hit for a window whose content rect contains the point:
-/// resolves the exact wl_surface (subsurfaces included) to hand the
-/// seat. Falls back to the root surface when the tree walk declines the
-/// point (a client buffer briefly smaller than its configured rect
-/// mid-resize) — coordinates a little outside the buffer are what X11
-/// delivered in that gap too, and clients cope.
+/// Resolves the exact wl_surface (subsurfaces included) to hand the seat.
+/// A frameless native window owns only points accepted by its surface tree's
+/// input regions, including resize handles outside its window geometry.
+/// Framed and X11 callers already bound the point to their content rectangle;
+/// those retain the root fallback during a buffer/configure size mismatch.
 fn content_hit(
     backend: &WaylandBackend,
     frame: Option<WlFrameId>,
@@ -3195,10 +3167,16 @@ fn content_hit(
         Some(root) => {
             let scale = backend.window_surface_scale(record);
             let probe = surface_probe(anchor, position, scale);
-            let (surface, found) = under_from_surface_tree(
+            let hit = under_from_surface_tree(
                 root, probe, (content_origin.x, content_origin.y), WindowSurfaceType::ALL,
-            ).map(|(surface, found)| (surface, found.to_f64()))
-                .unwrap_or_else(|| (root.clone(), anchor));
+            );
+            let (surface, found) = match hit {
+                Some((surface, found)) => (surface, found.to_f64()),
+                // Do not undo an input-region rejection by focusing the
+                // root anyway: that steals clicks through shadows/holes.
+                None if frame.is_none() && matches!(&record.surface, ManagedSurface::Xdg(_)) => return None,
+                None => (root.clone(), anchor),
+            };
             let (surface, origin) = SurfaceTarget::from_tree(surface, anchor, found, scale, position);
             (Some(surface), origin)
         }
@@ -3853,62 +3831,9 @@ mod tests {
         assert!(!grab.anchor_alive(&backend), "the frame is not in the ledger");
     }
 
-    // -- shadow-band ownership ---------------------------------------
-    // The boundary rule for a client-decorated window whose buffer is
-    // bigger than the window it declared. Pinned with GTK's real
-    // numbers (LibreOffice's template dialog declares
-    // `set_window_geometry(26, 23, 818, 651)`), because the failure on
-    // either side of the line is user-visible: claim the shadow and a
-    // press in thin air starts a drag on this window instead of the
-    // one visibly under it; claim strictly the geometry and the
-    // client's own edge grips are a pixel-hunt.
-
-    #[test]
-    fn the_declared_window_geometry_is_owned_and_the_shadow_is_not() {
-        let content = Rect { pos: Point::new(200, 100), size: Size::new(818, 651) };
-        let shadow = Point::new(26, 23);
-        // Inside the window, corners included.
-        assert!(frameless_claims(content, shadow, Point::new(200, 100)));
-        assert!(frameless_claims(content, shadow, Point::new(1017, 750)));
-        // The far reaches of the shadow band fall through to whatever
-        // is beneath — this is the click the shadow used to steal.
-        assert!(!frameless_claims(content, shadow, Point::new(200 - 26, 100)));
-        assert!(!frameless_claims(content, shadow, Point::new(200, 100 - 23)));
-        assert!(!frameless_claims(content, shadow, Point::new(1017 + 26, 750)));
-    }
-
-    #[test]
-    fn a_thin_grip_band_of_the_shadow_still_belongs_to_the_window() {
-        let content = Rect { pos: Point::new(200, 100), size: Size::new(818, 651) };
-        let shadow = Point::new(26, 23);
-        // Just outside the visible edge: the client's resize grip.
-        assert!(frameless_claims(content, shadow, Point::new(200 - RESIZE_MARGIN, 100)));
-        assert!(frameless_claims(content, shadow, Point::new(200, 100 - RESIZE_MARGIN)));
-        assert!(frameless_claims(
-            content,
-            shadow,
-            Point::new(200 + 818 + RESIZE_MARGIN - 1, 100 + 651 + RESIZE_MARGIN - 1),
-        ));
-        // One past the margin is shadow again.
-        assert!(!frameless_claims(content, shadow, Point::new(200 - RESIZE_MARGIN - 1, 100)));
-    }
-
-    /// A window with no declared shadow claims exactly its rectangle:
-    /// the margin is carved out of the client's own oversized buffer,
-    /// never out of a neighbour's pixels.
-    #[test]
-    fn no_shadow_means_no_margin() {
-        let content = Rect { pos: Point::new(50, 50), size: Size::new(100, 100) };
-        let none = Point::new(0, 0);
-        assert!(frameless_claims(content, none, Point::new(50, 50)));
-        assert!(!frameless_claims(content, none, Point::new(49, 50)));
-        assert!(!frameless_claims(content, none, Point::new(50, 150)));
-        // A shadow thinner than the margin clamps the claim to the
-        // shadow — there is no buffer past it to press on.
-        let thin = Point::new(3, 3);
-        assert!(frameless_claims(content, thin, Point::new(47, 50)));
-        assert!(!frameless_claims(content, thin, Point::new(46, 50)));
-    }
+    // Client input regions are exercised over the wire in
+    // chonk-testkit/tests/client_input_regions.rs, including scaled resize
+    // bands, asymmetric shadows, and input holes.
 
     // -- pointer position mirror -------------------------------------
 

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -61,6 +61,7 @@ mod gesture_scene;
 mod layout_scene;
 mod selection;
 mod session;
+mod termination;
 mod state;
 // End-to-end test injection door — inert unless CHONKSTEP_TEST_SOCKET
 // is set; see its module docs for the three regressions it exists for.

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -36,7 +36,6 @@ use std::os::fd::{BorrowedFd, RawFd};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use calloop::signals::{Signal, Signals};
 use smithay::backend::allocator::Fourcc;
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::memory::MemoryRenderBuffer;
@@ -3588,19 +3587,9 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     let mut event_loop: EventLoop<Compositor> = EventLoop::try_new()?;
     let loop_handle = event_loop.handle();
 
-    // A display-manager/session-scope stop is a logout, not a crash.
-    // signalfd integrates the three ordinary termination signals into
-    // the same event loop as every protocol client, so teardown below
-    // runs in order and `main` returns success. SIGABRT is deliberately
-    // absent: the panic hook uses it as the watchdog's crash signal.
-    loop_handle.insert_source(
-        Signals::new(&[Signal::SIGTERM, Signal::SIGHUP, Signal::SIGINT])?,
-        |event, &mut (), comp| {
-            tracing::info!(signal = ?event.signal(), "session termination requested; logging out cleanly");
-            comp.restart = false;
-            comp.running = false;
-        },
-    )?;
+    // Keep registration alive through teardown. Children inherit ordinary
+    // signal delivery, while session stops still run the event-loop cleanup.
+    let _termination = crate::termination::install(&loop_handle)?;
 
     let display: Display<Compositor> = Display::new()?;
     let display_handle = display.handle();

--- a/crates/wm-wayland/src/termination.rs
+++ b/crates/wm-wayland/src/termination.rs
@@ -1,0 +1,77 @@
+//! Session termination must not disable signal delivery in launched apps.
+//!
+//! A signalfd source blocks signals on its thread. Every later worker and
+//! child inherits that mask, and exec preserves it: udiskie, shell helpers,
+//! and even `uwsm stop` could then wait until systemd's kill timeout. A
+//! self-pipe handler instead wakes calloop with ordinary signal delivery;
+//! exec resets caught handlers automatically, including in library-spawned
+//! children such as XWayland. All teardown stays outside the signal handler.
+//! SIGABRT remains unhandled: a panic must still reach the crash supervisor.
+
+use std::io::{self, Read};
+use std::os::unix::net::UnixStream;
+
+use signal_hook::{consts::signal::{SIGHUP, SIGINT, SIGTERM}, SigId};
+use smithay::reexports::calloop::{generic::Generic, Interest, LoopHandle, Mode, PostAction};
+
+use crate::state::Compositor;
+
+/// Unregisters even after a partially failed installation. The registered
+/// actions own their write descriptors; the event loop owns the reader.
+pub(crate) struct Registration(Vec<SigId>);
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        for id in self.0.drain(..) {
+            signal_hook::low_level::unregister(id);
+        }
+    }
+}
+
+pub(crate) fn install(handle: &LoopHandle<'_, Compositor>) -> Result<Registration, Box<dyn std::error::Error>> {
+    let (reader, writer) = UnixStream::pair()?;
+    reader.set_nonblocking(true)?;
+    writer.set_nonblocking(true)?;
+    let mut registration = Registration(Vec::new());
+    for signal in [SIGTERM, SIGHUP, SIGINT] {
+        registration.0.push(signal_hook::low_level::pipe::register(signal, writer.try_clone()?)?);
+    }
+    handle.insert_source(Generic::new(reader, Interest::READ, Mode::Level), |_, reader, comp| {
+        // A byte confirms a signal, even if several coalesced. Spurious
+        // readiness must not log out the user. Only the event loop logs and
+        // changes compositor state; the handler only writes to the pipe.
+        let mut bytes = [0; 64];
+        loop {
+            match (&**reader).read(&mut bytes) {
+                Ok(0) => return Ok(PostAction::Remove),
+                Ok(_) => break,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(PostAction::Continue),
+                Err(error) => return Err(error),
+            }
+        }
+        tracing::info!("session termination requested; logging out cleanly");
+        comp.restart = false;
+        comp.running = false;
+        Ok(PostAction::Continue)
+    })?;
+
+    // Older builds re-execed with signalfd's mask still blocked. Clear only
+    // our three signals, after their handlers are installed and before any
+    // workers or children start. This also repairs an inherited login mask.
+    // SAFETY: all pointers reference initialized, live sigset_t storage.
+    // pthread_sigmask changes only this calling thread's mask; installation
+    // runs at startup before the compositor creates its worker threads.
+    unsafe {
+        let mut signals: libc::sigset_t = std::mem::zeroed();
+        libc::sigemptyset(&mut signals);
+        for signal in [SIGTERM, SIGHUP, SIGINT] {
+            libc::sigaddset(&mut signals, signal);
+        }
+        let error = libc::pthread_sigmask(libc::SIG_UNBLOCK, &signals, std::ptr::null_mut());
+        if error != 0 {
+            return Err(io::Error::from_raw_os_error(error).into());
+        }
+    }
+    Ok(registration)
+}

--- a/docs/engineering/2026-09-07/logout-signal-inheritance.md
+++ b/docs/engineering/2026-09-07/logout-signal-inheritance.md
@@ -1,0 +1,86 @@
+# Logout stalled on inherited signal masks
+
+The logout requested from the Omarchy menu at 22:38:37 PDT on September 7
+closed windows promptly, but the desktop remained responsive while shutdown
+waited on background processes. This was a delayed logout, not a successful
+fix being activated: no logout changes had been applied at that point.
+
+## Evidence and cause
+
+The user journal records `uwsm stop` at 22:38:39. At 22:40:10, systemd killed
+`app-chonkstep-udiskie-34c46b02.scope` after its 90-second stop timeout. Only
+then did the compositor's service begin stopping. Its remaining `inotifywait`,
+`faked`, and `uwsm` processes caused another 10-second timeout. The session
+was stopped at 22:40:20; a new compositor session became active at 22:40:38.
+
+Live `/proc/*/status` checks in that new session showed the same `SigBlk`
+value, `0000000000004003`, in the compositor, udiskie, inotifywait, and faked.
+That is HUP, INT, and TERM. ChonkStep registered calloop's signalfd source
+before creating workers and launching applications. The blocked mask
+therefore reached all of those descendants. Linux preserves a signal mask
+across both fork and exec; see the [signal manual](https://man7.org/linux/man-pages/man7/signal.7.html).
+
+## Implementation and review
+
+`wm-wayland/src/termination.rs` replaces the signalfd source with
+[signal-hook's self-pipe registration](https://docs.rs/signal-hook/0.4.4/signal_hook/low_level/pipe/fn.register.html).
+The signal handler writes to a nonblocking socket; calloop reads it and sets
+the existing clean-logout flags. Children inherit normal signal delivery,
+and exec resets caught handlers, including for children spawned inside
+Smithay rather than through ChonkStep's launch helpers. SIGABRT retains its
+crash behavior.
+
+The three termination signals are explicitly unblocked after handler
+registration and before workers start. This handles an upgrade via exec from
+the old compositor, which left those signals blocked. Unrelated blocked
+signals are preserved. Registration owns its handlers and releases them on
+partial installation failure or normal teardown; the event loop owns the
+reader. Spurious readiness without a byte does not request logout. The
+handler contains no compositor state changes, logging, or blocking work.
+
+The recorder's existing explicit signal-default wrapper is retained. No
+systemd timeout or Omarchy logout script was changed.
+
+## Validation
+
+- The new application-inheritance regression failed against the previously
+  installed release, observing mask `0x4003` instead of zero.
+- All three new integration tests passed against both debug and optimized
+  release builds: autostart and interactive children receive termination
+  signals; Smithay's XWayland child has an unblocked termination mask;
+  inherited masks are repaired; HUP, INT, and TERM each produce a successful
+  compositor exit with the clean-logout log message.
+- An isolated scope launched by a nested compositor exercised the real
+  systemd user manager. With a three-second timeout used only for that probe,
+  the old release stopped in 3.052 seconds with `Result=timeout`. The fixed
+  debug build stopped in 0.006 seconds with `Result=success`. All probe
+  scopes were removed. The real desktop session was never stopped by this
+  experiment. Script, logs, and JSON results are in
+  `/tmp/chonkstep-logout-review/`.
+- `scripts/check.sh`: strict workspace Clippy and rustdoc passed; 2,054 Rust
+  tests and 65 Python harness tests passed. The display-dependent tests are
+  separate from those counts.
+- The existing real-compositor termination test passed. The four Pinta/CSD
+  input-region regressions also passed against the fixed optimized release.
+- A final strict Clippy pass covers the final regression-test cleanup changes.
+
+An exploratory nested hot-restart test exposed an existing limitation:
+`restart_in_place` retains the nested compositor's own `WAYLAND_DISPLAY`
+instead of restoring the host's display, so its replacement fails winit
+initialization. That separate issue is outside this change. The upgrade
+regression explicitly supplies the inherited blocked mask at startup; it
+does not claim to validate nested hot restart.
+
+## Deployment
+
+The tested optimized binary has SHA-256
+`a5ebb2c27597a761e10193e1b3d7eec79a65647e3ae552ca1e19fd461bb10085`.
+The binary was installed atomically after checking both the existing binary
+and the staged replacement. The previous binary is backed up in
+`/var/lib/chonkstep/local-backups/logout-20260908T061531Z/`.
+Installation evidence is in
+`~/.local/state/chonkstep/logout-update/install.log`.
+
+A fresh graphical login is required for all existing processes to receive
+the corrected behavior. Replacing the on-disk binary does not change the
+signal masks of the already running compositor or its old children.

--- a/docs/engineering/2026-09-07/pinta-window-controls.md
+++ b/docs/engineering/2026-09-07/pinta-window-controls.md
@@ -1,0 +1,96 @@
+# Pinta window controls
+
+The reported session ran packaged ChonkStep 0.4.3, Pinta 3.1.2, and GTK
+4.22.4 at output scale 2. Pinta drew its own header bar. Its modal About
+window was open, disabling the main window's controls. In an isolated
+session without About, the installed compositor successfully handled
+Pinta's maximize button and restore request.
+
+There were two compositor defects in edge resizing:
+
+1. `input.rs` limited frameless input to window geometry plus eight device
+   pixels. GTK declares a twelve-*logical*-pixel resize band outside the
+   window geometry through `wl_surface.set_input_region`. Most of that band
+   was unreachable at scale 2. The root-surface fallback also swallowed
+   points the client's input region explicitly excluded.
+2. Client-initiated resizing placed the dragged edge directly under the
+   pointer. Starting in the shadow therefore made the window jump by the
+   distance between the pointer and the visible edge.
+
+The native frameless path now uses the surface tree's input regions and
+existing coordinate transform, including subsurfaces and fractional scaling.
+Excluded pixels fall through the stacking order. Client-requested resizing
+records the initial pointer position and applies movement relative to it,
+preserving the opposite edge and the existing size-hint/workarea constraints.
+The decision applies to native windows generally; it uses no application list.
+
+GTK's input-shape calculation is in
+[`update_realized_window_properties`](https://github.com/GNOME/gtk/blob/4.22.4/gtk/gtkwindow.c).
+Window geometry and input regions have different purposes in the
+[xdg-shell](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/stable/xdg-shell/xdg-shell.xml)
+and [Wayland core](https://gitlab.freedesktop.org/wayland/wayland/-/blob/main/protocol/wayland.xml)
+protocols.
+
+## Regression evidence
+
+`client_input_regions` uses real Wayland clients and pointer events. Its
+three scale tests failed against `/usr/bin/chonkstep-wayland` before the fix:
+the first resize handle resolved to `root`, instead of `content`, at 1x,
+1.5x, and 2x. The corrected tests cover all eight handles, asymmetric shadow
+extents, exact client coordinates, input holes, out-of-buffer points, an
+authorized resize request, and release ending the resize. A separate
+overlapping-window test verifies delivery to the application underneath.
+
+The core offset test exercises all eight edges with grabs inside and outside
+the edge, on framed and frameless windows (32 cases). A stationary pointer
+must leave the original geometry unchanged; movement must preserve the
+opposite edge. A resize without a known pointer position is refused.
+
+Real Pinta was also driven in private headless Weston sessions at both 1x
+and 2x, with isolated application settings and a fresh unsaved image:
+
+| Scale | Maximize | Restore | Resize from 10 logical pixels outside the right edge |
+| --- | --- | --- | --- |
+| 1x | 1280 x 800 | 1100 x 750 | 1170 x 750 after 70 device pixels of movement |
+| 2x | 2560 x 1600 | 2200 x 1500 | 2340 x 1500 after 140 device pixels of movement |
+
+The application committed buffers matching those sizes. Screenshots confirmed
+one header bar with working window controls. Local diagnostic source, protocol
+logs, and screenshots were retained under `/tmp/chonkstep-pinta-review/`.
+The automated regression suite uses its own protocol fixture so CI does not
+depend on Pinta's packaging or GTK theme.
+
+Run the regression suite with:
+
+```sh
+scripts/e2e.sh --headless --test client_input_regions
+cargo test --locked -p wm-core --lib
+```
+
+Final validation passed:
+
+- `scripts/check.sh`: strict workspace Clippy, documentation, 2,054 Rust
+  tests, and 65 harness tests. The ordinary Rust run left 289 ignored tests;
+  it does not substitute for the separate integration runs.
+- 52 targeted integration tests across `client_input_regions`,
+  `interactive_request`, `pointer_coordinates`, `pointer_constraints`,
+  `xwayland_input`, GTK frameless resize, and Chromium resize at scale 2.
+- The four new integration tests repeated against the optimized release
+  compositor using `CHONKSTEP_WAYLAND_BIN`.
+- Both `chonkstep` and `chonkstep-wayland` built with `--release --locked`.
+
+The reviewed Wayland binary's build ID is
+`bd73d188050cf7f710fd48888f4b7836825d71c4`, with SHA-256
+`3654eaa7c0e9b4ea157749d9caa0e901f374f63a7e02b87ed2cd43c245cdea74`.
+After user approval, both release binaries were installed atomically in
+`/usr/bin` and ChonkStep was restarted. The previous binaries are backed up
+in `/var/lib/chonkstep/local-backups/window-controls-20260908T053407Z/`.
+The running compositor's `/proc/1343/exe` hash matches the reviewed binary;
+its new IPC endpoint reports DP-1 at 3840 x 2160 and scale 2. Installation
+and restart verification logs are in
+`~/.local/state/chonkstep/window-controls-update/`.
+
+Applying a rebuilt compositor requires a new Wayland session or a restart.
+As documented in the README, restarting disconnects existing Wayland clients.
+The live Pinta document was left open during investigation; the restart was
+performed only after the user approved installing and restarting the build.


### PR DESCRIPTION
GTK applications such as Pinta could miss edge resize grips because ChonkStep clipped input to a hard-coded eight-pixel margin. A client-initiated resize could also jump to the pointer instead of preserving the initial grab offset. Native windows now use their surface input regions at the correct scale, let clicks pass through excluded shadows and holes, and resize relative to the initial pointer position.

Logout could leave the desktop responsive for roughly 100 seconds while systemd waited for background processes. The compositor's signalfd setup blocked HUP, INT, and TERM in subsequently launched applications and helpers. Self-pipe handlers now wake the compositor's event loop without passing that blocked mask to children; startup also repairs masks inherited from older builds. Clean logout and crash supervision retain their existing behavior.

The two fixes are separate commits. Regression tests cover all eight resize edges, 1x/1.5x/2x input regions, click-through, resize release, application and XWayland signal inheritance, inherited-mask repair, and clean exits for each termination signal.

Validation:

- On the rebased branch: `scripts/check.sh` passed strict Clippy, rustdoc, 2,054 Rust tests, and 65 Python harness tests.
- `scripts/e2e.sh --headless --test client_input_regions` and `scripts/e2e.sh --headless --test logout` passed all seven new integration tests. Both suites also passed against the original optimized 0.4.3 fix build.
- Real Pinta maximize/restore and edge resize were verified at 1x and 2x. Its disabled maximize controls were caused by the open About modal; no maximize-specific workaround was added.
- Both bugs were reproduced against the previous installed binary. An isolated systemd scope hit its three-second forced-kill timeout before the logout fix and stopped successfully in 6 ms afterward. Production timeouts were not changed.

Detailed evidence and deployment notes: [window controls](https://github.com/iconidentify/chonkstep/blob/facf999aa92a2bd06f8b411ec64e191bbb20fb6e/docs/engineering/2026-09-07/pinta-window-controls.md), [logout](https://github.com/iconidentify/chonkstep/blob/facf999aa92a2bd06f8b411ec64e191bbb20fb6e/docs/engineering/2026-09-07/logout-signal-inheritance.md).
