### PR TITLE
Finish capture review, recording color, and nested repaint fixes

### DIFF
--- a/crates/chonk-testkit/src/lib.rs
+++ b/crates/chonk-testkit/src/lib.rs
@@ -1646,6 +1646,19 @@ impl Door {
         })
     }
 
+    /// Retained incoming/outgoing XWM transfers, including unremoved completed entries.
+    pub fn selection_transfers(&mut self) -> Result<(usize, usize), String> {
+        self.send("selection-transfers")?;
+        let line = self.read_line()?;
+        if !line.starts_with("selection-transfers ") {
+            return Err(format!("unexpected selection-transfers reply: {line}"));
+        }
+        Ok((
+            field(&line, "incoming=").ok_or_else(|| format!("missing incoming count: {line}"))?,
+            field(&line, "outgoing=").ok_or_else(|| format!("missing outgoing count: {line}"))?,
+        ))
+    }
+
     /// Number of protocol snapshots/synchronizations attempted so far.
     /// Unlike counting output events, this detects an expensive full diff
     /// that rebuilt state only to discover that nothing changed.

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -727,6 +727,11 @@ fn recording_screen_and_area_preserve_changing_content() {
         for rgb in decoded.stdout.as_chunks::<3>().0 {
             let is_red = rgb[0] > 150 && rgb[2] < 100;
             let is_blue = rgb[2] > 150 && rgb[0] < 100;
+            if is_red || is_blue {
+                let expected: [u8; 3] = if is_red { [240, 20, 20] } else { [20, 20, 240] };
+                assert!(rgb.iter().zip(expected).all(|(actual, expected)| actual.abs_diff(expected) < 8),
+                    "recording mode {mode} preserves RGB levels: {rgb:?} vs {expected:?}");
+            }
             red |= is_red;
             blue |= is_blue;
             if is_red || is_blue {

--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -66,7 +66,7 @@ fn boot(name: &str, scale: f32) -> Session {
                 "hypr/hyprland.conf".into(),
                 "bind = SUPER, F12, workspace, 1\nbind = , PRINT, exec, omarchy-capture-screenshot\n".into(),
             )],
-            config_files: ["xdg-open", "omacut"]
+            config_files: ["imv", "omacut"]
                 .into_iter()
                 .map(|program| (format!("fixture-bin/{program}"), wrapper.into()))
                 .chain(std::iter::once(("fixture-bin/notify-send".into(), notification.into())))
@@ -95,7 +95,7 @@ fn boot(name: &str, scale: f32) -> Session {
     .unwrap();
     // Session::boot recreates the session directory, so chmod must happen
     // after boot and before sending the first capture shortcut.
-    for program in ["xdg-open", "omacut", "notify-send"] {
+    for program in ["imv", "omacut", "notify-send"] {
         std::fs::set_permissions(
             fixture_bin.join(program),
             std::fs::Permissions::from_mode(0o700),
@@ -195,7 +195,7 @@ fn window_click_workflow(scale: f32, name: &str) {
     let image = Screenshot::load(&path).unwrap();
     let frame = world.frame_of(window.id).unwrap();
     assert_eq!((image.width, image.height), (frame.w, frame.h));
-    reviews_opened(&session, &[("xdg-open", &path)]);
+    reviews_opened(&session, &[("imv", &path)]);
     session.door().tap_key(30).unwrap();
     poll_until(
         Duration::from_secs(5),
@@ -343,7 +343,7 @@ fn screenshot_workflow(scale: f32, name: &str) {
     let before = session.screenshot("before").unwrap();
     shortcut(&mut session, 3);
     let path = saved(&exports, 1, "png");
-    reviews_opened(&session, &[("xdg-open", &path)]);
+    reviews_opened(&session, &[("imv", &path)]);
     assert_eq!(notification_preview(&session, &path, "Screenshot saved"), path);
     let full = Screenshot::load(&path).unwrap();
     assert_eq!((full.width, full.height), (before.width, before.height));
@@ -381,7 +381,7 @@ fn screenshot_workflow(scale: f32, name: &str) {
     session.door().button("left", false).unwrap();
     session.door().barrier().unwrap();
     let area_path = saved(&exports, 2, "png");
-    reviews_opened(&session, &[("xdg-open", &path), ("xdg-open", &area_path)]);
+    reviews_opened(&session, &[("imv", &path), ("imv", &area_path)]);
     assert_eq!(notification_preview(&session, &area_path, "Screenshot saved"), area_path);
     let area = Screenshot::load(&area_path).unwrap();
     assert_eq!(
@@ -418,9 +418,9 @@ fn screenshot_workflow(scale: f32, name: &str) {
     reviews_opened(
         &session,
         &[
-            ("xdg-open", &path),
-            ("xdg-open", &area_path),
-            ("xdg-open", &window_path),
+            ("imv", &path),
+            ("imv", &area_path),
+            ("imv", &window_path),
         ],
     );
     let shot = Screenshot::load(&window_path).unwrap();
@@ -1061,7 +1061,7 @@ fn toolbar_screen_modes_work_without_moving_off_the_toolbar_and_badge_stops() {
     assert!(preview.width <= 256 && preview.height <= 256);
     reviews_opened(
         &session,
-        &[("xdg-open", &screenshot_path), ("omacut", &path)],
+        &[("imv", &screenshot_path), ("omacut", &path)],
     );
     assert!(Command::new("ffprobe")
         .args(["-v", "error"])

--- a/crates/chonk-testkit/tests/mac_mode.rs
+++ b/crates/chonk-testkit/tests/mac_mode.rs
@@ -478,14 +478,15 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
     let fixture_bin = root.join("config/chonkstep/bin");
     let mut paths = vec![fixture_bin.clone()];
     paths.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap()));
+    let review_wrapper = "#!/bin/sh\npublished=missing\nif [ \"$#\" -eq 1 ] && [ -s \"$1\" ]; then published=published; fi\nprintf '%s\\0' \"${0##*/}\" \"$1\" \"$published\" >> \"$MAC_REVIEW_LOG\"\n";
     let mut s = Session::boot(
         "mac-capture",
         SessionOptions {
             config_extra: "interaction_mode = 'mac'\nhyprland_config = false\nshow_dock = false\n".into(),
             config_files: vec![
-                ("bin/xdg-open".into(), "#!/bin/sh\n: > \"$MAC_REVIEW_LOG\"\n".into()),
+                ("bin/imv".into(), review_wrapper.into()),
                 ("bin/notify-send".into(), "#!/bin/sh\nexit 0\n".into()),
-                ("bin/omacut".into(), "#!/bin/sh\n: > \"$MAC_REVIEW_LOG\"\n".into()),
+                ("bin/omacut".into(), review_wrapper.into()),
             ],
             env: vec![
                 ("OMARCHY_SCREENSHOT_DIR".into(), exports.display().to_string()),
@@ -503,7 +504,7 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
         },
     )
     .unwrap();
-    for name in ["xdg-open", "notify-send", "omacut"] {
+    for name in ["imv", "notify-send", "omacut"] {
         std::fs::set_permissions(fixture_bin.join(name), std::fs::Permissions::from_mode(0o700)).unwrap();
     }
     let mut b = browser(&mut s, "wayland", "capture");
@@ -525,6 +526,11 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
     let path = poll_until(WAIT, "Command-Shift-3 saves PNG", || files().into_iter().next()).unwrap();
     let screenshot = chonk_testkit::Screenshot::load(&path).unwrap();
     assert_eq!((screenshot.width, screenshot.height), (1280, 800));
+    let reviews = || std::fs::read(root.join("review-launched")).unwrap_or_default();
+    let mut expected_reviews = format!("imv\0{}\0published\0", path.display()).into_bytes();
+    poll_until(WAIT, "saved Mac screenshot opens in imv after publication", || {
+        (reviews() == expected_reviews).then_some(())
+    }).unwrap();
     focus(&mut s, &mut b, "target");
     chord(&mut s, &[CMD], 47);
     expect(&mut b, "target", CONTENT);
@@ -554,10 +560,7 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
     .unwrap();
     chonk_testkit::Screenshot::load(&png).unwrap();
     assert_eq!(files().len(), 1, "clipboard capture must not save a user file");
-    assert!(
-        !root.join("review-launched").exists(),
-        "Mac capture must not open a viewer"
-    );
+    assert_eq!(reviews(), expected_reviews, "clipboard-only capture must not open another viewer");
     chord(&mut s, &[CMD, SHIFT], 5);
     chord(&mut s, &[], 1);
     assert_eq!(files().len(), 1, "Escape cancels the selection");
@@ -591,7 +594,7 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
             "-of",
             "json",
         ])
-        .arg(recording)
+        .arg(&recording)
         .stdout(Stdio::from(std::fs::File::create(&probe).unwrap()))
         .spawn()
         .unwrap();
@@ -604,10 +607,10 @@ fn screenshot_file_and_clipboard_destinations_are_independent() {
     assert_eq!(info["streams"][0]["width"], 300);
     assert_eq!(info["streams"][0]["height"], 200);
     assert!(info["format"]["duration"].as_str().unwrap().parse::<f64>().unwrap() > 1.0);
-    assert!(
-        !root.join("review-launched").exists(),
-        "Mac recording must not open an editor"
-    );
+    expected_reviews.extend_from_slice(format!("omacut\0{}\0published\0", recording.display()).as_bytes());
+    poll_until(WAIT, "saved Mac recording opens in omacut after publication", || {
+        (reviews() == expected_reviews).then_some(())
+    }).unwrap();
 }
 
 #[test]
@@ -783,21 +786,28 @@ fn overlapping_navigation_both_commands_caps_lock_and_mode_rollback() {
 #[test]
 #[ignore = "scripts/e2e.sh --headless --test mac_mode"]
 fn german_and_french_layouts_use_their_own_letters_and_shifted_digits() {
+    use std::os::unix::fs::PermissionsExt;
     for (layout, z) in [("de", 21), ("fr", 17)] {
         let name = format!("mac-layout-{layout}");
         let exports = chonk_testkit::session_dir(&name).join("exports");
+        let fixture_bin = chonk_testkit::session_dir(&name).join("config/chonkstep/bin");
+        let mut paths = vec![fixture_bin.clone()];
+        paths.extend(std::env::split_paths(&std::env::var_os("PATH").unwrap()));
         let mut s = Session::boot(
             &name,
             SessionOptions {
                 config_extra: "interaction_mode='mac'\nhyprland_config=false\nshow_dock=false\n".into(),
+                config_files: vec![("bin/imv".into(), "#!/bin/sh\nexit 0\n".into())],
                 env: vec![
                     ("XKB_DEFAULT_LAYOUT".into(), layout.into()),
                     ("OMARCHY_SCREENSHOT_DIR".into(), exports.display().to_string()),
+                    ("PATH".into(), std::env::join_paths(paths).unwrap().into_string().unwrap()),
                 ],
                 ..Default::default()
             },
         )
         .unwrap();
+        std::fs::set_permissions(fixture_bin.join("imv"), std::fs::Permissions::from_mode(0o700)).unwrap();
         let mut b = browser(&mut s, "wayland", layout);
         focus(&mut s, &mut b, "source");
         let a = if layout == "fr" { 16 } else { 30 };

--- a/crates/chonk-testkit/tests/selection_transfer.rs
+++ b/crates/chonk-testkit/tests/selection_transfer.rs
@@ -575,6 +575,8 @@ fn a_stalled_x11_paste_applies_backpressure_instead_of_buffering_the_whole_paylo
     let mut x11 = x_selection::XSelection::new(&mut session, "application/octet-stream", b"unused");
     let before = anonymous_kib(&session);
     x11.hold_receive(false);
+    assert_eq!(session.door().selection_transfers().unwrap(), (0, 1),
+        "the read-only counter includes a live backpressured transfer");
     let completed = format!("send {} Ok(())", payload.len());
     let prematurely_drained = poll_until(
         Duration::from_millis(500),
@@ -846,21 +848,22 @@ fn completed_small_pastes_do_not_retain_a_buffer_per_live_requestor() {
     }
     session.door().barrier().unwrap();
     let after = anonymous_kib(&session);
+    let transfers = session.door().selection_transfers().unwrap();
     std::fs::write(
         session.dir.join("completed-retention.json"),
         serde_json::to_vec_pretty(&serde_json::json!({
             "payload_bytes": payload.len(), "requestors": 128,
             "anonymous_before_kib": before, "anonymous_after_kib": after,
+            "incoming_transfers": transfers.0, "outgoing_transfers": transfers.1,
         }))
         .unwrap(),
     )
     .unwrap();
     assert_eq!(x11.received_incremental, 0);
-    assert!(
-        after.saturating_sub(before) < 4 * 1024,
-        "completed pastes retained {} KiB with requestors still alive",
-        after.saturating_sub(before)
-    );
+    // Process PSS also includes lazy software-renderer buffers and allocator
+    // arenas. Keep it as diagnostic evidence; assert the actual retained state
+    // instead. Even one leaked completed transfer must fail this check.
+    assert_eq!(transfers, (0, 0), "completed transfers remain with requestors still alive");
 }
 
 fn native_roundtrip(name: &str, mime: &str, payload: &[u8]) {

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -52,8 +52,7 @@ enum ReviewKind {
 impl ReviewKind {
     fn program(self) -> &'static str {
         match self {
-            // Omarchy defaults PNG to imv. Respect a user's replacement too.
-            Self::Screenshot => "xdg-open",
+            Self::Screenshot => "imv",
             Self::Recording => "omacut",
         }
     }
@@ -554,14 +553,15 @@ pub(super) fn start() -> (
                         Ok(path) => {
                             // The file is synced and published: opening it
                             // need not wait for the clipboard liveness check.
+                            if destination != Destination::Clipboard {
+                                background.review(ReviewKind::Screenshot, path.clone());
+                            }
                             if destination == Destination::File {
                                 let _ = updates.try_send(Update::ScreenshotDone);
                                 background.notify_with_icon("Screenshot saved", &path.display().to_string(), NotificationIcon::Image(&path));
                                 continue;
                             }
-                            if destination == Destination::Legacy {
-                                background.review(ReviewKind::Screenshot, path.clone());
-                            } else { temporary.insert(path.clone()); }
+                            if destination == Destination::Clipboard { temporary.insert(path.clone()); }
                             if let Err(path) = clipboard.enqueue(path) {
                                 let _ = updates.try_send(Update::ScreenshotDone);
                                 if temporary.remove(&path) {
@@ -925,6 +925,9 @@ fn record(output: &str, geometry: &str, filter: &str, policy: Destination) -> Re
     // Keep the recorder's explicit signal defaults for its SIGINT stop path.
     // General child signal delivery is established by termination.rs; this
     // older recorder-specific boundary also resets ignored dispositions.
+    // wf-recorder releases disagree on automatic RGB-to-YUV range conversion.
+    // Set both the conversion and encoder metadata, including older FFmpeg.
+    let filter = format!("{filter},scale=in_range=pc:out_range=tv,format=yuv420p");
     let child = Command::new("env")
         .args(["--default-signal=INT,TERM,HUP", "wf-recorder"])
         .args([
@@ -941,9 +944,7 @@ fn record(output: &str, geometry: &str, filter: &str, policy: Destination) -> Re
             "preset=veryfast",
             "-p",
             "crf=18",
-            // RGB capture is converted to limited-range yuv420p. Match the
-            // encoder metadata; wf-recorder otherwise labels it full-range
-            // on newer FFmpeg, lifting blacks and compressing highlights.
+            // Match the explicit limited-range conversion below.
             "-p",
             "color_range=tv",
             "-r",
@@ -951,7 +952,7 @@ fn record(output: &str, geometry: &str, filter: &str, policy: Destination) -> Re
             "-x",
             "yuv420p",
             "-F",
-            filter,
+            &filter,
             "-f",
         ])
         .arg(&partial)
@@ -961,7 +962,7 @@ fn record(output: &str, geometry: &str, filter: &str, policy: Destination) -> Re
         .spawn();
     match child {
         Ok(child) => Ok(Recording {
-            review: policy == Destination::Legacy,
+            review: policy != Destination::Clipboard,
             child,
             partial,
             destination,
@@ -1086,7 +1087,7 @@ mod tests {
             // PATH belongs to each Command, never the multithreaded test process.
             // GNU env is real; both review apps are isolated argument recorders.
             symlink("/usr/bin/env", directory.join("env")).unwrap();
-            for program in ["xdg-open", "omacut"] {
+            for program in ["imv", "omacut"] {
                 let executable = directory.join(program);
                 std::fs::write(&executable, b"#!/bin/sh\nprintf '%s\\0' \"$0\" \"$@\" > \"$CAPTURE_REVIEW_LOG\"\nif [ \"$CAPTURE_REVIEW_WAIT\" = 1 ]; then exec /usr/bin/sleep 30; fi\nexit \"$CAPTURE_REVIEW_EXIT\"\n").unwrap();
                 std::fs::set_permissions(executable, std::fs::Permissions::from_mode(0o700))
@@ -1231,7 +1232,7 @@ mod tests {
             .background
             .launch_review(ReviewKind::Screenshot, path, &mut command)
             .unwrap_err();
-        assert!(error.contains("xdg-open"));
+        assert!(error.contains("imv"));
         assert!(fixture.background.reviews.is_empty());
     }
 

--- a/crates/wm-wayland/src/capture_tool/worker.rs
+++ b/crates/wm-wayland/src/capture_tool/worker.rs
@@ -941,6 +941,11 @@ fn record(output: &str, geometry: &str, filter: &str, policy: Destination) -> Re
             "preset=veryfast",
             "-p",
             "crf=18",
+            // RGB capture is converted to limited-range yuv420p. Match the
+            // encoder metadata; wf-recorder otherwise labels it full-range
+            // on newer FFmpeg, lifting blacks and compressing highlights.
+            "-p",
+            "color_range=tv",
             "-r",
             "60",
             "-x",

--- a/crates/wm-wayland/src/renderer.rs
+++ b/crates/wm-wayland/src/renderer.rs
@@ -1059,6 +1059,12 @@ fn make_winit_surface_current(
     // buffer. Keep ownership in the backend; only copy its raw handles
     // to avoid overlapping renderer/surface accessor borrows.
     drop(backend.bind().map_err(|error| format!("bind: {error:?}"))?);
+    backend.renderer().with_context(|gl| {
+        // SAFETY: with_context owns this renderer's current context. Restore
+        // the default framebuffer before latching the EGL window backbuffer;
+        // captures can leave an offscreen framebuffer bound.
+        unsafe { gl.BindFramebuffer(smithay::backend::renderer::gles::ffi::FRAMEBUFFER, 0); }
+    }).map_err(|error| format!("default framebuffer: {error:?}"))?;
     let context = backend.renderer().egl_context();
     let handle = context.get_context_handle();
     let display = context.display().get_display_handle();

--- a/crates/wm-wayland/src/test_door.rs
+++ b/crates/wm-wayland/src/test_door.rs
@@ -73,6 +73,7 @@
 //! | `hyprland-sources` | replies with desired and registered Hyprland IPC calloop-source counts |
 //! | `memory-stats` | opt-in memory-profile builds only: Rust, allocator and glyph-cache counters; no payloads |
 //! | `selection-devices` | read-only retained core/primary/wlr/ext device counts, including dead resources |
+//! | `selection-transfers` | read-only retained XWM incoming/outgoing transfer counts; no cleanup or payloads |
 //! | `hit X Y` | replies with `hit root\|shell\|frame\|content\|layer\|ime\|lock` from the production scene hit-test |
 //! | `barrier` | replies `ok` once every command before it has been dispatched **and** a frame has been rendered with no damage left over |
 //! | `windows` | replies one line per ledger entry (see below), then `done` |
@@ -805,6 +806,16 @@ fn handle_command(line: &str, stream: &mut UnixStream, comp: &mut Compositor) {
                 "selection-devices core={} primary={} wlr={} ext={} dead={}\n",
                 counts.core, counts.primary, counts.wlr, counts.ext, counts.dead,
             ).as_bytes());
+        }
+        Some("selection-transfers") => {
+            if let Some(wm) = comp.xwayland.wm.as_ref() {
+                let (incoming, outgoing) = wm.selection_transfer_counts();
+                let _ = stream.write_all(format!(
+                    "selection-transfers incoming={incoming} outgoing={outgoing}\n"
+                ).as_bytes());
+            } else {
+                let _ = stream.write_all(b"selection-transfers unavailable\n");
+            }
         }
         #[cfg(feature = "memory-profile")]
         Some("memory-stats") => {

--- a/docs/capture.md
+++ b/docs/capture.md
@@ -68,13 +68,14 @@ destinations directly. Filenames contain the date, time and a unique suffix.
 Overrides must be absolute paths.
 Existing files are never replaced; published captures have owner-only access.
 
-Every successful screenshot also offers the exact saved PNG as `image/png` on
+In desktop mode, every successful screenshot also offers the exact saved PNG as `image/png` on
 the Wayland clipboard. Saving does not depend on clipboard availability; the
 completion notification distinguishes those outcomes. Failed writes are
 reported and do not leave the input grab active. After a successful save, the
-screenshot opens in the default image viewer through `xdg-open` (imv on a
-standard Omarchy installation). Your chosen default is respected. An unavailable
-viewer does not undo the saved file or clipboard copy.
+screenshot opens directly in imv. Saved screenshots in Mac mode also open in
+imv, while leaving the clipboard unchanged. Clipboard-only Mac screenshots do
+not open a viewer. An unavailable viewer does not undo the saved file or
+clipboard copy. See [Mac mode](mac-mode.md) for its Desktop-directory default.
 
 Saved-capture notifications show the screenshot itself or a small first-frame
 preview of the recording. Video previews are generated asynchronously and kept
@@ -112,8 +113,9 @@ than silently cropped.
 
 Dependencies are included in the Arch package and source installer:
 `wl-clipboard`, `wf-recorder`, `ffmpeg`, `libnotify`, `xdg-user-dirs`, and
-`xdg-utils`. Omacut is provided by the Omarchy desktop; standalone installations
-need it installed to review recordings automatically.
+`xdg-utils`. Automatic review additionally needs `imv` for screenshots and
+`omacut` for recordings in either keyboard mode. Both are provided by the
+Omarchy desktop; standalone installations should install them separately.
 
 Review applications and notifications are launched asynchronously. At most 16
 review processes started by capture are tracked at once; further screenshots

--- a/docs/engineering/2026-09-10-release-review.md
+++ b/docs/engineering/2026-09-10-release-review.md
@@ -18,6 +18,7 @@ prerelease through `preview-v0.5.0`, not a claim of complete macOS compatibility
 | X11 client sets its title before mapping and never changes it | The cached title remained empty | Initialize the title cache when creating its record; exercised by the XWayland miniature workflow |
 | A browser or terminal changes its title during an Overview drag | Semantic refresh cancelled the held gesture | Preserve the gesture and its visual when card geometry and desktop identities are unchanged; invalidate layout or target changes |
 | Record RGB desktop content through newer wf-recorder/FFmpeg | Limited-range YUV was tagged full-range, lifting blacks and compressing highlights | Set the encoder's color range explicitly; real screen/region recording failed with red 226 instead of 240 before and passes the RGB-level assertion after |
+| Reuse a nested EGL window after offscreen capture | An offscreen framebuffer could still be bound when querying window buffer age; a recording retained a selection edge | Bind the default framebuffer before latching/querying the window target; three consecutive recordings passed all 135 checked frames and nine complete overlay-image comparisons |
 
 The clipboard tests toggle the live profile three times and verify exact UTF-8
 text after the original owner exits. The Mac key regression also toggles eight
@@ -109,6 +110,14 @@ worker and the demo recorder. The real recording workflow checks RGB fidelity fo
 both screen and area modes; the demo verifies raw and captioned video against its
 PNG. Two harness regressions reject uniformly washed-out video even when every
 frame has consistent pixels.
+
+A later recording retained a thin selection edge in both the parent screenshot
+and video. The nested target setup now also restores the default framebuffer
+before making the window surface current and querying its age. Incremental
+rendering remains enabled. The demo compares each complete capture-overlay PNG
+with an independent full repaint, excluding only the fixture's small pulsing dot.
+The failing image is rejected by this check; all nine overlay pairs in three
+consecutive corrected recordings matched exactly outside that dot.
 
 ## Limits and defaults
 

--- a/docs/engineering/2026-09-10-release-review.md
+++ b/docs/engineering/2026-09-10-release-review.md
@@ -130,6 +130,14 @@ and no viewer for clipboard-only captures. Desktop-mode workflows cover launch
 failures and ensure failed saves never launch an app. The reusable demo also
 opens the actual installed applications and displays the saved PNG and MP4.
 
+Release CI also exposed the completed-paste test's process-memory heuristic:
+5,128 KiB of anonymous growth exceeded its 4 MiB allowance. The regression now
+inspects retained XWM transfer records directly, requiring zero after 128 pastes
+while every requestor stays alive. Process memory remains recorded as diagnostic
+evidence. A held transfer must report one; a deliberately broken test executable
+that skips completed-transfer removal reports 129 and fails. The read-only
+diagnostic neither cleans up records nor exposes clipboard contents.
+
 The accelerated-path flags remain separate, opt-in experiments. Hardware results
 are in the [cross-GPU report](../benchmarks/cross-gpu-2026-09-10/README.md), including
 the Apple scanout regression and test conditions. Nested tests establish protocol,

--- a/docs/engineering/2026-09-10-release-review.md
+++ b/docs/engineering/2026-09-10-release-review.md
@@ -17,6 +17,7 @@ prerelease through `preview-v0.5.0`, not a claim of complete macOS compatibility
 | Scene imports run after querying a nested EGL backbuffer age | NVIDIA recordings could retain dimmed strips on some reused buffers | Complete imports and GPU-timer setup before latching/querying the backbuffer; verify every frame during a stable capture hold |
 | X11 client sets its title before mapping and never changes it | The cached title remained empty | Initialize the title cache when creating its record; exercised by the XWayland miniature workflow |
 | A browser or terminal changes its title during an Overview drag | Semantic refresh cancelled the held gesture | Preserve the gesture and its visual when card geometry and desktop identities are unchanged; invalidate layout or target changes |
+| Record RGB desktop content through newer wf-recorder/FFmpeg | Limited-range YUV was tagged full-range, lifting blacks and compressing highlights | Set the encoder's color range explicitly; real screen/region recording failed with red 226 instead of 240 before and passes the RGB-level assertion after |
 
 The clipboard tests toggle the live profile three times and verify exact UTF-8
 text after the original owner exits. The Mac key regression also toggles eight
@@ -100,6 +101,14 @@ checks and ffprobe metadata. Spaces additionally records actual membership
 checkpoints. Captioned share videos retain the same uncut footage; the original
 recording is included separately. Final publication must use the release binary,
 not a relabeled rehearsal.
+
+Final video QA also compares decoded dark pixels with the independent screenshot.
+The old recording path changed the fixture's RGB `[240, 20, 20]` to `[226, 32, 32]`.
+The encoder now labels its limited-range YUV correctly in both the actual capture
+worker and the demo recorder. The real recording workflow checks RGB fidelity for
+both screen and area modes; the demo verifies raw and captioned video against its
+PNG. Two harness regressions reject uniformly washed-out video even when every
+frame has consistent pixels.
 
 ## Limits and defaults
 

--- a/docs/engineering/2026-09-10-release-review.md
+++ b/docs/engineering/2026-09-10-release-review.md
@@ -105,8 +105,10 @@ not a relabeled rehearsal.
 
 Final video QA also compares decoded dark pixels with the independent screenshot.
 The old recording path changed the fixture's RGB `[240, 20, 20]` to `[226, 32, 32]`.
-The encoder now labels its limited-range YUV correctly in both the actual capture
-worker and the demo recorder. The real recording workflow checks RGB fidelity for
+The worker and demo recorder now explicitly convert RGB to limited-range YUV and
+label it correctly. Older Ubuntu wf-recorder/FFmpeg otherwise used a full-range
+conversion; its real regression failed before the explicit conversion and passed
+after. The real recording workflow checks RGB fidelity for
 both screen and area modes; the demo verifies raw and captioned video against its
 PNG. Two harness regressions reject uniformly washed-out video even when every
 frame has consistent pixels.
@@ -120,6 +122,13 @@ The failing image is rejected by this check; all nine overlay pairs in three
 consecutive corrected recordings matched exactly outside that dot.
 
 ## Limits and defaults
+
+Saved captures now open in both keyboard profiles: screenshots in imv and
+finalized recordings in Omacut. The Mac regression first reproduced the missing
+viewer, then verified exact literal file arguments, publication before launch,
+and no viewer for clipboard-only captures. Desktop-mode workflows cover launch
+failures and ensure failed saves never launch an app. The reusable demo also
+opens the actual installed applications and displays the saved PNG and MP4.
 
 The accelerated-path flags remain separate, opt-in experiments. Hardware results
 are in the [cross-GPU report](../benchmarks/cross-gpu-2026-09-10/README.md), including

--- a/docs/mac-mode.md
+++ b/docs/mac-mode.md
@@ -186,8 +186,11 @@ Mac captures default to the XDG Desktop directory. Explicit
 `OMARCHY_SCREENSHOT_DIR` and `OMARCHY_SCREENRECORD_DIR` overrides still apply.
 Saving an image leaves the clipboard untouched. Clipboard-only capture uses a
 private, temporary runtime file removed after publication and creates no image
-in the user's capture directory. Mac capture does not automatically open a
-viewer/editor. Legacy capture behavior remains unchanged in desktop mode.
+in the user's capture directory. Saved screenshots automatically open in imv;
+finished recordings open in Omacut. This applies in both keyboard modes.
+Clipboard-only screenshots do not open a viewer. Install `imv` and `omacut`
+for automatic review; if either app is unavailable, the file remains saved
+and a notification reports the problem.
 
 Volume, brightness, keyboard-backlight, and media keys use replaceable
 `[commands]` providers named `mac-volume-*`, `mac-brightness-*`,

--- a/docs/product-demos.md
+++ b/docs/product-demos.md
@@ -1,7 +1,8 @@
 # Repeatable product demos
 
 Run the actual compositor, open two real Foot terminals and a live GTK design
-board, and demonstrate window screenshots and region recording. A second
+board, and demonstrate window screenshots and region recording, including their
+automatic opening in the real imv and Omacut applications. A second
 scenario shows three Spaces, live desktop miniatures, dragging a window between
 Spaces, keyboard navigation, and entering/leaving a dedicated fullscreen Space. The fixtures
 are scripted sample content, not benchmark results. No existing desktop,
@@ -27,6 +28,7 @@ The output directory must be new. Dependencies: Weston with its GL headless
 backend and kiosk shell, Foot, grim, wf-recorder, FFmpeg/ffprobe, dbus-run-session,
 Python 3, Pillow, PyGObject, GTK 4 and the Python Cairo/GI bridge. On Debian/Ubuntu the
 Python packages are `python3-pil python3-gi python3-cairo python3-gi-cairo gir1.2-gtk-4.0`.
+The capture scenario also requires imv and Omacut with their Wayland support.
 A headless Mesa software driver can be selected with
 `LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe`; these demos are not performance
 measurements. No root access or physical display is needed.
@@ -46,6 +48,9 @@ Outputs:
   screenshots. Corresponding `-diagnostic.png` files support visual QA.
 - `exports/`: the window screenshot and region video produced by using the
   feature itself. Keep these distinct from the walkthrough recording.
+- `screenshot-in-imv.png` and `recording-in-omacut.png`: real automatic review
+  windows. The runner verifies their exact file arguments and closes them with
+  Command-Q; stable process handles also clean them up if the demo fails.
 - `chonkstep-spaces-demo.mp4` and `spaces-{overview,design,window-moved,fullscreen,restored}.png`:
   the Spaces walkthrough and its checkpoints. These show actual client textures,
   including a GTK text editor on the third desktop.

--- a/docs/product-demos.md
+++ b/docs/product-demos.md
@@ -58,7 +58,9 @@ Outputs:
   in a stable selection interval for stale dimming, before a diagnostic PNG can
   force a repaint. Both raw and captioned capture videos must also match the
   independent PNG's dark RGB levels; the encoder explicitly labels limited-range
-  YUV correctly. An invalid recording fails the run. Logs and final window geometry remain alongside it.
+  YUV correctly. Complete capture-overlay PNGs are compared with independent
+  full repaints, excluding only the fixture's pulsing dot. An invalid recording
+  fails the run. Logs and final window geometry remain alongside it.
 
 The runner stops its process groups and private bus on exit, refuses to replace
 an existing artifact directory, bounds waits, and rejects missing outputs or

--- a/docs/product-demos.md
+++ b/docs/product-demos.md
@@ -25,8 +25,8 @@ python3 -B scripts/product-demo.py \
 
 The output directory must be new. Dependencies: Weston with its GL headless
 backend and kiosk shell, Foot, grim, wf-recorder, FFmpeg/ffprobe, dbus-run-session,
-Python 3, PyGObject, GTK 4 and the Python Cairo/GI bridge. On Debian/Ubuntu the
-Python packages are `python3-gi python3-cairo python3-gi-cairo gir1.2-gtk-4.0`.
+Python 3, Pillow, PyGObject, GTK 4 and the Python Cairo/GI bridge. On Debian/Ubuntu the
+Python packages are `python3-pil python3-gi python3-cairo python3-gi-cairo gir1.2-gtk-4.0`.
 A headless Mesa software driver can be selected with
 `LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe`; these demos are not performance
 measurements. No root access or physical display is needed.
@@ -56,7 +56,9 @@ Outputs:
   hashes, ffprobe results and Spaces membership checkpoints. Every video must
   also pass a complete FFmpeg decode. Capture additionally checks every frame
   in a stable selection interval for stale dimming, before a diagnostic PNG can
-  force a repaint. An invalid recording fails the run. Logs and final window geometry remain alongside it.
+  force a repaint. Both raw and captioned capture videos must also match the
+  independent PNG's dark RGB levels; the encoder explicitly labels limited-range
+  YUV correctly. An invalid recording fails the run. Logs and final window geometry remain alongside it.
 
 The runner stops its process groups and private bus on exit, refuses to replace
 an existing artifact directory, bounds waits, and rejects missing outputs or

--- a/docs/releases/0.5.0.md
+++ b/docs/releases/0.5.0.md
@@ -11,6 +11,7 @@ pipeline. Published through the existing `preview-v0.5.0` prerelease channel.
   and window membership preserved across reconnects.
 - **Capture and share:** screen, window and region screenshots, region recording,
   a keyboard-driven capture overlay, and repeatable product-demo tooling.
+  Saved screenshots open in imv and finished recordings in Omacut in both modes.
 - **Rendering improvements:** per-surface output tracking, refresh-aware frame
   callbacks, GPU-fence-driven capture downloads, improved native frame pacing,
   and counters that explain composition and scanout decisions. Nested rendering

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -47,7 +47,7 @@ depends=(
   'ffmpeg'           # finalize recoverable MKV recordings as fast-start MP4
   'libnotify'        # capture completion / failure notifications
   'xdg-user-dirs'    # localized Pictures / Videos destinations
-  'xdg-utils'        # open screenshots in the configured image viewer
+  'xdg-utils'        # desktop URL and file handlers
   'bash'             # the session launcher scripts in /usr/lib/chonkstep
   'gcc-libs'
   'glibc'
@@ -66,6 +66,8 @@ depends=(
   'ttf-dejavu'
 )
 optdepends=(
+  'imv: automatically review saved screenshots'
+  'omacut: automatically review completed recordings'
   'xorg-server: the X11 session (the Wayland session needs no X server)'
   'xorg-xinit: start the X11 session with startx from a TTY'
   'picom: translucent terminals on the X11 session (the compositor composites itself)'

--- a/packaging/arch/PKGBUILD-release
+++ b/packaging/arch/PKGBUILD-release
@@ -51,7 +51,7 @@ depends=(
   'ffmpeg'           # finalize recoverable MKV recordings as fast-start MP4
   'libnotify'        # capture completion / failure notifications
   'xdg-user-dirs'    # localized Pictures / Videos destinations
-  'xdg-utils'        # open screenshots in the configured image viewer
+  'xdg-utils'        # desktop URL and file handlers
   'bash'             # the session launcher scripts in /usr/lib/chonkstep
   'gcc-libs'
   'glibc'
@@ -70,6 +70,8 @@ depends=(
   'ttf-dejavu'       # the chiseled chrome's typeface
 )
 optdepends=(
+  'imv: automatically review saved screenshots'
+  'omacut: automatically review completed recordings'
   'xorg-server: the X11 session (the Wayland session needs no X server)'
   'xorg-xinit: start the X11 session with startx from a TTY'
   'picom: translucent terminals on the X11 session (the compositor composites itself)'

--- a/scripts/product-demo.py
+++ b/scripts/product-demo.py
@@ -276,6 +276,34 @@ def verify_capture_colors(video, timeline, reference):
             'reference':reference.name,'sample_origin':[1100,400],'sample_size':[16,8]}
 
 
+def verify_capture_still(captured, reference):
+    from PIL import Image, ImageChops, ImageDraw
+    with Image.open(captured) as actual, Image.open(reference) as expected:
+        if actual.size != (1920,1080) or actual.size != expected.size:
+            raise RuntimeError('capture comparison requires matching full HD images')
+        difference = ImageChops.difference(actual.convert('RGB'),expected.convert('RGB'))
+    # This is the fixture's pulsing dot, the only content that changes between
+    # the two snapshots. Selection borders, dimming and every window remain
+    # covered by the comparison, including edges outside the video row sample.
+    animated = (1720,278,1748,311)
+    ImageDraw.Draw(difference).rectangle(animated,fill=(0,0,0))
+    delta = max(high for low,high in difference.getextrema())
+    if delta > 2:
+        raise RuntimeError(f'captured desktop differs from a full repaint by {delta} levels: {captured.name}')
+    return {'file':captured.name,'reference':reference.name,'max_channel_difference':delta,
+            'allowed_difference':2,'animated_fixture_exclusion':list(animated)}
+
+
+def png_ready(path):
+    from PIL import Image
+    try:
+        with Image.open(path) as image:
+            image.load()
+            return image.format == 'PNG' and image.size == (1920,1080)
+    except OSError:
+        return False
+
+
 def run(args):
     binary = args.binary.resolve(strict=True)
     for command in ('weston', 'foot', 'wf-recorder', 'grim', 'ffmpeg', 'ffprobe'):
@@ -343,7 +371,10 @@ def run(args):
             diagnostic = output/f'{name}-diagnostic.png'
             pending.write_text(str(diagnostic))
             pending.replace(marker)
-            wait('diagnostic screenshot', lambda: diagnostic.exists() and diagnostic.stat().st_size > 8)
+            wait('diagnostic screenshot', lambda: png_ready(diagnostic))
+            if args.scenario == 'capture' and name.startswith('capture-'):
+                metadata.setdefault('still_verification',[]).append(
+                    verify_capture_still(output/f'{name}.png',diagnostic))
 
         if args.scenario == 'spaces':
             spaces_walkthrough(door, clients, step, still, metadata)

--- a/scripts/product-demo.py
+++ b/scripts/product-demo.py
@@ -255,6 +255,27 @@ def caption_file(timeline, output):
     (output/'timeline.srt').write_text('\n'.join(blocks),encoding='utf-8')
 
 
+def verify_capture_colors(video, timeline, reference):
+    from PIL import Image
+    start = next(item['seconds'] for item in timeline if item['action'] == 'Select a region') + .25
+    # Flat, unchanging board pixels inside the selected region. Compare the
+    # decoded video with the independent PNG, including absolute dark levels:
+    # a uniformly washed-out recording passes a spatial-variation check.
+    with Image.open(reference) as png:
+        expected = png.convert('RGB').getpixel((1100, 400))
+    pixels = subprocess.check_output(['ffmpeg','-v','error','-ss',str(start),'-t','1.5',
+        '-i',str(video),'-vf','format=rgb24,crop=16:8:1100:400',
+        '-f','rawvideo','-pix_fmt','rgb24','-'],timeout=30)
+    stride = 16*8*3
+    if len(pixels) % stride or len(pixels) < 20*stride:
+        raise RuntimeError('too few complete frames to verify capture colors')
+    delta = max(abs(value-expected[index%3]) for index,value in enumerate(pixels))
+    if delta > 8:
+        raise RuntimeError(f'recorded colors differ from the screenshot by {delta} levels')
+    return {'frames':len(pixels)//stride,'max_channel_difference':delta,'allowed_difference':8,
+            'reference':reference.name,'sample_origin':[1100,400],'sample_size':[16,8]}
+
+
 def run(args):
     binary = args.binary.resolve(strict=True)
     for command in ('weston', 'foot', 'wf-recorder', 'grim', 'ffmpeg', 'ffprobe'):
@@ -303,7 +324,8 @@ def run(args):
         time.sleep(1)
         raw = output/'demo.raw.mp4'
         recorder = stack.enter_context(b.child(['wf-recorder','--no-dmabuf','-D','-r','30','-c','libx264',
-            '-p','preset=fast','-p','crf=18','-x','yuv420p','-f',str(raw)], recording_env, output/'recorder.log'))
+            '-p','preset=fast','-p','crf=18','-p','color_range=tv',
+            '-x','yuv420p','-f',str(raw)], recording_env, output/'recorder.log'))
         started = time.monotonic()
 
         def step(name, pause=1):
@@ -362,6 +384,8 @@ def run(args):
     raw.unlink()
     if args.scenario == 'capture':
         metadata['repaint_verification'] = verify_capture_video(final, metadata['timeline'])
+        metadata['color_verification'] = verify_capture_colors(final, metadata['timeline'],
+            output/'capture-area-overlay-diagnostic.png')
     caption_file(metadata['timeline'],output)
     captioned = output/f'chonkstep-{args.scenario}-captioned.mp4'
     alignment = 8 if args.scenario == 'capture' else 2
@@ -372,6 +396,9 @@ def run(args):
                     '-movflags','+faststart',captioned.name],cwd=output,check=True,timeout=60)
     metadata['editorial_captions'] = {'video':captioned.name,'subtitles':'timeline.srt',
         'description':'Action labels added to the same uncut recording; the raw walkthrough remains available.'}
+    if args.scenario == 'capture':
+        metadata['caption_color_verification'] = verify_capture_colors(captioned,
+            metadata['timeline'],output/'capture-area-overlay-diagnostic.png')
     metadata['artifacts'] = []
     for path in sorted(output.rglob('*')):
         if path.suffix not in ('.png','.mp4','.srt'):

--- a/scripts/product-demo.py
+++ b/scripts/product-demo.py
@@ -98,6 +98,42 @@ def dispatch(runtime, command):
         raise RuntimeError(f'demo command {command}: {response}')
 
 
+def review_window(stack, runtime, program, path):
+    """Find the real review app with this exact export, on our private desktop."""
+    def find():
+        for client in json.loads(ipc_request(runtime, 'j/clients')):
+            try:
+                argv = (Path('/proc')/str(client['pid'])/'cmdline').read_bytes().split(b'\0')
+                if (os.fsencode(path) in argv and argv and
+                    Path(os.fsdecode(argv[0])).name in (program, program+'-wayland')):
+                    return client
+            except (FileNotFoundError, ProcessLookupError):
+                continue
+        return None
+    client = wait(f'{program} opens the saved file', find)
+    # Capture apps have their own process groups. Keep a stable handle so a
+    # failed demo cannot leak a viewer or accidentally signal a recycled PID.
+    fd = os.pidfd_open(client['pid'])
+    def cleanup():
+        try:
+            signal.pidfd_send_signal(fd, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        finally:
+            os.close(fd)
+    stack.callback(cleanup)
+    dispatch(runtime, 'focuswindow address:'+client['address'])
+    return client
+
+
+def close_review(door, runtime, client):
+    dispatch(runtime, 'focuswindow address:'+client['address'])
+    chord(door, [125], 16)  # Command-Q, through the production Mac profile.
+    wait('review app closes', lambda: not any(
+        row['address'] == client['address']
+        for row in json.loads(ipc_request(runtime, 'j/clients'))))
+
+
 def overview_rows(door, kind):
     return [dict(word.split('=',1) for word in shlex.split(row)[1:])
             for row in door.query('windows',multiple=True) if row.startswith(kind+' ')]
@@ -201,6 +237,11 @@ def boot(stack, root, host, binary, logs, name):
     env = environment(root, host)
     config = root/'config/chonkstep'
     config.mkdir()
+    # Fixture-only viewer sizing and title; never alter the user's imv config.
+    imv = root/'config/imv'
+    imv.mkdir()
+    (imv/'config').write_text('[options]\nwidth=900\nheight=700\n'
+        'title_text=imv — Saved screenshot\n')
     (config/'config.toml').write_text(
         "interaction_mode='mac'\nhyprland_config=false\nomarchy_shell=false\nomarchy_menu=false\n"
         "show_dock=false\nrestore_session=false\ntheme='nextstep-classic'\nscale=1\n")
@@ -306,7 +347,10 @@ def png_ready(path):
 
 def run(args):
     binary = args.binary.resolve(strict=True)
-    for command in ('weston', 'foot', 'wf-recorder', 'grim', 'ffmpeg', 'ffprobe'):
+    commands = ('weston', 'foot', 'wf-recorder', 'grim', 'ffmpeg', 'ffprobe')
+    if args.scenario == 'capture':
+        commands += ('imv', 'omacut')
+    for command in commands:
         if not shutil.which(command):
             raise RuntimeError(f'missing required demo tool: {command}')
     subprocess.run([sys.executable, '-c', "import gi, cairo; gi.require_version('Gtk','4.0'); from gi.repository import Gtk"], check=True)
@@ -353,7 +397,7 @@ def run(args):
         raw = output/'demo.raw.mp4'
         recorder = stack.enter_context(b.child(['wf-recorder','--no-dmabuf','-D','-r','30','-c','libx264',
             '-p','preset=fast','-p','crf=18','-p','color_range=tv',
-            '-x','yuv420p','-f',str(raw)], recording_env, output/'recorder.log'))
+            '-x','yuv420p','-F','scale=in_range=pc:out_range=tv,format=yuv420p','-f',str(raw)], recording_env, output/'recorder.log'))
         started = time.monotonic()
 
         def step(name, pause=1):
@@ -393,7 +437,13 @@ def run(args):
             still('capture-window-overlay')
             chord(door,[],28)
             step('Save the window screenshot',2)
-            wait('saved screenshot', lambda: list((output/'exports').glob('*.png')))
+            screenshot = wait('saved screenshot', lambda: list((output/'exports').glob('*.png')))[0]
+            runtime = clients['XDG_RUNTIME_DIR']
+            viewer = review_window(stack, runtime, 'imv', screenshot)
+            place(door, 'imv', 545, 175, runtime)
+            step('The saved screenshot opens in imv',3)
+            still('screenshot-in-imv')
+            close_review(door, runtime, viewer)
             chord(door,[125,42],6)
             chord(door,[],6) # 5: record region
             drag(door,(990,180),(1800,825),1.2)
@@ -403,7 +453,16 @@ def run(args):
             step('Record the live design board',5)
             chord(door,[125,42],6) # Capture shortcut stops an active recording.
             step('Stop recording and save',2)
-            wait('saved recording', lambda: list((output/'exports').glob('*.mp4')))
+            recording = wait('saved recording', lambda: list((output/'exports').glob('*.mp4')))[0]
+            editor = review_window(stack, runtime, 'omacut', recording)
+            place(door, 'omacut', 480, 175, runtime)
+            step('The finished recording opens in Omacut',4)
+            still('recording-in-omacut')
+            chord(door, [], 57)
+            step('Play the captured video in Omacut',3)
+            metadata['automatic_review'] = {'screenshot':'imv', 'recording':'omacut',
+                'verification':'Mapped real applications received the exact published files.'}
+            close_review(door, runtime, editor)
         recorder.send_signal(signal.SIGINT)
         recorder.wait(timeout=20)
         if recorder.returncode != 0:

--- a/scripts/tests/test_product_demo.py
+++ b/scripts/tests/test_product_demo.py
@@ -59,3 +59,17 @@ class RecordedPixels(unittest.TestCase):
             with patch.object(demo.subprocess, 'check_output', return_value=bytes([31,35,46])*16*8*45):
                 with self.assertRaisesRegex(RuntimeError, 'differ from the screenshot'):
                     demo.verify_capture_colors(Path('sample.mp4'), self.timeline, reference)
+
+    def test_dynamic_fixture_dot_does_not_hide_a_stale_selection_edge(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            reference = Path(temporary)/'reference.png'
+            captured = Path(temporary)/'captured.png'
+            image = Image.new('RGB', (1920,1080), (19,23,35))
+            image.save(reference)
+            image.putpixel((1734,295),(255,255,255))
+            image.save(captured)
+            self.assertEqual(demo.verify_capture_still(captured,reference)['max_channel_difference'],0)
+            image.putpixel((1568,210),(255,255,255))
+            image.save(captured)
+            with self.assertRaisesRegex(RuntimeError, 'differs from a full repaint'):
+                demo.verify_capture_still(captured,reference)

--- a/scripts/tests/test_product_demo.py
+++ b/scripts/tests/test_product_demo.py
@@ -2,8 +2,10 @@
 import importlib.util
 from pathlib import Path
 import subprocess
+import tempfile
 import unittest
 from unittest.mock import patch
+from PIL import Image
 
 spec = importlib.util.spec_from_file_location('product_demo', Path(__file__).parents[1] / 'product-demo.py')
 demo = importlib.util.module_from_spec(spec)
@@ -38,3 +40,22 @@ class RecordedPixels(unittest.TestCase):
         with patch.object(demo.subprocess, 'check_output', side_effect=subprocess.CalledProcessError(1, 'ffmpeg')):
             with self.assertRaises(subprocess.CalledProcessError):
                 demo.verify_capture_video(Path('sample.mp4'), self.timeline)
+
+    def test_video_colors_match_the_independent_screenshot(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            reference = Path(temporary)/'reference.png'
+            Image.new('RGB', (1920,1080), (19,23,35)).save(reference)
+            with patch.object(demo.subprocess, 'check_output', return_value=bytes([18,22,35])*16*8*45):
+                result = demo.verify_capture_colors(Path('sample.mp4'), self.timeline, reference)
+            self.assertEqual(result['max_channel_difference'], 1)
+            self.assertEqual(result['frames'], 45)
+
+    def test_uniformly_washed_out_video_cannot_pass_the_color_check(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            reference = Path(temporary)/'reference.png'
+            Image.new('RGB', (1920,1080), (19,23,35)).save(reference)
+            # Limited-range samples mislabeled full-range have no spatial
+            # variation, but lift dark RGB levels by about twelve steps.
+            with patch.object(demo.subprocess, 'check_output', return_value=bytes([31,35,46])*16*8*45):
+                with self.assertRaisesRegex(RuntimeError, 'differ from the screenshot'):
+                    demo.verify_capture_colors(Path('sample.mp4'), self.timeline, reference)

--- a/vendor/smithay-0.7.0/src/xwayland/xwm/mod.rs
+++ b/vendor/smithay-0.7.0/src/xwayland/xwm/mod.rs
@@ -937,6 +937,17 @@ impl X11Wm {
         self.id
     }
 
+    /// Retained incoming and outgoing selection transfers across clipboard and primary.
+    ///
+    /// This read-only diagnostic includes completed entries if they have not
+    /// been removed; querying it never performs cleanup or reads payloads.
+    pub fn selection_transfer_counts(&self) -> (usize, usize) {
+        (
+            self.clipboard.incoming.len() + self.primary.incoming.len(),
+            self.clipboard.outgoing.len() + self.primary.outgoing.len(),
+        )
+    }
+
     /// Raises a window in the internal X11 state
     ///
     /// Needs to be called to match raising of windows inside the compositor to keep the stacking order


### PR DESCRIPTION
Saved screenshots now open in imv and finalized recordings open in Omacut in both Mac and desktop modes. Clipboard-only screenshots still create no user file or review window. The real-app demo verifies exact file arguments, shows the loaded image and video, and closes the apps with Command-Q. Missing viewers retain the saved capture and report a notification.

Recording QA also found inconsistent RGB-to-YUV behavior between current Arch and older Ubuntu wf-recorder/FFmpeg. Both the conversion and limited-range encoder metadata are now explicit. The real screen/area regression fails before and passes after on both versions; neither color thresholds nor frame-transition assertions were relaxed.

A retained capture-selection edge exposed an offscreen framebuffer remaining bound during nested buffer-age setup. The renderer now restores the default framebuffer before latching the EGL window and querying its age. Incremental rendering remains enabled. The demo checks raw/captioned RGB levels and compares complete overlay images with independent full repaints, excluding only the fixture’s pulsing dot.

Validation: 17 real capture workflows, 12 Mac-mode workflows, 8 review-worker tests, strict workspace lint and 93 harness tests pass. Three consecutive framebuffer-fix recordings passed 135 sampled frames and all nine overlay pairs matched exactly outside the dot. Updated real imv/Omacut walkthroughs pass full video decode, color and overlay-image checks. Package recipes document the review-app dependencies.

The completed-paste memory regression now checks actual retained XWM transfer records, requiring zero completed entries while all 128 requestors stay alive. This removes process-wide allocator/renderer noise without permitting a leaked transfer: a deliberately broken executable retained 129 entries and failed; the corrected full 22-workflow selection suite passes, including one held transfer reporting one. Anonymous memory remains recorded as diagnostic evidence. Strict lint passes.
