### PR TITLE
fix: harden compositor isolation, pacing, and lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,10 @@ jobs:
         # compiled client rather than a shell one-liner.
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb xterm x11-utils libx11-dev libgtk-3-bin
+          sudo apt-get install -y xvfb xauth xterm x11-utils libx11-dev libgtk-3-bin
+
+      - name: Reject oversized X11 application properties
+        run: xvfb-run -a cargo test --locked -p wm-x11 hostile_properties -- --ignored
 
       - name: Build release binaries
         run: cargo build --release -p chonkstep

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3408,6 +3408,7 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 name = "wm-config"
 version = "0.4.4"
 dependencies = [
+ "chonk-test-support",
  "regex",
  "serde",
  "toml",

--- a/crates/chonk-shell/src/appearance.rs
+++ b/crates/chonk-shell/src/appearance.rs
@@ -203,6 +203,8 @@ pub fn resolve(config_appearance: Option<&str>, theme_native: Appearance) -> App
 /// writing it is the one move that reaches GTK4/libadwaita, Electron
 /// and everything else watching `org.freedesktop.appearance
 /// color-scheme` — live, no restart.
+mod propagation;
+
 const GSETTINGS_SCHEMA: &str = "org.gnome.desktop.interface";
 
 /// GTK theme pairs this desktop is willing to publish, in preference
@@ -274,11 +276,9 @@ pub fn gtk_theme_name(mode: Appearance) -> Option<&'static str> {
 
 /// Tells foreign toolkits about the mode, off-thread.
 ///
-/// Two GSettings writes at most, run on a dedicated short-lived thread
-/// because reading the current `gtk-theme` back means waiting on a
-/// child, which is banned on the shell's thread (see `clippy.toml` —
-/// this is the same shape as the widget sampler workers). Switches are
-/// user gestures, so the thread count is bounded by fingers.
+/// One lazy worker serializes GSettings writes, retaining only the latest
+/// pending mode. Each helper has a deadline and bounded output; a stalled
+/// settings service cannot accumulate workers or reorder final preferences.
 ///
 /// - `color-scheme` is always set (`prefer-dark`/`prefer-light`): it
 ///   is a preference, not a theme name, and cannot dangle.
@@ -309,53 +309,52 @@ pub fn propagate_to_applications(mode: Appearance) {
         tracing::info!(mode = mode.name(), "appearance propagation to GSettings disabled by environment");
         return;
     }
-    std::thread::spawn(move || {
-        let scheme = match mode {
-            Appearance::Dark => "prefer-dark",
-            Appearance::Light => "prefer-light",
-        };
-        // Audited exception to `clippy.toml`'s ban on blocking child
-        // calls: this closure is the whole body of a thread spawned per
-        // user gesture; nothing waits on it, and a gsettings that never
-        // returns holds up one thread-sized allocation, not the shell.
-        #[allow(clippy::disallowed_methods)]
-        let run = |args: &[&str]| -> Option<std::process::Output> {
-            std::process::Command::new("gsettings")
-                .args(args)
-                .output()
-                .ok()
-        };
-        let set = run(&["set", GSETTINGS_SCHEMA, "color-scheme", scheme]);
-        match set {
-            Some(output) if output.status.success() => {
-                tracing::info!(scheme, "told GSettings the appearance (portal color-scheme follows)");
-            }
-            _ => {
-                // One line, as promised: covers both "no gsettings on
-                // this system" and "no org.gnome.desktop.interface
-                // schema installed".
-                tracing::warn!(scheme, "gsettings unavailable or schema missing; GTK/portal applications will not follow the appearance");
-                return;
-            }
+    propagation::submit(mode);
+}
+
+fn apply_to_applications(mode: Appearance) {
+    let scheme = match mode {
+        Appearance::Dark => "prefer-dark",
+        Appearance::Light => "prefer-light",
+    };
+    let run = |args: &[&str]| -> Option<String> {
+        let child = std::process::Command::new("gsettings")
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn().ok()?;
+        crate::widgets::sampling::wait_with_deadline(child, "gsettings", std::time::Duration::from_secs(2))
+    };
+    let set = run(&["set", GSETTINGS_SCHEMA, "color-scheme", scheme]);
+    match set {
+        Some(_) => {
+            tracing::info!(scheme, "told GSettings the appearance (portal color-scheme follows)");
         }
-        let Some((light, dark)) = gtk_theme_pair() else {
+        _ => {
+            // One line, as promised: covers both "no gsettings on
+            // this system" and "no org.gnome.desktop.interface
+            // schema installed".
+            tracing::warn!(scheme, "gsettings unavailable or schema missing; GTK/portal applications will not follow the appearance");
             return;
-        };
-        let Some(current) = run(&["get", GSETTINGS_SCHEMA, "gtk-theme"]) else {
-            return;
-        };
-        let current = String::from_utf8_lossy(&current.stdout).trim().trim_matches('\'').to_string();
-        if current == light || current == dark {
-            let next = match mode {
-                Appearance::Light => light,
-                Appearance::Dark => dark,
-            };
-            if current != next {
-                let _ = run(&["set", GSETTINGS_SCHEMA, "gtk-theme", next]);
-                tracing::info!(from = %current, to = %next, "flipped the managed GTK theme pair");
-            }
         }
-    });
+    }
+    let Some((light, dark)) = gtk_theme_pair() else {
+        return;
+    };
+    let Some(current) = run(&["get", GSETTINGS_SCHEMA, "gtk-theme"]) else {
+        return;
+    };
+    let current = current.trim().trim_matches('\'');
+    if current == light || current == dark {
+        let next = match mode {
+            Appearance::Light => light,
+            Appearance::Dark => dark,
+        };
+        if current != next && run(&["set", GSETTINGS_SCHEMA, "gtk-theme", next]).is_some() {
+            tracing::info!(from = %current, to = %next, "flipped the managed GTK theme pair");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/chonk-shell/src/appearance/propagation.rs
+++ b/crates/chonk-shell/src/appearance/propagation.rs
@@ -1,0 +1,117 @@
+//! Serialize external preference writes and coalesce pending switches. A slow
+//! helper must neither grow a thread queue nor let an old mode finish last.
+use std::sync::{Arc, Condvar, Mutex, OnceLock};
+use std::thread::JoinHandle;
+use wm_theme::Appearance;
+
+#[derive(Default)]
+struct Pending {
+    mode: Option<Appearance>,
+    closed: bool,
+}
+
+#[derive(Default)]
+struct Mailbox {
+    pending: Mutex<Pending>,
+    wake: Condvar,
+}
+
+struct Worker(Arc<Mailbox>);
+
+impl Worker {
+    fn start(
+        mut apply: impl FnMut(Appearance) + Send + 'static,
+    ) -> std::io::Result<(Self, JoinHandle<()>)> {
+        let shared = Arc::new(Mailbox::default());
+        let receiver = shared.clone();
+        let thread = std::thread::Builder::new()
+            .name("appearance".into())
+            .spawn(move || loop {
+                let mode = {
+                    let mut pending = receiver.pending.lock().unwrap();
+                    while pending.mode.is_none() && !pending.closed {
+                        pending = receiver.wake.wait(pending).unwrap();
+                    }
+                    if pending.closed {
+                        return;
+                    }
+                    pending.mode.take().unwrap()
+                };
+                // Never hold the mailbox while running an external command.
+                apply(mode);
+            })?;
+        Ok((Self(shared), thread))
+    }
+
+    fn submit(&self, mode: Appearance) {
+        self.0.pending.lock().unwrap().mode = Some(mode);
+        self.0.wake.notify_one();
+    }
+}
+
+impl Drop for Worker {
+    fn drop(&mut self) {
+        self.0.pending.lock().unwrap().closed = true;
+        self.0.wake.notify_one();
+    }
+}
+
+pub(super) fn submit(mode: Appearance) {
+    static WORKER: OnceLock<Option<Worker>> = OnceLock::new();
+    let worker = WORKER.get_or_init(|| match Worker::start(super::apply_to_applications) {
+        Ok((worker, _thread)) => Some(worker),
+        Err(error) => {
+            tracing::warn!(?error, "could not start appearance propagation worker");
+            None
+        }
+    });
+    if let Some(worker) = worker {
+        worker.submit(mode);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn a_busy_worker_keeps_only_the_latest_pending_mode_and_stops_on_drop() {
+        let (started, observed) = mpsc::channel();
+        let (release, proceed) = mpsc::channel();
+        let (worker, thread) = Worker::start(move |mode| {
+            started.send(mode).unwrap();
+            proceed.recv_timeout(Duration::from_secs(5)).unwrap();
+        })
+        .unwrap();
+        worker.submit(Appearance::Dark);
+        assert_eq!(
+            observed.recv_timeout(Duration::from_secs(5)).unwrap(),
+            Appearance::Dark
+        );
+        for _ in 0..10_000 {
+            worker.submit(Appearance::Light);
+            worker.submit(Appearance::Dark);
+        }
+        worker.submit(Appearance::Light);
+        assert_eq!(
+            observed.try_recv(),
+            Err(mpsc::TryRecvError::Empty),
+            "requests must not start concurrent writes"
+        );
+        release.send(()).unwrap();
+        assert_eq!(
+            observed.recv_timeout(Duration::from_secs(5)).unwrap(),
+            Appearance::Light
+        );
+        drop(worker);
+        release.send(()).unwrap();
+        assert_eq!(
+            observed.recv_timeout(Duration::from_secs(5)),
+            Err(mpsc::RecvTimeoutError::Disconnected),
+            "dropping the worker must terminate it, not merely time out"
+        );
+        thread.join().unwrap();
+    }
+}

--- a/crates/chonk-shell/src/widgets/sampling.rs
+++ b/crates/chonk-shell/src/widgets/sampling.rs
@@ -537,7 +537,7 @@ const SAMPLE_OUTPUT_LIMIT: usize = 4 * 1024 * 1024;
 /// for exit first deadlocks any legitimate reply larger than the pipe
 /// buffer; reading to EOF after exit can block forever if a descendant
 /// inherited stdout. Exit and EOF must both arrive before one deadline.
-fn wait_with_deadline(mut child: std::process::Child, program: &str, deadline: Duration) -> Option<String> {
+pub(crate) fn wait_with_deadline(mut child: std::process::Child, program: &str, deadline: Duration) -> Option<String> {
     use std::io::{ErrorKind, Read};
     use std::os::fd::AsRawFd;
 

--- a/crates/chonk-testkit/tests/logout.rs
+++ b/crates/chonk-testkit/tests/logout.rs
@@ -171,3 +171,28 @@ fn each_session_termination_signal_exits_the_compositor_cleanly() {
         assert!(session.log().contains("session termination requested; logging out cleanly"));
     }
 }
+
+#[test]
+#[ignore = "needs an isolated Wayland host; scripts/e2e.sh --headless --test logout"]
+fn repeated_nested_restarts_reconnect_to_the_host_and_keep_logout_working() {
+    let name = "logout-after-reexec";
+    let dir = session_dir(name);
+    let pid_file = dir.join("child.pid");
+    let config = format!("autostart = [{}]\n", sleeper_command(&pid_file));
+    let mut session = Session::boot(name, SessionOptions { config_extra: config, ..Default::default() }).unwrap();
+    let compositor = session.compositor_pid();
+    for _ in 0..2 {
+        let child = Sleeper::ready(&pid_file);
+        assert_eq!(blocked(child.pid()) & TERMINATION_MASK, 0);
+        child.terminate(libc::SIGTERM);
+        std::fs::remove_file(&pid_file).unwrap();
+        std::fs::write(dir.join("state/chonkstep/restart"), []).unwrap();
+        poll_until(EVENT, "the restarted compositor to autostart its child", || {
+            pid_file.exists().then_some(())
+        }).unwrap_or_else(|error| panic!("{error}\n{}", session.log()));
+        assert_eq!(session.compositor_pid(), compositor, "restart must exec in place");
+    }
+    Sleeper::ready(&pid_file).terminate(libc::SIGTERM);
+    signal(compositor, libc::SIGTERM);
+    assert!(session.wait_for_compositor_exit(EVENT).unwrap().success());
+}

--- a/crates/chonk-testkit/tests/security_context.rs
+++ b/crates/chonk-testkit/tests/security_context.rs
@@ -1,0 +1,214 @@
+//! Registry and forged-bind checks through an actual security-context listener.
+use chonk_testkit::{Session, SessionOptions};
+use rustix::event::{poll, PollFd, PollFlags, Timespec};
+use std::collections::HashMap;
+use std::os::fd::AsFd;
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::time::{Duration, Instant};
+use wayland_client::protocol::{wl_callback, wl_compositor, wl_registry, wl_surface};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+use wayland_protocols::wp::security_context::v1::client::{
+    wp_security_context_manager_v1, wp_security_context_v1,
+};
+use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1;
+
+#[derive(Default)]
+struct Registry {
+    globals: HashMap<String, (u32, u32)>,
+    done: bool,
+}
+impl Dispatch<wl_registry::WlRegistry, ()> for Registry {
+    fn event(
+        state: &mut Self,
+        _: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global {
+            name,
+            interface,
+            version,
+        } = event
+        {
+            state.globals.insert(interface, (name, version));
+        }
+    }
+}
+impl Dispatch<wl_callback::WlCallback, ()> for Registry {
+    fn event(
+        state: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        state.done = true;
+    }
+}
+macro_rules! ignore_events {
+    ($($proxy:ty),* $(,)?) => {$(
+        impl Dispatch<$proxy, ()> for Registry {
+            fn event(_: &mut Self, _: &$proxy, _: <$proxy as Proxy>::Event,
+                _: &(), _: &Connection, _: &QueueHandle<Self>) {}
+        }
+    )*};
+}
+ignore_events!(
+    wp_security_context_manager_v1::WpSecurityContextManagerV1,
+    wp_security_context_v1::WpSecurityContextV1,
+    wl_compositor::WlCompositor,
+    wl_surface::WlSurface,
+    zwlr_layer_shell_v1::ZwlrLayerShellV1
+);
+
+struct Client {
+    connection: Connection,
+    queue: EventQueue<Registry>,
+    state: Registry,
+    registry: wl_registry::WlRegistry,
+}
+impl Client {
+    fn connect(stream: UnixStream) -> Self {
+        let connection = Connection::from_socket(stream).unwrap();
+        let queue = connection.new_event_queue();
+        let registry = connection.display().get_registry(&queue.handle(), ());
+        let mut client = Self {
+            connection,
+            queue,
+            state: Registry::default(),
+            registry,
+        };
+        client.sync().unwrap();
+        client
+    }
+    fn sync(&mut self) -> Result<(), String> {
+        self.state.done = false;
+        self.connection.display().sync(&self.queue.handle(), ());
+        self.connection.flush().map_err(|e| e.to_string())?;
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !self.state.done {
+            self.queue
+                .dispatch_pending(&mut self.state)
+                .map_err(|e| e.to_string())?;
+            if self.state.done {
+                break;
+            }
+            if Instant::now() >= deadline {
+                return Err("private display sync timed out".into());
+            }
+            if let Some(reader) = self.queue.prepare_read() {
+                let timeout = Timespec::try_from(Duration::from_millis(10)).unwrap();
+                if poll(
+                    &mut [PollFd::new(&self.connection, PollFlags::IN)],
+                    Some(&timeout),
+                )
+                .unwrap()
+                    != 0
+                {
+                    reader.read().map_err(|e| e.to_string())?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[test]
+#[ignore = "needs nested Wayland: scripts/e2e.sh --headless --test security_context"]
+fn confined_clients_keep_application_globals_but_cannot_bind_desktop_privileges() {
+    let session = Session::boot("security-context-boundary", SessionOptions::default()).unwrap();
+    let socket = std::path::PathBuf::from(std::env::var_os("XDG_RUNTIME_DIR").unwrap())
+        .join(&session.wayland_display);
+    let mut creator = Client::connect(UnixStream::connect(socket).unwrap());
+    let (name, _) = creator.state.globals["wp_security_context_manager_v1"];
+    let manager: wp_security_context_manager_v1::WpSecurityContextManagerV1 =
+        creator.registry.bind(name, 1, &creator.queue.handle(), ());
+    let path = session.dir.join("confined.sock");
+    let listener = UnixListener::bind(&path).unwrap();
+    let (close_fd, _keep_open) = UnixStream::pair().unwrap();
+    let context = manager.create_listener(
+        listener.as_fd(),
+        close_fd.as_fd(),
+        &creator.queue.handle(),
+        (),
+    );
+    context.set_sandbox_engine("audit-test".into());
+    context.set_app_id("org.chonkstep.confined-probe".into());
+    context.commit();
+    creator.sync().unwrap();
+    let mut confined = Client::connect(UnixStream::connect(&path).unwrap());
+    for interface in [
+        "wl_compositor",
+        "wl_shm",
+        "wl_seat",
+        "wl_output",
+        "xdg_wm_base",
+        "wl_data_device_manager",
+    ] {
+        assert!(
+            confined.state.globals.contains_key(interface),
+            "ordinary application capability missing: {interface}"
+        );
+    }
+    for interface in [
+        "wp_security_context_manager_v1",
+        "zwlr_layer_shell_v1",
+        "ext_session_lock_manager_v1",
+        "zwlr_screencopy_manager_v1",
+        "ext_image_copy_capture_manager_v1",
+        "zwlr_data_control_manager_v1",
+        "ext_data_control_manager_v1",
+        "zwp_virtual_keyboard_manager_v1",
+        "zwlr_virtual_pointer_manager_v1",
+        "zwlr_output_manager_v1",
+        "zwlr_foreign_toplevel_manager_v1",
+        "zwp_input_method_manager_v2",
+    ] {
+        assert!(
+            creator.state.globals.contains_key(interface),
+            "test must exercise an implemented global: {interface}"
+        );
+        assert!(
+            !confined.state.globals.contains_key(interface),
+            "sandbox escaped through {interface}"
+        );
+    }
+    // These are advertised only by the native DRM backend. The shared
+    // predicate still covers their bind implementations; a nested run cannot
+    // pretend to exercise native-only globals.
+    for interface in [
+        "zwlr_output_power_manager_v1",
+        "zwlr_gamma_control_manager_v1",
+    ] {
+        if creator.state.globals.contains_key(interface) {
+            assert!(!confined.state.globals.contains_key(interface));
+        }
+    }
+    let (name, _) = confined.state.globals["wl_compositor"];
+    let compositor: wl_compositor::WlCompositor =
+        confined
+            .registry
+            .bind(name, 4, &confined.queue.handle(), ());
+    compositor
+        .create_surface(&confined.queue.handle(), ())
+        .commit();
+    confined.sync().unwrap();
+    // Knowing a global's numeric ID from an ordinary connection must not
+    // bypass the registry filter when a confined connection forges a bind.
+    let (name, _) = creator.state.globals["zwlr_layer_shell_v1"];
+    let _: zwlr_layer_shell_v1::ZwlrLayerShellV1 =
+        confined
+            .registry
+            .bind(name, 1, &confined.queue.handle(), ());
+    let error = confined
+        .sync()
+        .expect_err("forged privileged bind must disconnect the confined client");
+    assert!(
+        !error.contains("timed out"),
+        "a timeout is not proof of bind rejection"
+    );
+    creator.sync().unwrap();
+}

--- a/crates/chonk-testkit/tests/surface_pacing.rs
+++ b/crates/chonk-testkit/tests/surface_pacing.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use std::collections::{HashMap, HashSet};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::os::fd::AsFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
@@ -12,7 +12,8 @@ use std::time::{Duration, Instant};
 use chonk_testkit::{keys, poll_until, profile_binary, Session, SessionOptions};
 use rustix::event::{poll, PollFd, PollFlags, Timespec};
 use wayland_client::protocol::{
-    wl_buffer, wl_callback, wl_compositor, wl_registry, wl_shm, wl_shm_pool, wl_surface,
+    wl_buffer, wl_callback, wl_compositor, wl_region, wl_registry, wl_shm, wl_shm_pool,
+    wl_subcompositor, wl_subsurface, wl_surface,
 };
 use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
 use wayland_protocols::wp::commit_timing::v1::client::{
@@ -28,6 +29,7 @@ const EVENT: Duration = Duration::from_secs(5);
 struct Probe {
     compositor: Option<wl_compositor::WlCompositor>,
     shm: Option<wl_shm::WlShm>,
+    subcompositor: Option<wl_subcompositor::WlSubcompositor>,
     shell: Option<xdg_wm_base::XdgWmBase>,
     fifo: Option<wp_fifo_manager_v1::WpFifoManagerV1>,
     timing: Option<wp_commit_timing_manager_v1::WpCommitTimingManagerV1>,
@@ -60,6 +62,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Probe {
                     state.compositor = Some(registry.bind(name, version.min(4), qh, ()))
                 }
                 "wl_shm" => state.shm = Some(registry.bind(name, 1, qh, ())),
+                "wl_subcompositor" => state.subcompositor = Some(registry.bind(name, 1, qh, ())),
                 "xdg_wm_base" => state.shell = Some(registry.bind(name, version.min(3), qh, ())),
                 "wp_fifo_manager_v1" => state.fifo = Some(registry.bind(name, 1, qh, ())),
                 "wp_commit_timing_manager_v1" => {
@@ -184,6 +187,9 @@ ignore_events!(
     wl_shm_pool::WlShmPool,
     wl_buffer::WlBuffer,
     wl_surface::WlSurface,
+    wl_subcompositor::WlSubcompositor,
+    wl_subsurface::WlSubsurface,
+    wl_region::WlRegion,
     xdg_toplevel::XdgToplevel,
     wp_fifo_manager_v1::WpFifoManagerV1,
     wp_fifo_v1::WpFifoV1,
@@ -303,6 +309,15 @@ impl Native {
             &self.queue.handle(),
             (),
         );
+        let opaque = self
+            .probe
+            .compositor
+            .as_ref()
+            .unwrap()
+            .create_region(&self.queue.handle(), ());
+        opaque.add(0, 0, 160, 120);
+        surface.set_opaque_region(Some(&opaque));
+        opaque.destroy();
         surface.attach(Some(&buffer), 0, 0);
         surface.damage_buffer(0, 0, 160, 120);
         surface.frame(&self.queue.handle(), Callback::Frame(tag));
@@ -458,6 +473,193 @@ fn hidden_and_locked_fifo_progress_without_presenting_private_pixels() {
         session.compositor_alive(),
         "pacing scratch must release dead client/surface handles"
     );
+}
+
+fn move_window(session: &mut Session, title: &str, x: i32, y: i32) {
+    let socket = PathBuf::from(std::env::var_os("XDG_RUNTIME_DIR").unwrap())
+        .join("hypr")
+        .join(session.hyprland_signature().unwrap())
+        .join(".socket.sock");
+    let mut stream = UnixStream::connect(socket).unwrap();
+    stream.set_read_timeout(Some(EVENT)).unwrap();
+    stream
+        .write_all(format!("/dispatch movewindowpixel exact {x} {y},title:^{title}$").as_bytes())
+        .unwrap();
+    let mut reply = String::new();
+    stream.read_to_string(&mut reply).unwrap();
+    assert_eq!(reply.trim(), "ok");
+    session.door().barrier().unwrap();
+}
+
+#[test]
+#[ignore = "needs nested Wayland: scripts/e2e.sh --headless --test surface_pacing"]
+fn offscreen_windows_sleep_and_are_not_reported_as_presented() {
+    let mut session = boot("surface-pacing-offscreen");
+    let mut client = Native::connect(&session);
+    let surface = client.window("pacing-offscreen");
+    session.wait_for_window("pacing-offscreen").unwrap();
+    move_window(&mut session, "pacing-offscreen", 5000, 200);
+    let world = session.world().unwrap();
+    assert!(world.window_matching("pacing-offscreen").unwrap().x >= 4900);
+    client.paint(&surface, [40, 70, 190, 255], 50);
+    client.sync();
+    // Visible commits guarantee actual output frames. Waiting on a fixed
+    // sleep alone could pass because the compositor never rendered anything.
+    let mut visible = Native::connect(&session);
+    let driver = visible.window("pacing-visible-driver");
+    for tag in 1..=12 {
+        visible.paint(&driver, [tag as u8, 40, 170, 255], tag);
+        visible.until("visible driver presentation", |p| {
+            p.presented.contains_key(&tag)
+        });
+        client.sync();
+    }
+    assert!(
+        !client.probe.presented.contains_key(&50),
+        "no pixels reached an output"
+    );
+    assert!(
+        !client.probe.frames.contains(&50),
+        "invisible clients must sleep across unrelated frames"
+    );
+    move_window(&mut session, "pacing-offscreen", 300, 300);
+    client.until("revealing the sleeping client presents its buffer", |p| {
+        p.presented.contains_key(&50)
+    });
+    client.until(
+        "revealing the sleeping client resumes frame callbacks",
+        |p| p.frames.contains(&50),
+    );
+}
+
+#[test]
+#[ignore = "needs nested Wayland: scripts/e2e.sh --headless --test surface_pacing"]
+fn subsurface_visibility_is_independent_of_its_offscreen_parent() {
+    let mut session = boot("surface-pacing-overflow");
+    let mut client = Native::connect(&session);
+    let parent = client.window("pacing-overflow-parent");
+    session.wait_for_window("pacing-overflow-parent").unwrap();
+    move_window(&mut session, "pacing-overflow-parent", 5000, 200);
+    let child = client.surface();
+    let subsurface = client.probe.subcompositor.as_ref().unwrap().get_subsurface(
+        &child,
+        &parent,
+        &client.queue.handle(),
+        (),
+    );
+    subsurface.set_position(-4800, 0);
+    client.paint(&child, [190, 70, 30, 255], 60);
+    client.paint(&parent, [40, 70, 190, 255], 61);
+    client.until("onscreen overflow subsurface presentation", |p| {
+        p.presented.contains_key(&60)
+    });
+    client.until("onscreen overflow subsurface callback", |p| {
+        p.frames.contains(&60)
+    });
+    assert!(!client.probe.presented.contains_key(&61));
+    assert!(!client.probe.frames.contains(&61));
+    // Reversing visibility must update each surface separately too.
+    client.paint(&child, [60, 70, 30, 255], 62);
+    parent.commit();
+    move_window(&mut session, "pacing-overflow-parent", 300, 300);
+    client.until("parent revealed", |p| p.presented.contains_key(&61));
+    client.sync();
+    // The second child commit may have been presented before the move. Issue
+    // another only after movement has completed, so the negative assertion
+    // names a buffer that was never onscreen.
+    client.paint(&child, [80, 70, 30, 255], 63);
+    client.paint(&parent, [40, 90, 190, 255], 64);
+    client.until("visible parent drives a frame", |p| {
+        p.presented.contains_key(&64)
+    });
+    client.sync();
+    assert!(!client.probe.presented.contains_key(&63));
+    assert!(!client.probe.frames.contains(&63));
+}
+
+#[test]
+#[ignore = "needs nested Wayland: scripts/e2e.sh --headless --test surface_pacing"]
+fn opaque_occlusion_suspends_callbacks_until_the_cover_is_destroyed() {
+    let mut session = boot("surface-pacing-occlusion");
+    let mut client = Native::connect(&session);
+    let surface = client.window("pacing-covered");
+    session.wait_for_window("pacing-covered").unwrap();
+    move_window(&mut session, "pacing-covered", 300, 300);
+    let mut front = Native::connect(&session);
+    let cover = front.window("pacing-front");
+    session.wait_for_window("pacing-front").unwrap();
+    move_window(&mut session, "pacing-front", 300, 300);
+    let world = session.world().unwrap();
+    let covered = world.window_matching("pacing-covered").unwrap();
+    let covering = world.window_matching("pacing-front").unwrap();
+    assert_eq!(
+        (covered.x, covered.y, covered.w, covered.h),
+        (covering.x, covering.y, covering.w, covering.h)
+    );
+    front.paint(&cover, [180, 50, 170, 255], 80);
+    front.until("cover has reached its final position", |p| {
+        p.presented.contains_key(&80)
+    });
+    session.screenshot("occlusion-cover").unwrap();
+    client.paint(&surface, [20, 40, 190, 255], 70);
+    client.sync();
+    for tag in 1..=12 {
+        front.paint(&cover, [tag as u8, 40, 170, 255], tag);
+        front.until("cover animation presents", |p| {
+            p.presented.contains_key(&tag)
+        });
+        client.sync();
+    }
+    assert!(!client.probe.presented.contains_key(&70));
+    assert!(!client.probe.frames.contains(&70));
+    drop(front);
+    client.until("uncovered buffer presentation", |p| {
+        p.presented.contains_key(&70)
+    });
+    client.until("uncovered frame callback", |p| p.frames.contains(&70));
+}
+
+#[test]
+#[ignore = "benchmark: scripts/e2e.sh --headless --release --test surface_pacing offscreen_animation_work_profile --nocapture"]
+fn offscreen_animation_work_profile() {
+    let mut session = boot("surface-pacing-animation-profile");
+    let mut hidden = Native::connect(&session);
+    let surface = hidden.window("profile-hidden");
+    session.wait_for_window("profile-hidden").unwrap();
+    move_window(&mut session, "profile-hidden", 5000, 200);
+    let mut driver = Native::connect(&session);
+    let visible = driver.window("profile-visible");
+    let mut pending = 1000;
+    hidden.paint(&surface, [40, 70, 190, 255], pending);
+    hidden.sync();
+    session.door().frame_stats().unwrap();
+    let started = Instant::now();
+    for tag in 1..=120 {
+        driver.paint(&visible, [tag as u8, 40, 170, 255], tag);
+        driver.until("visible animation presentation", |p| {
+            p.presented.contains_key(&tag)
+        });
+        hidden.sync();
+        // Model the normal application animation loop: each callback permits
+        // another buffer. The preserved binary unnecessarily drives this loop.
+        if hidden.probe.frames.contains(&pending) {
+            pending += 1;
+            hidden.paint(&surface, [pending as u8, 70, 190, 255], pending);
+            hidden.sync();
+        }
+    }
+    let elapsed = started.elapsed();
+    let stats = session.door().frame_stats().unwrap();
+    println!(
+        "offscreen-animation-profile {}",
+        serde_json::json!({
+            "visible_presentations": 120, "hidden_redraws": pending - 1000,
+            "elapsed_us": elapsed.as_micros(), "dispatch_calls": stats.dispatch_calls,
+            "dispatch_us": stats.dispatch_us, "render_calls": stats.render_calls,
+            "render_us": stats.render_us,
+        })
+    );
+    assert!(session.compositor_alive());
 }
 
 #[test]

--- a/crates/wm-config/Cargo.toml
+++ b/crates/wm-config/Cargo.toml
@@ -24,3 +24,6 @@ serde = { version = "1", features = ["derive"] }
 # iterating the table in document order, not BTreeMap key order.
 toml = { version = "0.9", features = ["preserve_order"] }
 tracing = "0.1"
+
+[dev-dependencies]
+chonk-test-support = { path = "../chonk-test-support" }

--- a/crates/wm-config/src/hyprland/mod.rs
+++ b/crates/wm-config/src/hyprland/mod.rs
@@ -1231,9 +1231,8 @@ fn filter_env(env: Vec<(String, String)>, skipped: &mut Vec<Skipped>) -> Vec<(St
 pub struct Watch {
     cadence: std::time::Duration,
     last_checked: Option<std::time::Instant>,
-    seen: Option<Signature>,
-    watched: Vec<PathBuf>,
-    directories: Vec<PathBuf>,
+    seen: bool,
+    signature: Signature,
 }
 
 /// What identifies one watched file: its modification time, size and
@@ -1258,14 +1257,16 @@ impl Watch {
         Self {
             cadence: std::time::Duration::from_secs(1),
             last_checked: None,
-            seen: None,
-            watched: reading.files.clone(),
-            directories: vec![
-                roots.user.clone(),
-                roots.defaults.clone(),
-                roots.defaults.join("bindings"),
-                roots.defaults.join("apps"),
-            ],
+            seen: false,
+            signature: Signature {
+                files: reading.files.iter().cloned().map(|path| (path, None)).collect(),
+                directories: [
+                    roots.user.clone(),
+                    roots.defaults.clone(),
+                    roots.defaults.join("bindings"),
+                    roots.defaults.join("apps"),
+                ].into_iter().map(|path| (path, None)).collect(),
+            },
         }
     }
 
@@ -1285,9 +1286,8 @@ impl Watch {
             return false;
         }
         self.last_checked = Some(now);
-        let signature = self.signature();
-        let changed = self.seen.as_ref().is_some_and(|seen| *seen != signature);
-        self.seen = Some(signature);
+        let changed = self.refresh() && self.seen;
+        self.seen = true;
         changed
     }
 
@@ -1299,34 +1299,29 @@ impl Watch {
     /// line brings a file into the set that was never watched before,
     /// and a user deleting one takes it out.
     pub fn follow(&mut self, reading: &Reading) {
-        self.watched = reading.files.clone();
-        self.seen = Some(self.signature());
+        self.signature.files = reading.files.iter().cloned().map(|path| (path, None)).collect();
+        self.refresh();
+        self.seen = true;
     }
 
-    fn signature(&self) -> Signature {
+    /// Reuse the stable path set and replace only scalar metadata. Do not
+    /// short-circuit after a change: every entry needs the same new baseline.
+    fn refresh(&mut self) -> bool {
         use std::os::unix::fs::MetadataExt;
-        Signature {
-            files: self
-                .watched
-                .iter()
-                .map(|path| {
-                    let identity = std::fs::metadata(path)
-                        .ok()
-                        .and_then(|m| Some((m.modified().ok()?, m.len(), m.ino())));
-                    (path.clone(), identity)
-                })
-                .collect(),
-            directories: self
-                .directories
-                .iter()
-                .map(|path| {
-                    (
-                        path.clone(),
-                        std::fs::metadata(path).and_then(|m| m.modified()).ok(),
-                    )
-                })
-                .collect(),
+        let mut changed = false;
+        for (path, previous) in &mut self.signature.files {
+            let identity = std::fs::metadata(path)
+                .ok()
+                .and_then(|m| Some((m.modified().ok()?, m.len(), m.ino())));
+            changed |= *previous != identity;
+            *previous = identity;
         }
+        for (path, previous) in &mut self.signature.directories {
+            let identity = std::fs::metadata(path).and_then(|m| m.modified()).ok();
+            changed |= *previous != identity;
+            *previous = identity;
+        }
+        changed
     }
 }
 

--- a/crates/wm-config/src/hyprland/tests.rs
+++ b/crates/wm-config/src/hyprland/tests.rs
@@ -1216,6 +1216,33 @@ fn chonksteps_own_config_still_wins_over_the_read() {
 
 // ---- the watch --------------------------------------------------------
 
+#[global_allocator]
+static ALLOCATOR: chonk_test_support::AllocationCounter = chonk_test_support::AllocationCounter;
+
+#[test]
+fn unchanged_watch_polls_do_not_allocate() {
+    let root = scratch("watch-allocations");
+    let roots = Roots::under(&root);
+    let mut reading = Reading::default();
+    for index in 0..256 {
+        let path = roots.user.join(format!("source-{index}.conf"));
+        write(&path, "# unchanged\n");
+        reading.files.push(path);
+    }
+    let mut watch = Watch::new(&roots, &reading);
+    let now = std::time::Instant::now();
+    assert!(!watch.changed(now));
+    let (changed, stats) = chonk_test_support::measure(|| {
+        (1..=20).fold(false, |changed, seconds| {
+            watch.changed(now + std::time::Duration::from_secs(seconds)) | changed
+        })
+    });
+    std::fs::remove_dir_all(root).unwrap();
+    assert!(!changed);
+    eprintln!("256 files, 20 unchanged polls: {stats:?}");
+    assert_eq!(stats, chonk_test_support::AllocationStats::default());
+}
+
 /// The live-edit path: a change to a watched file is seen, once.
 #[test]
 fn an_edit_to_a_watched_file_is_noticed_once() {

--- a/crates/wm-wayland/src/core_protocols.rs
+++ b/crates/wm-wayland/src/core_protocols.rs
@@ -405,7 +405,7 @@ mod security_context_tests {
     use std::sync::Arc;
 
     #[test]
-    fn confined_clients_cannot_nest_security_contexts_but_keep_current_policy() {
+    fn confined_clients_cannot_nest_security_contexts_or_use_privileged_globals() {
         let display = Display::<Compositor>::new().expect("wayland display");
         let mut handle = display.handle();
         let (creator_socket, _creator_peer) =
@@ -431,7 +431,7 @@ mod security_context_tests {
         assert!(crate::state::security_context_global_visible(&creator));
         assert!(!crate::state::security_context_global_visible(&confined));
         assert!(crate::state::privileged_global_visible(&creator));
-        assert!(crate::state::privileged_global_visible(&confined));
+        assert!(!crate::state::privileged_global_visible(&confined));
     }
 }
 delegate_relative_pointer!(Compositor);

--- a/crates/wm-wayland/src/data_control.rs
+++ b/crates/wm-wayland/src/data_control.rs
@@ -73,10 +73,10 @@
 //! # Shared security-context gate
 //!
 //! Data control is a read-anything-on-the-clipboard capability, so both
-//! globals consult `state::privileged_global_visible`. Security-context
-//! clients are now tagged and can be distinguished there. The current
-//! single-user policy remains permissive, where a clipboard manager, a
-//! terminal and a browser are all equally that user's own programs.
+//! globals consult `state::privileged_global_visible`. Clients admitted
+//! through a sandbox security context cannot bind them. Ordinary desktop
+//! clipboard managers retain access; confined applications use the focused
+//! `wl_data_device` clipboard path.
 
 use smithay::reexports::wayland_server::DisplayHandle;
 use smithay::wayland::selection::ext_data_control::{

--- a/crates/wm-wayland/src/lib.rs
+++ b/crates/wm-wayland/src/lib.rs
@@ -56,6 +56,7 @@ mod output_power;
 mod protocols;
 mod readback;
 mod renderer;
+mod restart;
 mod overview;
 mod gesture_scene;
 mod layout_scene;

--- a/crates/wm-wayland/src/protocols.rs
+++ b/crates/wm-wayland/src/protocols.rs
@@ -495,11 +495,8 @@ pub(crate) struct ScreencopyFrameData {
 /// Registers both globals. Called once from `run` — see the module's
 /// integration contract for where.
 ///
-/// Never fails. Both globals consult the shared security-context-aware
-/// predicate. That predicate remains permissive today because chonkstep
-/// runs one user's session rather than a multi-tenant kiosk, but clients
-/// admitted through `wp_security_context_v1` are now identifiable when
-/// that policy changes.
+/// Never fails. Both globals consult the shared security-context predicate:
+/// ordinary desktop helpers can bind; sandbox-context clients cannot.
 pub(crate) fn init(display_handle: &DisplayHandle) -> ProtocolState {
     // The `GlobalId`s are dropped deliberately: dropping one does not
     // withdraw the global (that takes `DisplayHandle::remove_global`),

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -87,13 +87,14 @@ use smithay::backend::renderer::element::memory::MemoryRenderBufferRenderElement
 use smithay::backend::renderer::element::solid::SolidColorRenderElement;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::utils::{CropRenderElement, RescaleRenderElement};
-use smithay::backend::renderer::element::{Kind, RenderElementStates};
+use smithay::backend::renderer::element::{default_primary_scanout_output_compare, Kind, RenderElementStates};
 use smithay::backend::renderer::gles::GlesRenderer;
 use smithay::backend::renderer::utils::{CommitCounter, RendererSurfaceStateUserData};
 use smithay::backend::renderer::{Color32F, ImportAll, ImportMem};
 use smithay::desktop::utils::{
     bbox_from_surface_tree, send_frames_surface_tree, take_presentation_feedback_surface_tree,
-    surface_presentation_feedback_flags_from_states, OutputPresentationFeedback,
+    surface_presentation_feedback_flags_from_states, surface_primary_scanout_output,
+    update_surface_primary_scanout_output, OutputPresentationFeedback,
 };
 use smithay::input::pointer::{CursorImageAttributes, CursorImageStatus};
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
@@ -480,9 +481,8 @@ pub(crate) fn push_background(
 /// surface must hear them while a parked window or policy-hidden layer
 /// should sleep. Shared by both backends for exactly that reason.
 ///
-/// Called from one output's completed presentation boundary. Only
-/// surfaces whose owning rectangle selects that output receive the
-/// callback, so mixed-refresh heads pace independently.
+/// Called from one output's completed presentation boundary. Render results
+/// select each surface's primary output; hidden surfaces receive no callbacks.
 pub(crate) fn send_frame_callbacks(
     backend: &WaylandBackend,
     output: &smithay::output::Output,
@@ -491,10 +491,9 @@ pub(crate) fn send_frame_callbacks(
     pointer_location: SPoint<f64, Logical>,
     elapsed: Duration,
 ) {
-    let throttle = frame_interval(output);
     let send_tree = |surface: &WlSurface| {
-        signal_pacing_barriers(surface);
-        send_frames_surface_tree(surface, output, elapsed, throttle, |_, _| Some(output.clone()));
+        signal_pacing_barriers(surface, output);
+        send_frames_surface_tree(surface, output, elapsed, None, surface_primary_scanout_output);
     };
     // While locked, ONLY lock surfaces hear about frames: withholding
     // callbacks from everything else freezes those clients for the
@@ -520,9 +519,7 @@ pub(crate) fn send_frame_callbacks(
     // namespace policy stay mapped but are absent from the scene, so
     // withholding callbacks is what makes them actually idle.
     for record in &backend.layers {
-        if !backend.layer_presented(record)
-            || !is_primary_rect(backend, record.geometry, output_rect)
-        {
+        if !backend.layer_presented(record) {
             continue;
         }
         let surface = record.surface.wl_surface();
@@ -537,12 +534,10 @@ pub(crate) fn send_frame_callbacks(
     // client produced a frame. The workspace transition frame supplies
     // the first callback when it becomes exposed again.
     for_each_presented_window(backend, |record| {
-        if is_primary_rect(backend, record.content, output_rect) {
-            if let Some(surface) = record.surface.wl_surface() {
-                send_tree(&surface);
-                for (popup, _) in backend.popups_for_surface(&surface) {
-                    send_tree(popup.wl_surface());
-                }
+        if let Some(surface) = record.surface.wl_surface() {
+            send_tree(&surface);
+            for (popup, _) in backend.popups_for_surface(&surface) {
+                send_tree(popup.wl_surface());
             }
         }
     });
@@ -553,17 +548,7 @@ pub(crate) fn send_frame_callbacks(
         }
     }
     for popup in &backend.ime_popups {
-        let Some(parent) = popup.get_parent() else {
-            continue;
-        };
-        let parent_rect = Rect::new(
-            Point::new(parent.location.loc.x, parent.location.loc.y),
-            wm_theme_api::Size::new(
-                parent.location.size.w.max(0) as u32,
-                parent.location.size.h.max(0) as u32,
-            ),
-        );
-        if popup.alive() && is_primary_rect(backend, parent_rect, output_rect) {
+        if popup.alive() && popup.get_parent().is_some() {
             send_tree(popup.wl_surface());
         }
     }
@@ -573,12 +558,15 @@ pub(crate) fn send_frame_callbacks(
 /// a presentation boundary. Commit timing is clock-driven instead and is
 /// serviced by `Compositor::service_surface_pacing`; coupling it to a frame
 /// would deadlock the commit whose pixels are waiting behind that timer.
-fn signal_pacing_barriers(surface: &WlSurface) {
+fn signal_pacing_barriers(surface: &WlSurface, output: &smithay::output::Output) {
     compositor::with_surface_tree_downward(
         surface,
         (),
         |_, _, &()| TraversalAction::DoChildren(()),
-        |_, states, &()| {
+        |surface, states, &()| {
+            if surface_primary_scanout_output(surface, states).as_ref() != Some(output) {
+                return;
+            }
             // Most surfaces never use FIFO. A frame callback must not create
             // pacing state which makes every later input pass service them.
             if !states.cached_state.has::<smithay::wayland::fifo::FifoBarrierCachedState>() {
@@ -598,28 +586,31 @@ fn signal_pacing_barriers(surface: &WlSurface) {
     );
 }
 
-/// Drain presentation requests for the surfaces whose primary output
-/// is `output`. The ownership choice is deterministic on multi-head:
-/// whichever monitor contains the largest part of the owning window
-/// wins, with monitor order breaking ties.
+/// Update surface visibility from a successfully submitted frame and drain
+/// feedback only for surfaces actually presented on their primary output.
+/// Smithay selects that output from visible area and refresh rate.
 pub(crate) fn take_presentation_feedback(
     backend: &WaylandBackend,
     output: &smithay::output::Output,
     output_rect: Rect,
-    render_states: Option<&RenderElementStates>,
+    render_states: &RenderElementStates,
+    cursor_status: &CursorImageStatus,
+    pointer_location: SPoint<f64, Logical>,
 ) -> OutputPresentationFeedback {
     let mut feedback = OutputPresentationFeedback::new(output);
     let mut take_tree = |surface: &WlSurface| {
+        // Use actual rendered pixels, including transforms, clipping,
+        // occlusion and each subsurface/popup's independent visibility.
+        // Geometry-based ownership invents presentations for offscreen Flow
+        // windows and misses overflow rendered on a parent's other output.
         take_presentation_feedback_surface_tree(
             surface,
             &mut feedback,
-            |_, _| Some(output.clone()),
-            |surface, _| {
-                render_states.map_or_else(
-                    smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::empty,
-                    |states| surface_presentation_feedback_flags_from_states(surface, states),
-                )
+            |surface, states| {
+                update_surface_primary_scanout_output(surface, output, states, render_states,
+                    default_primary_scanout_output_compare)
             },
+            |surface, _| surface_presentation_feedback_flags_from_states(surface, render_states),
         );
     };
 
@@ -635,17 +626,15 @@ pub(crate) fn take_presentation_feedback(
     }
 
     for_each_presented_window(backend, |record| {
-        if is_primary_rect(backend, record.content, output_rect) {
-            if let Some(surface) = record.surface.wl_surface() {
-                take_tree(&surface);
-                for (popup, _) in backend.popups_for_surface(&surface) {
-                    take_tree(popup.wl_surface());
-                }
+        if let Some(surface) = record.surface.wl_surface() {
+            take_tree(&surface);
+            for (popup, _) in backend.popups_for_surface(&surface) {
+                take_tree(popup.wl_surface());
             }
         }
     });
     for record in &backend.layers {
-        if !backend.layer_presented(record) || !is_primary_rect(backend, record.geometry, output_rect) {
+        if !backend.layer_presented(record) {
             continue;
         }
         let surface = record.surface.wl_surface();
@@ -655,13 +644,14 @@ pub(crate) fn take_presentation_feedback(
         }
     }
     for popup in &backend.ime_popups {
-        let Some(parent) = popup.get_parent() else { continue };
-        let parent_rect = Rect::new(
-            Point::new(parent.location.loc.x, parent.location.loc.y),
-            wm_theme_api::Size::new(parent.location.size.w.max(0) as u32, parent.location.size.h.max(0) as u32),
-        );
-        if popup.alive() && is_primary_rect(backend, parent_rect, output_rect) {
+        if popup.alive() && popup.get_parent().is_some() {
             take_tree(popup.wl_surface());
+        }
+    }
+    let pointer = Point::new(pointer_location.x.floor() as i32, pointer_location.y.floor() as i32);
+    if output_rect.contains(pointer) {
+        if let CursorImageStatus::Surface(surface) = cursor_status {
+            take_tree(surface);
         }
     }
     feedback
@@ -735,27 +725,11 @@ fn fullscreen_rect_occludes_viewport(content: Rect, viewport: Rect) -> bool {
     overlap_area(content, viewport) > 0
 }
 
-fn is_primary_rect(backend: &WaylandBackend, surface: Rect, candidate: Rect) -> bool {
-    backend
-        .monitors
-        .iter()
-        .max_by_key(|monitor| overlap_area(surface, monitor.geometry))
-        .is_none_or(|monitor| monitor.geometry == candidate)
-}
-
 pub(crate) fn presentation_refresh(output: &smithay::output::Output) -> smithay::wayland::presentation::Refresh {
     output.current_mode().and_then(|mode| u64::try_from(mode.refresh).ok()).filter(|rate| *rate > 0).map_or(
         smithay::wayland::presentation::Refresh::Unknown,
         |millihertz| smithay::wayland::presentation::Refresh::fixed(Duration::from_nanos(1_000_000_000_000 / millihertz)),
     )
-}
-
-fn frame_interval(output: &smithay::output::Output) -> Option<Duration> {
-    output
-        .current_mode()
-        .and_then(|mode| u64::try_from(mode.refresh).ok())
-        .filter(|rate| *rate > 0)
-        .map(|millihertz| Duration::from_nanos(1_000_000_000_000 / millihertz))
 }
 
 pub(crate) fn present_now(
@@ -950,7 +924,7 @@ fn render_frame_winit(comp: &mut Compositor, plain_capture_pending: bool) -> boo
 
     note_frame_success();
     let output_rect = wm.backend().monitors.first().map(|monitor| monitor.geometry).unwrap_or_default();
-    let mut feedback = take_presentation_feedback(wm.backend(), output, output_rect, Some(&render_states));
+    let mut feedback = take_presentation_feedback(wm.backend(), output, output_rect, &render_states, cursor_status, *pointer_location);
     present_now(
         &mut feedback,
         presentation_refresh(output),

--- a/crates/wm-wayland/src/restart.rs
+++ b/crates/wm-wayland/src/restart.rs
@@ -1,0 +1,77 @@
+//! The compositor's upstream display and its children's display are different
+//! endpoints. Preserve the former before startup publishes the latter.
+use std::ffi::OsString;
+use std::process::Command;
+
+pub(crate) struct HostDisplay {
+    wayland: Option<OsString>,
+    x11: Option<OsString>,
+}
+
+impl HostDisplay {
+    pub fn capture() -> Self {
+        Self {
+            wayland: std::env::var_os("WAYLAND_DISPLAY"),
+            x11: std::env::var_os("DISPLAY"),
+        }
+    }
+
+    pub fn configure_restart(&self, command: &mut Command, nested: bool) {
+        command.env("CHONKSTEP_BACKEND", if nested { "winit" } else { "drm" });
+        // A WAYLAND_SOCKET is an already-consumed protocol connection, not
+        // an address a new client can reconnect to after exec.
+        command.env_remove("WAYLAND_SOCKET");
+        for (key, value) in [("WAYLAND_DISPLAY", &self.wayland), ("DISPLAY", &self.x11)] {
+            match value.as_ref().filter(|_| nested) {
+                Some(value) => {
+                    command.env(key, value);
+                }
+                None => {
+                    command.env_remove(key);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn restart_restores_only_the_original_host_addresses() {
+        for (wayland, x11) in [
+            (Some("wayland-host"), None),
+            (None, Some(":7")),
+            (Some("/run/user/123/host"), Some(":2")),
+            (None, None),
+        ] {
+            let host = HostDisplay {
+                wayland: wayland.map(Into::into),
+                x11: x11.map(Into::into),
+            };
+            for nested in [false, true] {
+                let mut command = Command::new("unused");
+                command
+                    .env("WAYLAND_DISPLAY", "own-dead-socket")
+                    .env("DISPLAY", ":99");
+                host.configure_restart(&mut command, nested);
+                let env: std::collections::HashMap<_, _> = command.get_envs().collect();
+                assert_eq!(
+                    env[OsStr::new("WAYLAND_DISPLAY")],
+                    wayland.filter(|_| nested).map(OsStr::new)
+                );
+                assert_eq!(
+                    env[OsStr::new("DISPLAY")],
+                    x11.filter(|_| nested).map(OsStr::new)
+                );
+                assert_eq!(env[OsStr::new("WAYLAND_SOCKET")], None);
+                assert_eq!(
+                    env[OsStr::new("CHONKSTEP_BACKEND")],
+                    Some(OsStr::new(if nested { "winit" } else { "drm" }))
+                );
+            }
+        }
+    }
+}

--- a/crates/wm-wayland/src/session.rs
+++ b/crates/wm-wayland/src/session.rs
@@ -2738,7 +2738,9 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
                             wm.backend(),
                             &entry.output,
                             monitor.geometry,
-                            Some(&render_states),
+                            &render_states,
+                            cursor_status,
+                            *pointer_location,
                         ));
                     }
                 }
@@ -2753,7 +2755,9 @@ pub(crate) fn render_frame_session(comp: &mut Compositor, plain_capture_pending:
                             wm.backend(),
                             &entry.output,
                             monitor.geometry,
-                            Some(&render_states),
+                            &render_states,
+                            cursor_status,
+                            *pointer_location,
                         );
                         let flags = smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback::Kind::Vsync;
                         if let Some((at, sequence)) = output.last_vblank {

--- a/crates/wm-wayland/src/state.rs
+++ b/crates/wm-wayland/src/state.rs
@@ -1432,15 +1432,14 @@ pub(crate) fn client_is_confined(client: &smithay::reexports::wayland_server::Cl
         .is_some_and(|data| data.security_context.lock().is_ok_and(|context| context.is_some()))
 }
 
-/// One gate for capabilities that affect other clients. The current
-/// policy remains permissive for both ordinary and confined clients;
-/// centralizing the decision makes confinement a policy choice instead
-/// of information the compositor cannot represent.
+/// Capabilities that affect other clients belong to ordinary desktop helpers,
+/// not clients explicitly admitted through a sandbox security context. Keep
+/// this gate shared so capture, input injection, clipboard monitoring and
+/// output/session management enforce the same boundary.
 pub(crate) fn privileged_global_visible(
     client: &smithay::reexports::wayland_server::Client,
 ) -> bool {
-    let _confined = client_is_confined(client);
-    true
+    !client_is_confined(client)
 }
 
 /// The security-context protocol's own recursively-confined-listener guard.
@@ -3568,6 +3567,7 @@ fn recovery_locker_argv<'a>(
 
 
 pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> {
+    let host_display = crate::restart::HostDisplay::capture();
     // Consume the supervisor's one-shot marker before bringing up any
     // display machinery. A recovery with no resolved locker must fail
     // at the login boundary, not finish booting an unlocked desktop.
@@ -3859,7 +3859,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
     // The ecosystem protocols, under the same timing rule. Layer-shell
     // is what fuzzel/mako/waybar look for the moment they connect;
     // layer-shell and session-lock both consult the shared
-    // security-context-aware policy (currently permissive); the idle
+    // security-context policy excluding confined clients; the idle
     // notifier's timers live on this very event loop.
     let layer_shell = crate::layers::LayerShell::new(
         smithay::wayland::shell::wlr_layer::WlrLayerShellState::new_with_filter::<Compositor, _>(
@@ -4295,7 +4295,7 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
         // `nested` is the decision this process made at startup, so the
         // replacement makes the same one rather than re-deriving it
         // from an environment this compositor itself wrote.
-        restart_in_place(nested);
+        restart_in_place(nested, &host_display);
     }
     tracing::info!("compositor session over");
     Ok(())
@@ -4306,23 +4306,13 @@ pub fn run(config: wm_config::Config) -> Result<(), Box<dyn std::error::Error>> 
 /// X11 binary documents at length. The one behavioral difference is
 /// unavoidable: Wayland clients die with our socket (no SaveSet), so
 /// the fresh process starts with an empty session.
-fn restart_in_place(nested: bool) -> ! {
+fn restart_in_place(nested: bool, host_display: &crate::restart::HostDisplay) -> ! {
     use std::os::unix::process::CommandExt;
     let bin = std::env::args_os().next().unwrap_or_else(|| "chonkstep-wayland".into());
     let mut command = std::process::Command::new(&bin);
-    // Pin the backend across the re-exec instead of letting the new
-    // process guess again.
-    //
-    // A compositor exports `WAYLAND_DISPLAY` (and `DISPLAY`, through
-    // XWayland) into its own environment so the apps it spawns find it.
-    // `exec` keeps that environment, so a session restarted from a TTY
-    // would wake up seeing both variables set, conclude from them that
-    // a desktop is already running here, and try to nest inside the
-    // compositor it just replaced - which is gone, taking the session
-    // with it. Passing the decision explicitly is the fix; the sockets
-    // themselves are stale after the exec either way, so they are
-    // cleared rather than handed to the new process.
-    command.env("CHONKSTEP_BACKEND", if nested { "winit" } else { "drm" });
+    // Pin the backend and restore its upstream display. The current
+    // environment instead names our own sockets, which die on exec.
+    host_display.configure_restart(&mut command, nested);
     // A deliberate hot restart is a continuation of the same session,
     // not a fresh login — session-layout restore must not fire from
     // it. On this stack the distinction is subtle (the clients die
@@ -4333,10 +4323,6 @@ fn restart_in_place(nested: bool) -> ! {
     // by the session supervisor with a fresh environment, which is
     // exactly when restore *should* fire.
     command.env("CHONKSTEP_SESSION_CONTINUES", "1");
-    if !nested {
-        command.env_remove("WAYLAND_DISPLAY");
-        command.env_remove("DISPLAY");
-    }
     let err = command.exec();
     tracing::error!(?err, bin = ?bin, "re-exec failed; exiting instead of restarting");
     std::process::exit(1);

--- a/crates/wm-wayland/src/virtual_keyboard.rs
+++ b/crates/wm-wayland/src/virtual_keyboard.rs
@@ -100,52 +100,15 @@
 //!
 //! # Trust model
 //!
-//! [`may_create_virtual_keyboard`] is where a compositor says no, and
-//! this one says yes to every client. That deserves an argument,
-//! because the reflex — "this protocol lets any client type into any
-//! other client" — is correct and the conclusion still does not
-//! follow.
+//! [`may_create_virtual_keyboard`] uses the shared privileged-global policy.
+//! Ordinary desktop helpers can bind, so `wtype` and Omarchy's text-insertion
+//! tools work. Clients admitted through `wp_security_context_v1` cannot bind
+//! virtual keyboards or other desktop-wide capabilities. Their sandbox launcher
+//! must also prevent access to the unrestricted Wayland socket.
 //!
-//! The reasoning `test_door.rs` uses for its debugging socket
-//! ("anything that can set the compositor's environment and reach the
-//! socket path already runs as the user") does **not** transfer as
-//! written. That door demands a privilege — writing the compositor's
-//! environment before it starts — that an ordinary client does not
-//! have. This global is bound off the registry by anything that opened
-//! the Wayland socket. The premise is different, so the argument has
-//! to be made again from scratch.
-//!
-//! Made again, it lands in the same place, for a different reason:
-//! this session grants no client less than user privilege in the first
-//! place. Any client on this socket can already capture every pixel of
-//! every other client's window (`zwlr_screencopy_manager_v1`, under
-//! the shared policy — see [`crate::protocols::init`]), enumerate every
-//! window and close or raise any of them
-//! (`zwlr_foreign_toplevel_manager_v1`, under the same shared policy),
-//! and lock the session out from under the user (`ext_session_lock_v1`,
-//! which consults that policy too). Nearest of all: it can read every
-//! copy the user makes, at the
-//! moment they make it and without ever holding focus, through
-//! data-control (see [`crate::data_control`], which grants that to
-//! every client for its own stated reasons). A protocol that hands out
-//! the contents of the clipboard and one that hands out the ability to
-//! type are the same trust decision viewed from two sides, and this
-//! session has already made it once. It is also, being a process of
-//! this user, free to `ptrace`
-//! the compositor, write `~/.bashrc`, or start its own `wtype` against
-//! any other compositor the user runs. Reading a password field is
-//! already within reach; typing into one is a smaller step, not a new
-//! kind of one. Refusing it would break `wtype` — and the three
-//! Omarchy features above — while moving nothing out of an attacker's
-//! reach.
-//!
-//! `wp_security_context_v1` now gives that future policy a real input:
-//! clients admitted through one are tagged in `ClientState`, cannot
-//! create nested security contexts, and every cross-client capability
-//! consults `state::privileged_global_visible`. The current single-user
-//! policy deliberately returns true for both tagged and ordinary
-//! clients, preserving the behavior above while making a later policy
-//! change one shared predicate instead of eleven unrelated filters.
+//! This is a bind-time boundary. Ordinary clients that already hold a virtual
+//! keyboard retain it across lock/unlock, as described above; this protocol's
+//! upstream handler does not provide a per-event authorization callback.
 //!
 //! # Integration contract
 //!
@@ -271,10 +234,9 @@ mod tests {
         assert!(seat_can_accept_virtual_keys(&seat));
     }
 
-    /// The shared policy is currently permissive, deliberately. This test
-    /// preserves byte-for-byte behavior for an ordinary unconfined client.
+    /// Ordinary unconfined desktop helpers retain virtual-input access.
     #[test]
-    fn every_client_on_this_socket_may_create_a_virtual_keyboard() {
+    fn ordinary_clients_may_create_a_virtual_keyboard() {
         let display = Display::<Compositor>::new().expect("wayland display");
         let mut display_handle = display.handle();
         let (compositor_end, _client_end) =

--- a/crates/wm-wayland/src/virtual_pointer.rs
+++ b/crates/wm-wayland/src/virtual_pointer.rs
@@ -30,10 +30,8 @@ use crate::state::Compositor;
 
 const VERSION: u32 = 2;
 
-/// Held for the global's lifetime. The policy seam deliberately has
-/// the same shape as virtual-keyboard's; every client on this socket is
-/// currently a full user-session peer, and this is where a future
-/// security-context restriction belongs.
+/// Held for the global's lifetime. The shared virtual-input policy permits
+/// ordinary desktop helpers and excludes sandbox-context clients.
 pub(crate) struct VirtualPointerState {
     _global: GlobalId,
 }

--- a/crates/wm-x11/src/backend.rs
+++ b/crates/wm-x11/src/backend.rs
@@ -18,6 +18,11 @@ use x11rb::wrapper::ConnectionExt as _;
 use x11rb::{COPY_DEPTH_FROM_PARENT, CURRENT_TIME, NONE};
 
 
+// GetProperty's length is in 32-bit words, even for 8-bit strings. Bound
+// the server reply itself: truncating after receiving it still allocates and
+// transfers the entire client-controlled property on the desktop thread.
+const MAX_PROPERTY_WORDS: u32 = (64 * 1024) / 4;
+
 /// A client's own top-level window.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct XWindow(pub Window);
@@ -214,9 +219,9 @@ impl X11Backend {
     /// for `UTF8_STRING`-typed ones. `None` for a missing or empty value,
     /// never an empty string — callers treat both as "no title."
     fn get_text_property(&self, window: Window, atom: Atom, type_atom: Atom) -> Option<String> {
-        let cookie = self.conn.get_property(false, window, atom, type_atom, 0, u32::MAX).ok()?;
+        let cookie = self.conn.get_property(false, window, atom, type_atom, 0, MAX_PROPERTY_WORDS).ok()?;
         let reply = cookie.reply().ok()?;
-        if reply.value.is_empty() {
+        if reply.format != 8 || reply.value.is_empty() {
             None
         } else {
             Some(String::from_utf8_lossy(&reply.value).into_owned())
@@ -2219,14 +2224,12 @@ impl X11Backend {
     /// so naming the class still catches every instance under it. The
     /// compositor's XWayland arm resolves the identity the same way.
     fn window_identity(&self, window: XWindow) -> Option<String> {
-        let cookie = self.conn.get_property(false, window.0, AtomEnum::WM_CLASS, AtomEnum::STRING, 0, u32::MAX).ok()?;
-        let reply = cookie.reply().ok()?;
-        let mut parts = reply.value.split(|&b| b == 0).map(|s| String::from_utf8_lossy(s).into_owned());
-        let instance = parts.next().unwrap_or_default();
-        if !instance.is_empty() {
-            return Some(instance);
+        let identity = self.window_class(window)?;
+        if !identity.instance.is_empty() {
+            Some(identity.instance)
+        } else {
+            (!identity.class.is_empty()).then_some(identity.class)
         }
-        parts.next().filter(|class| !class.is_empty())
     }
 }
 
@@ -2431,8 +2434,11 @@ impl Backend for X11Backend {
     }
 
     fn window_class(&self, window: Self::WindowId) -> Option<WmClass> {
-        let cookie = self.conn.get_property(false, window.0, AtomEnum::WM_CLASS, AtomEnum::STRING, 0, u32::MAX).ok()?;
+        let cookie = self.conn.get_property(false, window.0, AtomEnum::WM_CLASS, AtomEnum::STRING, 0, MAX_PROPERTY_WORDS).ok()?;
         let reply = cookie.reply().ok()?;
+        // A partial class could accidentally match a different application's
+        // rules. Reject oversized identities instead of inventing one.
+        if reply.format != 8 || reply.bytes_after != 0 { return None; }
         let mut parts = reply.value.split(|&b| b == 0).map(|s| String::from_utf8_lossy(s).into_owned());
         let instance = parts.next()?;
         let class = parts.next().unwrap_or_default();
@@ -2465,12 +2471,13 @@ impl Backend for X11Backend {
             WmProtocol::DeleteWindow => self.wm_delete_window,
             WmProtocol::TakeFocus => self.wm_take_focus,
         };
-        let Ok(cookie) = self.conn.get_property(false, window.0, self.wm_protocols, AtomEnum::ATOM, 0, u32::MAX) else {
+        let Ok(cookie) = self.conn.get_property(false, window.0, self.wm_protocols, AtomEnum::ATOM, 0, MAX_PROPERTY_WORDS) else {
             return false;
         };
         let Ok(reply) = cookie.reply() else {
             return false;
         };
+        if reply.bytes_after != 0 { return false; }
         reply.value32().map(|it| it.into_iter().any(|a| a == target)).unwrap_or(false)
     }
 
@@ -2502,13 +2509,14 @@ impl Backend for X11Backend {
             self.ewmh.net_wm_state,
             AtomEnum::ATOM,
             0,
-            u32::MAX,
+            MAX_PROPERTY_WORDS,
         ) else {
             return false;
         };
         let Ok(reply) = cookie.reply() else {
             return false;
         };
+        if reply.bytes_after != 0 { return false; }
         reply
             .value32()
             .is_some_and(|mut atoms| atoms.any(|atom| atom == self.ewmh.net_wm_state_modal))
@@ -3367,6 +3375,49 @@ impl wm_theme_api::PopupHost for X11Backend {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[ignore = "run only on a private server: xvfb-run -a cargo test -p wm-x11 hostile_properties -- --ignored"]
+    fn hostile_properties_are_bounded_and_ordinary_titles_still_work() {
+        let backend = X11Backend::connect_and_become_wm(None, 1.0).unwrap();
+        let window = backend.conn.generate_id().unwrap();
+        backend.conn.create_window(x11rb::COPY_DEPTH_FROM_PARENT, window, backend.root,
+            0, 0, 100, 100, 0, WindowClass::INPUT_OUTPUT, 0, &CreateWindowAux::default()).unwrap().check().unwrap();
+        let large = vec![b'x'; 128 * 1024];
+        backend.conn.change_property8(PropMode::REPLACE, window, backend.net_wm_name,
+            backend.utf8_string, &large).unwrap().check().unwrap();
+        let title = backend.window_title(XWindow(window)).unwrap();
+        assert_eq!(title.len(), 64 * 1024, "a title request must cap the server reply before allocation");
+        backend.conn.change_property8(PropMode::REPLACE, window, AtomEnum::WM_CLASS,
+            AtomEnum::STRING, &large).unwrap().check().unwrap();
+        assert!(backend.window_class(XWindow(window)).is_none(), "truncated identity must not match application rules");
+        assert!(backend.window_identity(XWindow(window)).is_none());
+        backend.conn.change_property8(PropMode::REPLACE, window, backend.net_wm_name,
+            backend.utf8_string, "normal λ title".as_bytes()).unwrap().check().unwrap();
+        assert_eq!(backend.window_title(XWindow(window)).as_deref(), Some("normal λ title"));
+        backend.conn.change_property8(PropMode::REPLACE, window, AtomEnum::WM_CLASS,
+            AtomEnum::STRING, b"instance\0Class\0").unwrap().check().unwrap();
+        assert_eq!(backend.window_identity(XWindow(window)).as_deref(), Some("instance"));
+        let class = backend.window_class(XWindow(window)).unwrap();
+        assert_eq!((class.instance.as_str(), class.class.as_str()), ("instance", "Class"));
+        // Atom properties are bounded too; an overlong list is malformed,
+        // even when a supported value appears in its retained prefix.
+        let atoms = vec![backend.wm_delete_window; 32 * 1024];
+        backend.conn.change_property32(PropMode::REPLACE, window, backend.wm_protocols,
+            AtomEnum::ATOM, &atoms).unwrap().check().unwrap();
+        assert!(!backend.supports_protocol(XWindow(window), WmProtocol::DeleteWindow));
+        backend.conn.change_property32(PropMode::REPLACE, window, backend.wm_protocols,
+            AtomEnum::ATOM, &[backend.wm_delete_window]).unwrap().check().unwrap();
+        assert!(backend.supports_protocol(XWindow(window), WmProtocol::DeleteWindow));
+        let states = vec![backend.ewmh.net_wm_state_modal; 32 * 1024];
+        backend.conn.change_property32(PropMode::REPLACE, window, backend.ewmh.net_wm_state,
+            AtomEnum::ATOM, &states).unwrap().check().unwrap();
+        assert!(!backend.window_is_modal(XWindow(window)));
+        backend.conn.change_property32(PropMode::REPLACE, window, backend.ewmh.net_wm_state,
+            AtomEnum::ATOM, &[backend.ewmh.net_wm_state_modal]).unwrap().check().unwrap();
+        assert!(backend.window_is_modal(XWindow(window)));
+        backend.conn.destroy_window(window).unwrap().check().unwrap();
+    }
 
     fn monitor(name: &str, x: i32, y: i32, w: u32, h: u32, primary: bool) -> MonitorInfo {
         MonitorInfo {

--- a/docs/engineering/2026-09-08-adversarial-review.md
+++ b/docs/engineering/2026-09-08-adversarial-review.md
@@ -1,0 +1,208 @@
+# Adversarial compositor review — 2026-09-08
+
+This review produced six fixes across Wayland presentation, session restart,
+sandbox capabilities, shell workers, configuration polling and X11 property
+reads. The baseline is `facf999aa92a2bd06f8b411ec64e191bbb20fb6e` (0.4.4 plus
+PR #147's resize/logout fixes), not an older build missing those fixes.
+
+## Scope and comparison method
+
+The inventory covers roughly 204,000 tracked Rust/Python/Go/shell lines in 384
+files outside `vendor/`. This is a repository-wide architecture and risk review
+with deeper investigation of critical paths, not a claim that every line or
+hardware combination has been exhaustively verified. Previous September 7
+reviews and existing regression tests were checked before selecting new findings;
+their already-fixed issues are not counted again here.
+
+| Area | Review performed |
+| --- | --- |
+| `wm-wayland` | Frame/presentation/FIFO ownership, surface-tree visibility, DRM queue/vblank boundaries, restart environment, protocol admission, grabs and activation, capture limits and lock filtering |
+| `wm-core` | Layout/lifecycle invariants and previous solver/geometry audit; workspace regression suite |
+| `wm-x11` | Synchronous property reads, class/title/protocol parsing, resize/event paths; new live Xvfb regression |
+| `chonk-shell`, config, theme | External process lifetimes, appearance ordering, config-watch allocation, existing IPC/restore limits, raster/render tests |
+| Dock protocol and SDKs | Message limits, framing and timeout paths; Rust, Python and Go suites |
+| Instruments, utility apps, packaging | Workspace lint/tests, dependency inventory, installer fixtures and CI/test wiring; no new application-specific runtime certification |
+| Vendored Smithay | Read the actual 0.7.0 renderer/primary-output, callback and security-context implementations used by this tree; no vendor changes |
+
+Comparisons use primary sources, pinned where possible:
+
+- [Niri, `dd75865`](https://github.com/niri-wm/niri/blob/dd75865f547f0eac0e9b6c4d86d2cd00c0744252/src/niri.rs): actual render-element states determine primary outputs and presentation feedback. Its explicit hidden-client fallback pacing differs from ChonkStep's existing policy of letting hidden windows sleep. ChonkStep now follows actual render visibility while retaining that sleeping policy.
+- [Sway, `5bc72de`](https://github.com/swaywm/sway/blob/5bc72dee4771a2d2d2648b8f69d30e0747f263f6/sway/server.c): privileged globals are unavailable to clients admitted through a security context. This directly informed the shared admission-policy fix.
+- [Weston output/repaint documentation](https://wayland.pages.freedesktop.org/weston/toc/libweston/output.html): idle, scheduled, deferred and awaiting-completion states are explicit. ChonkStep's existing per-output damage/queue/vblank separation was retained; presentation ownership was corrected inside it.
+
+These are design comparisons, not a speed ranking against those compositors.
+
+## Findings and fixes
+
+### 1. High: sandbox tags did not restrict privileged protocols
+
+`privileged_global_visible` identified confined clients and then returned `true`
+for everyone. A real client admitted through `wp_security_context_v1` could see
+layer-shell and other desktop-wide capabilities despite its confinement tag.
+This was an intentional permissive policy in the previous code, but an unsafe
+boundary for applications whose launcher actually supplies a sandbox context.
+
+The shared predicate now rejects confined clients. Normal application protocols
+and ordinary desktop-helper access remain available. The live regression checks
+normal globals, denied privileged globals, and a forged bind using a numeric
+global ID learned from an unrestricted connection. The forged bind must produce
+an error, not merely disappear from registry enumeration. Native-only gamma and
+output-power globals cannot be exercised by a nested backend.
+
+The surrounding sandbox must prevent direct access to the unrestricted display
+socket. This change does not sandbox ordinary same-user processes or XWayland.
+
+### 2. High: nested hot restart reconnected to its own dead display
+
+Startup overwrites `WAYLAND_DISPLAY`/`DISPLAY` so children connect to ChonkStep.
+Nested restart preserved those values, so the replacement attempted to use the
+compositor socket destroyed by its own exec. The preserved baseline fails the
+new test with `winit backend init failed: Failed to initialize an event loop`.
+
+Capture the upstream display addresses before startup changes them and restore
+them for nested exec. Native restart still removes display addresses and pins
+DRM. Never reuse a consumed `WAYLAND_SOCKET` connection. Tests cover both display
+address kinds, absent values, native selection, two real successive nested execs,
+autostart signal delivery and clean logout afterward.
+
+An FD-only host connection with no reconnectable display address remains outside
+the tested restart contract; replaying the same initialized Wayland stream after
+exec would be invalid.
+
+### 3. Medium: invisible surfaces were paced and falsely reported as presented
+
+The old primary-output calculation chose the monitor with maximum rectangle
+intersection even when every intersection was zero. It also assigned every
+subsurface and popup its parent's output, ignoring rendering transforms and
+occlusion. An unrelated visible frame could therefore report an offscreen
+window's buffer as presented and request another invisible frame.
+
+Presentation collection now updates Smithay's per-surface primary output from
+actual render results. Frame callbacks and FIFO presentation-barrier release use
+that output. The same logic serves nested swaps and native queued frames/vblank;
+capture-only renders do not update display presentation ownership. Cursor
+surfaces participate in the same feedback/visibility collection.
+
+Real-client regressions cover offscreen sleep/reveal, opaque occlusion/uncover,
+and a visible subsurface extending from an offscreen parent, then the reverse.
+Existing FIFO, commit-timing and locked/hidden-workspace tests remain in the gate.
+The new occlusion fixture was visually reviewed: its first version used an
+ambiguous substring selector and moved the wrong window. Exact selectors and
+separate names fixed the fixture before accepting its result.
+
+### 4. Medium: appearance switches created unbounded competing workers
+
+Each switch spawned a thread whose `gsettings` `.output()` calls had neither a
+deadline nor an output limit. A stalled settings service retained one thread per
+switch; concurrent writes could finish in the wrong order.
+
+One lazy worker now serializes writes and retains one replaceable pending mode.
+It uses the existing bounded subprocess reader, with a two-second deadline per
+helper and the reader's 4 MiB output cap. Managed-theme adoption and the nested
+session opt-out remain intact. The concurrency regression holds one operation
+in progress, submits 20,001 subsequent requests, and verifies that only the
+latest pending mode runs next. Existing reader tests cover hangs, pipe overflow,
+nonzero exits and descendants holding stdout open.
+
+### 5. Low/performance: unchanged config polls cloned every watched path
+
+Every one-second poll built two vectors and cloned all paths despite an unchanged
+watch set. With 256 files, 20 polls requested **5,240 allocations / 646,000 bytes**.
+The new implementation reuses paths and updates scalar metadata in place. The
+same measured operation now requests **zero allocations / zero bytes**.
+
+All files and directories are still sampled even after detecting a change;
+rename-over inode changes, deletion, cadence and following new source files retain
+their previous semantics. Filesystem `stat` calls are intentionally unchanged.
+These numbers describe allocation requests, not RSS savings or latency.
+
+### 6. Medium: X11 property replies had effectively unbounded requested sizes
+
+Title, class and atom-list requests used `GetProperty(long_length = u32::MAX)`.
+A client-controlled property could therefore make the WM receive and allocate
+arbitrarily large replies before parsing them on the desktop thread.
+
+Requests now cap replies at 64 KiB, accounting for X11's four-byte length units.
+Titles accept a bounded prefix; oversized identities and atom lists are rejected
+so partial data cannot invent an application-rule match or protocol capability.
+String-format checks reject malformed values. The live Xvfb regression compares
+a 128 KiB property with the 64 KiB bound and checks normal UTF-8 titles/classes,
+oversized protocol/state atom lists and ordinary protocol/modal handling.
+CI now runs this regression on its own private Xvfb display.
+
+## Validation and measurements
+
+[Raw measurements and environment](2026-09-08-audit-metrics.json) include all
+paired samples, summary ranges and exact executable SHA-256 hashes. Baseline and
+candidate binaries were preserved separately. Only explanatory comments and
+review artifacts changed after the measured build; the artifact records the
+pre-cleanup hashes for those two source files.
+
+| Workload | Baseline | Candidate |
+| --- | ---: | ---: |
+| Offscreen client redraws, 120 visible frames, each of three paired runs | 120 | 0 |
+| Compositor dispatches, median of those runs | 383 | 260 |
+| Visible presentations in every run | 120 | 120 |
+| Allocation requests, 20 unchanged polls / 256 config files | 5,240 | 0 |
+| Requested bytes for those polls | 646,000 | 0 |
+| Idle CPU range, five runs | 0–0.2% | 0–0.2% |
+| Idle PSS range | 137,214–138,179 KiB | 137,066–137,948 KiB |
+| Idle descriptors / threads | 46 / 40 | 46 / 40 |
+
+The hidden client does no further redraw work, and median compositor dispatches
+fall by 32%. Both cases remain paced by the visible animation. Render/dispatch
+wall durations include nested presentation waits and are not CPU-time or
+input-latency measurements. Idle CPU quantization is approximately 0.2 percentage
+points for these five-second samples; the baseline median is 0%, candidate 0.2%.
+The overlapping ranges do not establish an idle CPU, memory or startup gain.
+Unrelated background workloads were left running.
+
+Validation completed:
+
+- Strict workspace Clippy, with disallowed blocking calls and undocumented
+  unsafe blocks denied; Rustdoc with warnings denied.
+- 2,057 Rust test successes including doctests, plus the private Xvfb oversized
+  property regression. Wayland and appearance unit suites rerun after self-review.
+- Full release-mode Wayland suite: 271 integration tests and three installed
+  Omarchy fixture checks; no missing-client skips. This includes real Chromium,
+  capture, clipboard, input constraints, geometry, locking, spatial layouts and
+  desktop-churn tests, along with the new regressions.
+- 65 Python harness tests; 44 Python SDK cases (seven intentional abstract-base
+  skips); Go SDK `go test ./...`; disposable Omarchy installer fixtures.
+- New restart, offscreen-presentation, security-context and X11-property
+  regressions demonstrated the original failures before their fixes. The config
+  allocation test recorded its failing baseline before implementation changed.
+
+Reproduction commands:
+
+```sh
+scripts/check.sh
+scripts/e2e.sh --headless --release
+xvfb-run -a cargo test --locked -p wm-x11 hostile_properties -- --ignored
+python3 -B -m unittest discover bindings/python/tests
+mise exec go@1.27.0 -- go test ./...  # from bindings/go/chonkdock
+CHONKSTEP_WAYLAND_BIN=/absolute/preserved/binary scripts/e2e.sh --headless --release --test surface_pacing offscreen_animation_work_profile --nocapture
+python3 scripts/bench-compositor.py --binary baseline=/absolute/baseline --binary candidate=/absolute/candidate --runs 5 --settle-seconds 2 --idle-seconds 5 --output /tmp/cs-audit-idle
+```
+
+All live tests and measurements used private display/bus/configuration contexts.
+The running desktop was not restarted or replaced.
+
+## Remaining work and limits
+
+- Native DRM/KMS, mixed-refresh monitors, hotplug, VT switching and GPU-reset
+  recovery require hardware validation. Nested rendering and shared-path unit
+  tests cannot establish physical presentation timing or input-to-photon latency.
+- X11 still performs synchronous property round trips. Bounding replies limits
+  resource consumption; pipelining startup atom/property requests needs its own
+  latency experiment and careful event-order review.
+- Activation admission currently caps/expires tokens but does not implement
+  a user-serial-based focus-stealing policy. That is a separate behavior
+  change requiring launch/notification compatibility tests.
+- `cargo audit` reports no advisories in its vulnerability category, but does
+  report unmaintained `cgmath` and `ttf-parser`, plus the `cgmath::swap_columns`
+  identical-index unsoundness advisory. There are no `swap_columns` call sites in
+  our crates or vendored Smithay. Dependency migration remains necessary; the
+  absence of a direct call is not a general dependency safety certificate.
+- End-user Omarchy configuration, installed binaries, login services and release
+  publication were not changed. The fixes are reviewable repository changes.

--- a/docs/engineering/2026-09-08-audit-metrics.json
+++ b/docs/engineering/2026-09-08-audit-metrics.json
@@ -1,0 +1,533 @@
+{
+  "baseline_commit": "facf999aa92a2bd06f8b411ec64e191bbb20fb6e",
+  "date": "2026-09-08",
+  "environment": {
+    "backend": "nested-winit-on-headless-weston",
+    "renderer": "llvmpipe",
+    "host_renderer": "pixman",
+    "rustc": "rustc 1.98.1 (48a229cea 2026-09-01)\nbinary: rustc\ncommit-hash: 48a229ceaefd4985c50990b14116b6d856af0985\ncommit-date: 2026-09-01\nhost: x86_64-unknown-linux-gnu\nrelease: 1.98.1\nLLVM version: 22.1.8",
+    "weston": "weston 15.0.1",
+    "page_cache": "warm/uncontrolled; no system cache dropping",
+    "load_average_at_start": [
+      6.33740234375,
+      5.888671875,
+      6.5947265625
+    ]
+  },
+  "binary_sha256": {
+    "baseline": {
+      "chonkstep-wayland": "9ae68780118b210ed81762c95ac072bb99cbdbf565a1feb7e785623f794e821f",
+      "chonkstep": "f218e5c6d26438b87094abd2929ca972b14c35633dca4822a99fd0d07348b7ec"
+    },
+    "candidate": {
+      "chonkstep-wayland": "1f95c42b0858b0089dddcf119dffcdb638d66ada2e6e17394037091bdc162b5b",
+      "chonkstep": "35539393f05f3001907a353458995bcd640bf42dfd35ee9bf79f11cb74e182be"
+    }
+  },
+  "provenance_note": "Candidate built from the audit working tree. Only explanatory comments in state.rs and virtual_keyboard.rs and review artifacts changed after this build. Preserved executable hashes identify the exact measured binaries.",
+  "pre_comment_cleanup_source_sha256": {
+    "crates/wm-wayland/src/virtual_keyboard.rs": "f5419628afea625e1fd324416e27ed5c216a6ea0867ffeacf36657d612dbbbba",
+    "crates/wm-wayland/src/state.rs": "5398752a2a5ce3269220681cec76ba234cd2119f6799e1138fd34f177786e490"
+  },
+  "offscreen_animation": {
+    "method": "Three alternating paired release runs; 120 changing visible frames and one frame-callback-driven offscreen client. Wall timings include nested presentation waits, not CPU or input latency.",
+    "samples": [
+      {
+        "run": 1,
+        "label": "baseline",
+        "dispatch_calls": 383,
+        "dispatch_us": 1957846,
+        "elapsed_us": 1999546,
+        "hidden_redraws": 120,
+        "render_calls": 120,
+        "render_us": 1942512,
+        "visible_presentations": 120
+      },
+      {
+        "run": 1,
+        "label": "candidate",
+        "dispatch_calls": 260,
+        "dispatch_us": 1967077,
+        "elapsed_us": 1992148,
+        "hidden_redraws": 0,
+        "render_calls": 120,
+        "render_us": 1959201,
+        "visible_presentations": 120
+      },
+      {
+        "run": 2,
+        "label": "candidate",
+        "dispatch_calls": 259,
+        "dispatch_us": 1970562,
+        "elapsed_us": 1993411,
+        "hidden_redraws": 0,
+        "render_calls": 120,
+        "render_us": 1962962,
+        "visible_presentations": 120
+      },
+      {
+        "run": 2,
+        "label": "baseline",
+        "dispatch_calls": 381,
+        "dispatch_us": 1956356,
+        "elapsed_us": 1994452,
+        "hidden_redraws": 120,
+        "render_calls": 120,
+        "render_us": 1940608,
+        "visible_presentations": 120
+      },
+      {
+        "run": 3,
+        "label": "baseline",
+        "dispatch_calls": 386,
+        "dispatch_us": 1954503,
+        "elapsed_us": 1999323,
+        "hidden_redraws": 120,
+        "render_calls": 120,
+        "render_us": 1940030,
+        "visible_presentations": 120
+      },
+      {
+        "run": 3,
+        "label": "candidate",
+        "dispatch_calls": 263,
+        "dispatch_us": 1968564,
+        "elapsed_us": 1994094,
+        "hidden_redraws": 0,
+        "render_calls": 120,
+        "render_us": 1960552,
+        "visible_presentations": 120
+      }
+    ],
+    "medians": {
+      "baseline": {
+        "hidden_redraws": 120,
+        "dispatch_calls": 383,
+        "elapsed_us": 1999323,
+        "render_calls": 120,
+        "dispatch_us": 1956356,
+        "render_us": 1940608
+      },
+      "candidate": {
+        "hidden_redraws": 0,
+        "dispatch_calls": 260,
+        "elapsed_us": 1993411,
+        "render_calls": 120,
+        "dispatch_us": 1968564,
+        "render_us": 1960552
+      }
+    }
+  },
+  "config_watch": {
+    "files": 256,
+    "polls": 20,
+    "baseline": {
+      "allocation_requests": 5240,
+      "requested_bytes": 646000
+    },
+    "candidate": {
+      "allocation_requests": 0,
+      "requested_bytes": 0
+    },
+    "scope": "Per-thread allocation requests; does not measure RSS, filesystem syscall reduction or elapsed time."
+  },
+  "idle": {
+    "method": "Five alternating pairs, two-second settle and five-second sampling. CPU tick resolution is approximately 0.2 percentage points per sample. Unrelated background workloads were left running. No established idle CPU, PSS or startup improvement.",
+    "summary": {
+      "baseline": {
+        "ready_ms": {
+          "median": 271.764659,
+          "min": 257.372946,
+          "max": 279.625616,
+          "samples": [
+            275.001354,
+            257.372946,
+            260.683846,
+            279.625616,
+            271.764659
+          ]
+        },
+        "frame_ms": {
+          "median": 271.99951,
+          "min": 257.617071,
+          "max": 279.78795,
+          "samples": [
+            275.190326,
+            257.617071,
+            260.895535,
+            279.78795,
+            271.99951
+          ]
+        },
+        "cpu_percent": {
+          "median": 0.0,
+          "min": 0.0,
+          "max": 0.19954747007866705,
+          "samples": [
+            0.0,
+            0.0,
+            0.19954747007866705,
+            0.0,
+            0.0
+          ]
+        },
+        "context_switches_per_second": {
+          "median": 12.371389661994213,
+          "min": 11.966269756428039,
+          "max": 12.570834657926838,
+          "samples": [
+            11.966269756428039,
+            12.570834657926838,
+            12.371943144877356,
+            12.371389661994213,
+            11.97134826827426
+          ]
+        },
+        "rss_kib": {
+          "median": 258448,
+          "min": 258032,
+          "max": 258996,
+          "samples": [
+            258448,
+            258032,
+            258416,
+            258920,
+            258996
+          ]
+        },
+        "pss_kib": {
+          "median": 137561,
+          "min": 137214,
+          "max": 138179,
+          "samples": [
+            137561,
+            137214,
+            137440,
+            137942,
+            138179
+          ]
+        },
+        "private_kib": {
+          "median": 102232,
+          "min": 101944,
+          "max": 102904,
+          "samples": [
+            102232,
+            101944,
+            102112,
+            102608,
+            102904
+          ]
+        },
+        "tree_pss_kib": {
+          "median": 188521,
+          "min": 188201,
+          "max": 189114,
+          "samples": [
+            188521,
+            188201,
+            188303,
+            188848,
+            189114
+          ]
+        },
+        "fds": {
+          "median": 46,
+          "min": 46,
+          "max": 46,
+          "samples": [
+            46,
+            46,
+            46,
+            46,
+            46
+          ]
+        },
+        "threads": {
+          "median": 40,
+          "min": 40,
+          "max": 40,
+          "samples": [
+            40,
+            40,
+            40,
+            40,
+            40
+          ]
+        }
+      },
+      "candidate": {
+        "ready_ms": {
+          "median": 260.7219,
+          "min": 256.820933,
+          "max": 275.388007,
+          "samples": [
+            259.709746,
+            275.388007,
+            256.820933,
+            262.357378,
+            260.7219
+          ]
+        },
+        "frame_ms": {
+          "median": 260.845528,
+          "min": 257.051368,
+          "max": 275.581003,
+          "samples": [
+            259.905181,
+            275.581003,
+            257.051368,
+            262.588584,
+            260.845528
+          ]
+        },
+        "cpu_percent": {
+          "median": 0.1995266249976487,
+          "min": 0.0,
+          "max": 0.1995350507675912,
+          "samples": [
+            0.1995350507675912,
+            0.0,
+            0.19953403873464703,
+            0.1995266249976487,
+            0.0
+          ]
+        },
+        "context_switches_per_second": {
+          "median": 11.972430187075956,
+          "min": 11.97204232407882,
+          "max": 12.17112412485657,
+          "samples": [
+            11.972103046055473,
+            11.972430187075956,
+            11.97204232407882,
+            12.17112412485657,
+            11.972838275414336
+          ]
+        },
+        "rss_kib": {
+          "median": 258204,
+          "min": 257908,
+          "max": 258888,
+          "samples": [
+            258204,
+            258888,
+            258200,
+            257908,
+            258448
+          ]
+        },
+        "pss_kib": {
+          "median": 137363,
+          "min": 137066,
+          "max": 137948,
+          "samples": [
+            137363,
+            137948,
+            137275,
+            137066,
+            137600
+          ]
+        },
+        "private_kib": {
+          "median": 102048,
+          "min": 101784,
+          "max": 102628,
+          "samples": [
+            102048,
+            102628,
+            101956,
+            101784,
+            102312
+          ]
+        },
+        "tree_pss_kib": {
+          "median": 188268,
+          "min": 187931,
+          "max": 188864,
+          "samples": [
+            188268,
+            188864,
+            188158,
+            187931,
+            188512
+          ]
+        },
+        "fds": {
+          "median": 46,
+          "min": 46,
+          "max": 46,
+          "samples": [
+            46,
+            46,
+            46,
+            46,
+            46
+          ]
+        },
+        "threads": {
+          "median": 40,
+          "min": 40,
+          "max": 40,
+          "samples": [
+            40,
+            40,
+            40,
+            40,
+            40
+          ]
+        }
+      }
+    }
+  },
+  "validation": {
+    "rust_tests_including_doctests": 2057,
+    "wayland_integration_tests": 271,
+    "installed_omarchy_checks": 3,
+    "missing_client_skips": 0,
+    "python_harness_tests": 65,
+    "python_sdk_cases": 44,
+    "python_sdk_abstract_base_skips": 7,
+    "go_sdk": "go test ./... passed via mise exec go@1.27.0",
+    "x11_oversized_properties": "Passed on private Xvfb; test added to CI",
+    "clippy": "Strict workspace all-targets passed",
+    "rustdoc": "Warnings denied, passed"
+  },
+  "dependency_audit": {
+    "vulnerability_category_count": 0,
+    "warnings": [
+      {
+        "kind": "unmaintained",
+        "id": "RUSTSEC-2026-0196",
+        "package": "cgmath",
+        "title": "`cgmath` is unmaintained"
+      },
+      {
+        "kind": "unmaintained",
+        "id": "RUSTSEC-2026-0192",
+        "package": "ttf-parser",
+        "title": "`ttf-parser` is unmaintained"
+      },
+      {
+        "kind": "unsound",
+        "id": "RUSTSEC-2026-0197",
+        "package": "cgmath",
+        "title": "`Matrix{2,3,4}::swap_columns` can trigger undefined behavior for identical indices"
+      }
+    ]
+  },
+  "source_inventory": {
+    "bindings/go": [
+      6,
+      2428
+    ],
+    "bindings/python": [
+      7,
+      2383
+    ],
+    "crates/chonk-about": [
+      1,
+      92
+    ],
+    "crates/chonk-btpair": [
+      7,
+      2156
+    ],
+    "crates/chonk-build-info": [
+      2,
+      154
+    ],
+    "crates/chonk-dock-proto": [
+      7,
+      6482
+    ],
+    "crates/chonk-dock-widget": [
+      3,
+      1487
+    ],
+    "crates/chonk-hyprland-ipc": [
+      7,
+      4742
+    ],
+    "crates/chonk-instruments": [
+      23,
+      13021
+    ],
+    "crates/chonk-netjoin": [
+      7,
+      1776
+    ],
+    "crates/chonk-shell": [
+      27,
+      30110
+    ],
+    "crates/chonk-test-support": [
+      1,
+      146
+    ],
+    "crates/chonk-testkit": [
+      90,
+      29829
+    ],
+    "crates/chonk-toplevel": [
+      1,
+      587
+    ],
+    "crates/chonk-ui": [
+      4,
+      1239
+    ],
+    "crates/chonk-xsettings": [
+      7,
+      3953
+    ],
+    "crates/chonkstep": [
+      2,
+      713
+    ],
+    "crates/chonkstep-wayland": [
+      2,
+      210
+    ],
+    "crates/wm-config": [
+      12,
+      12419
+    ],
+    "crates/wm-core": [
+      18,
+      15679
+    ],
+    "crates/wm-theme": [
+      37,
+      15467
+    ],
+    "crates/wm-theme-api": [
+      4,
+      420
+    ],
+    "crates/wm-wayland": [
+      56,
+      44421
+    ],
+    "crates/wm-x11": [
+      2,
+      3553
+    ],
+    "examples": [
+      8,
+      3262
+    ],
+    "omarchy": [
+      2,
+      634
+    ],
+    "packaging": [
+      2,
+      239
+    ],
+    "scripts": [
+      39,
+      6339
+    ]
+  }
+}

--- a/docs/hyprland-ipc.md
+++ b/docs/hyprland-ipc.md
@@ -239,9 +239,12 @@ presentation feedback comes from winit presentation or DRM vblank.
 FIFO barriers release at that same presentation boundary; commit
 timestamps arm the event loop's monotonic-clock deadline, and invisible
 surfaces cannot remain wedged behind an unpresentable barrier. Security
-contexts tag admitted clients and every cross-client capability consults
-one shared policy predicate; the current single-user policy remains
-permissive, preserving ordinary and confined-client behavior.
+contexts tag admitted clients. A shared policy hides privileged globals from
+those clients, including capture, input injection, clipboard monitoring,
+layer surfaces and output/session management. Ordinary desktop helpers retain
+access; confined applications keep normal window, input and focused clipboard
+protocols. This boundary requires the sandbox launcher to use a security-context
+listener and prevent access to the unrestricted display socket.
 Tablet proximity, tip, buttons, pressure, distance, tilt, rotation,
 slider and wheel are forwarded from libinput.
 


### PR DESCRIPTION
Clients could receive presentation reports for invisible buffers, nested restart reconnected to the compositor's own dead display, and sandbox-tagged clients retained desktop-wide privileges. This audit fixes those paths and bounds additional shell/X11 work.

- Use actual render visibility for presentation, frame callbacks and FIFO release, including subsurfaces, popups and cursor surfaces.
- Restore upstream display addresses across nested exec and verify repeated restart followed by clean logout.
- Deny privileged globals to security-context clients; verify both registry filtering and forged-bind rejection.
- Serialize/coalesce appearance writes through one worker with bounded subprocess waits.
- Cap X11 title/class/atom-property replies at 64 KiB; add a private Xvfb regression to CI.
- Reuse config-watch paths instead of allocating each poll.

Three paired release runs reduced offscreen redraws from 120 to zero and median compositor dispatches from 383 to 260 while preserving all 120 visible frames. Twenty unchanged polls over 256 config files dropped from 5,240 allocation requests / 646,000 requested bytes to zero. Idle CPU/PSS ranges overlapped; no idle-memory or latency improvement is claimed.

Validation: strict workspace Clippy and Rustdoc; 2,057 Rust test successes including doctests; 271 release-mode Wayland integration tests plus three installed-Omarchy checks with no missing-client skips; private Xvfb regression; Python/Go SDK tests and installer fixtures. Original failures were reproduced against the preserved baseline.

The [review report](https://github.com/iconidentify/chonkstep/blob/2963182db5c781c56df8a4065cb0cb31d11e7dc8/docs/engineering/2026-09-08-adversarial-review.md) compares Niri, Sway and Weston and records coverage and remaining work. [Measurements](https://github.com/iconidentify/chonkstep/blob/2963182db5c781c56df8a4065cb0cb31d11e7dc8/docs/engineering/2026-09-08-audit-metrics.json) include all paired samples and binary hashes. Native DRM/mixed-refresh hardware validation and existing dependency advisories remain explicit limitations.

Based on #147 (`fix/wayland-resize-and-logout`), which contains the preceding resize/logout fixes. This PR adds only the audit changes. No installed desktop or release was changed.

Download: [CI amd64 Debian package](https://github.com/iconidentify/chonkstep/actions/runs/34245051567/artifacts/10063746404), built from this PR head and verified against its published SHA-256 file. The artifact expires September 22, 2026; downloading requires GitHub sign-in.

Final CI: all nine applicable checks passed, including the hosted Wayland suite, X11 smoke test, dependency audit, SDKs, installer checks, and both package-variant checks. Release-promotion jobs correctly skipped for this unmerged PR.
