### PR TITLE
Send capture test IPC commands as one buffer

### DIFF
--- a/crates/chonk-testkit/tests/capture_tool.rs
+++ b/crates/chonk-testkit/tests/capture_tool.rs
@@ -283,7 +283,11 @@ fn set_cursor_hidden(session: &mut Session, hidden: bool) {
     stream
         .set_read_timeout(Some(Duration::from_secs(10)))
         .unwrap();
-    write!(stream, "/keyword cursor:invisible {hidden}").unwrap();
+    // Hyprland IPC has no delimiter: format before writing so the server
+    // cannot dispatch the prefix while write_fmt emits the boolean separately.
+    stream
+        .write_all(format!("/keyword cursor:invisible {hidden}").as_bytes())
+        .unwrap();
     let mut response = String::new();
     stream.read_to_string(&mut response).unwrap();
     assert_eq!(response.trim(), "ok");


### PR DESCRIPTION
The capture cursor test sometimes sent `/keyword cursor:invisible ` separately from its Boolean argument because `write!` can issue multiple writes. The server dispatched the incomplete prefix and closed the connection, causing BrokenPipe before the argument arrived.

Build the complete command before writing it, matching the other IPC clients and product-demo runner. The cursor visibility and pixel assertions remain unchanged. This is a test-client transport correction; the released compositor executable is unchanged.

Validation: the failed package run retained its log showing the incomplete command rejection. The corrected capture suite runs against the same attested release executable, alongside native screenshot/imv and recording/Omacut checks. Strict workspace lint passes.
